### PR TITLE
fix for terminating the service_thread_ in PubQueue.h

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/PubQueue.h
+++ b/gazebo_plugins/include/gazebo_plugins/PubQueue.h
@@ -128,6 +128,7 @@ class PubMultiQueue
     {
       if(service_thread_.joinable())
       {
+        ros::shutdown();
         notifyServiceThread();
         service_thread_.join();
       }


### PR DESCRIPTION
During our process here to write tests, we discovered that gtests with plugins containing this queues didn't terminate properly and hung in the destructor of pubqueue, this should fix it. 

It would be nice, if you could leave the `deprecated-groovy` branch for now, since we will work with this for a little longer and will migrate in a bit.

Cheers
