### PR TITLE
Check camera util is initialized before publishing - fix from Atlas

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
@@ -197,8 +197,10 @@ namespace gazebo
     private: void LoadThread();
     private: boost::thread deferred_load_thread_;
 
+    /// \brief True if camera util is initialized
+    private: bool initialized_;
+
     friend class GazeboRosMultiCamera;
   };
 }
 #endif
-

--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -49,6 +49,11 @@ GazeboRosCameraUtils::GazeboRosCameraUtils()
   this->image_connect_count_ = 0;
   this->last_update_time_ = common::Time(0);
   this->last_info_update_time_ = common::Time(0);
+  this->height_ = 0;
+  this->width_ = 0;
+  this->skip_ = 0;
+  this->format_ = "";
+  this->initialized_ = false;
 }
 
 #ifdef DYNAMIC_RECONFIGURE
@@ -457,6 +462,8 @@ void GazeboRosCameraUtils::Init()
   // start custom queue for camera_
   this->callback_queue_thread_ = boost::thread(
     boost::bind(&GazeboRosCameraUtils::CameraQueueThread, this));
+
+  this->initialized_ = true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -470,6 +477,9 @@ void GazeboRosCameraUtils::PutCameraData(const unsigned char *_src,
 
 void GazeboRosCameraUtils::PutCameraData(const unsigned char *_src)
 {
+  if (!this->initialized_ || this->height_ <=0 || this->width_ <=0)
+    return;
+
   /// don't bother if there are no subscribers
   if (this->image_pub_.getNumSubscribers() > 0)
   {
@@ -499,6 +509,9 @@ void GazeboRosCameraUtils::PublishCameraInfo(common::Time &last_update_time)
 
 void GazeboRosCameraUtils::PublishCameraInfo()
 {
+  if (!this->initialized_ || this->height_ <=0 || this->width_ <=0)
+    return;
+
   if (this->camera_info_pub_.getNumSubscribers() > 0)
   {
     this->sensor_update_time_ = this->parentSensor_->GetLastUpdateTime();


### PR DESCRIPTION
This fix is copied from drcsim/Atlas:

_Fix gazebo (and ros image_transport) crashes due to image publication race condition. Happens when publishing image before params are initialized._

See [bitbucket issue](https://bitbucket.org/osrf/drcsim/pull-request/353/check-camera-util-is-initialized-before/diff)
