### PR TITLE
also support gazebo instead of gazebo_ros for package exports

### DIFF
--- a/gazebo_ros/src/gazebo_ros_paths_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_paths_plugin.cpp
@@ -140,6 +140,12 @@ public:
     // set gazebo media paths by adding all packages that exports "gazebo_media_path" for gazebo
     gazebo::common::SystemPaths::Instance()->gazeboPathsFromEnv = false;
     std::vector<std::string> gazebo_media_paths;
+    rosPackageGetPluginsDebug("gazebo","gazebo_media_path",gazebo_media_paths);
+    for (std::vector<std::string>::iterator iter=gazebo_media_paths.begin(); iter != gazebo_media_paths.end(); iter++)
+    {
+      ROS_DEBUG("med path %s",iter->c_str());
+      gazebo::common::SystemPaths::Instance()->AddGazeboPaths(iter->c_str());
+    }
     rosPackageGetPluginsDebug("gazebo_ros","gazebo_media_path",gazebo_media_paths);
     for (std::vector<std::string>::iterator iter=gazebo_media_paths.begin(); iter != gazebo_media_paths.end(); iter++)
     {
@@ -150,6 +156,12 @@ public:
     // set gazebo plugins paths by adding all packages that exports "plugin_path" for gazebo
     gazebo::common::SystemPaths::Instance()->pluginPathsFromEnv = false;
     std::vector<std::string> plugin_paths;
+    rosPackageGetPluginsDebug("gazebo","plugin_path",plugin_paths);
+    for (std::vector<std::string>::iterator iter=plugin_paths.begin(); iter != plugin_paths.end(); iter++)
+    {
+      ROS_DEBUG("plugin path %s",(*iter).c_str());
+      gazebo::common::SystemPaths::Instance()->AddPluginPaths(iter->c_str());
+    }
     rosPackageGetPluginsDebug("gazebo_ros","plugin_path",plugin_paths);
     for (std::vector<std::string>::iterator iter=plugin_paths.begin(); iter != plugin_paths.end(); iter++)
     {
@@ -160,6 +172,12 @@ public:
     // set model paths by adding all packages that exports "gazebo_model_path" for gazebo
     gazebo::common::SystemPaths::Instance()->modelPathsFromEnv = false;
     std::vector<std::string> model_paths;
+    rosPackageGetPluginsDebug("gazebo","gazebo_model_path",model_paths);
+    for (std::vector<std::string>::iterator iter=model_paths.begin(); iter != model_paths.end(); iter++)
+    {
+      ROS_DEBUG("model path %s",(*iter).c_str());
+      gazebo::common::SystemPaths::Instance()->AddModelPaths(iter->c_str());
+    }
     rosPackageGetPluginsDebug("gazebo_ros","gazebo_model_path",model_paths);
     for (std::vector<std::string>::iterator iter=model_paths.begin(); iter != model_paths.end(); iter++)
     {

--- a/gazebo_ros/src/gazebo_ros_paths_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_paths_plugin.cpp
@@ -143,6 +143,7 @@ public:
     rosPackageGetPluginsDebug("gazebo","gazebo_media_path",gazebo_media_paths);
     for (std::vector<std::string>::iterator iter=gazebo_media_paths.begin(); iter != gazebo_media_paths.end(); iter++)
     {
+      ROS_WARN("Using package gazebo to export a gazebo_media_path is deprecated. Please update your package to use gazebo_ros instead (%s).", iter->c_str());
       ROS_DEBUG("med path %s",iter->c_str());
       gazebo::common::SystemPaths::Instance()->AddGazeboPaths(iter->c_str());
     }
@@ -159,6 +160,7 @@ public:
     rosPackageGetPluginsDebug("gazebo","plugin_path",plugin_paths);
     for (std::vector<std::string>::iterator iter=plugin_paths.begin(); iter != plugin_paths.end(); iter++)
     {
+      ROS_WARN("Using package gazebo to export a plugin_path is deprecated. Please update your package to use gazebo_ros instead (%s).", iter->c_str());
       ROS_DEBUG("plugin path %s",(*iter).c_str());
       gazebo::common::SystemPaths::Instance()->AddPluginPaths(iter->c_str());
     }
@@ -175,6 +177,7 @@ public:
     rosPackageGetPluginsDebug("gazebo","gazebo_model_path",model_paths);
     for (std::vector<std::string>::iterator iter=model_paths.begin(); iter != model_paths.end(); iter++)
     {
+      ROS_WARN("Using package gazebo to export a gazebo_model_path is deprecated. Please update your package to use gazebo_ros instead (%s).", iter->c_str());
       ROS_DEBUG("model path %s",(*iter).c_str());
       gazebo::common::SystemPaths::Instance()->AddModelPaths(iter->c_str());
     }


### PR DESCRIPTION
Due to the renaming of the `gazebo` ROS package in `gazebo_ros` compared to the simulator_gazebo stack numerous packages that want to export plugin paths, model paths or media paths have to be updated and depend on the new gazebo_ros package now. But in fact the gazebo_ros_paths_plugin is only a helper to add the paths using the gazebo API and the semantics is more like exporting these paths for gazebo. I would strongly recommend to additionally support "gazebo" as a package name when searching for packages that export gazebo paths.

The same problem exists for the run scripts currently installed in lib/gazebo_ros/, forcing all users to update their launch files. Would it be very "bad" to install them in lib/gazebo/ instead or create symlinks there to not break existing launch files using `<node name="gazebo" pkg="gazebo" type="gazebo">...</node>`?

Having to maintain different branches for each ROS distro of repositories with packages using gazebo is quite annoying and should be avoided (although it's rarely possible due to other changes in the API). This is especially true if there are no (visible) fundamental changes but only small renamings.
