### PR TITLE
Path to setup.sh was hard coded in the scripts

### DIFF
--- a/gazebo_ros/scripts/debug
+++ b/gazebo_ros/scripts/debug
@@ -12,4 +12,5 @@ then
     final="$final -s `catkin_find libgazebo_ros_api_plugin.so`"
 fi
 
-. /usr/local/share/gazebo/setup.sh && `rospack find gazebo_ros`/scripts/gdbrun gzserver $final
+setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
+. $setup_path/setup.sh && `rospack find gazebo_ros`/scripts/gdbrun gzserver $final

--- a/gazebo_ros/scripts/gazebo
+++ b/gazebo_ros/scripts/gazebo
@@ -13,10 +13,11 @@ then
     final="$final -s `catkin_find libgazebo_ros_api_plugin.so`"
 fi
 
-client_final = "-g `catkin_find libgazebo_ros_paths_plugin.so`"
+client_final="-g `catkin_find libgazebo_ros_paths_plugin.so`"
 
 # Combine the commands
-. /usr/local/share/gazebo/setup.sh && gzserver $final & gzclient client_final
+setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
+. $setup_path/setup.sh && gzserver $final & gzclient $client_final
 
 # Kill the server... ?
 #killall gzserver -9

--- a/gazebo_ros/scripts/gzclient
+++ b/gazebo_ros/scripts/gzclient
@@ -8,4 +8,5 @@ then
 fi
 
 # Combine the commands
-. /usr/local/share/gazebo/setup.sh && gzclient $final
+setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
+. $setup_path/setup.sh && gzclient $final

--- a/gazebo_ros/scripts/gzserver
+++ b/gazebo_ros/scripts/gzserver
@@ -13,4 +13,5 @@ then
     final="$final -s `catkin_find libgazebo_ros_api_plugin.so`"
 fi
 
-. /usr/local/share/gazebo/setup.sh && gzserver $final
+setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
+. $setup_path/setup.sh && gzserver $final

--- a/gazebo_ros/scripts/perf
+++ b/gazebo_ros/scripts/perf
@@ -12,4 +12,5 @@ then
     final="$final -s `catkin_find libgazebo_ros_api_plugin.so`"
 fi
 
-. /usr/local/share/gazebo/setup.sh && /usr/bin/valgrind --tool=callgrind gzserver $final
+setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
+. $setup_path/setup.sh && /usr/bin/valgrind --tool=callgrind gzserver $final


### PR DESCRIPTION
This lead to a "Can't open /usr/local/share/gazebo/setup.sh" error when the installation is not made in the default path. This patch propose to use pkg-config to find the installation path. Command 

``` bash
pkg-config --variable=prefix gazebo
```

return the installation path, adding share/gazebo gives the path to the setup.sh script.

Also there was a typo with the client_final variable initialization and a missing "$".
