### PR TITLE
Segfault using the gazebo_ros_openni_kinect plugin

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
@@ -198,7 +198,7 @@ namespace gazebo
     private: boost::thread deferred_load_thread_;
 
     /// \brief True if camera util is initialized
-    private: bool initialized_;
+    protected: bool initialized_;
 
     friend class GazeboRosMultiCamera;
   };

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
@@ -77,6 +77,9 @@ namespace gazebo
     /// \param take in SDF root element
     public: virtual void Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf);
 
+    /// \brief Advertise point cloud and depth image
+    public: virtual void Advertise();
+
     /// \brief Update the controller
     protected: virtual void OnNewDepthFrame(const float *_image,
                    unsigned int _width, unsigned int _height,
@@ -146,6 +149,8 @@ namespace gazebo
     // overload with our own
     private: common::Time depth_sensor_update_time_;
     protected: ros::Publisher depth_image_camera_info_pub_;
+
+    private: bool advertised_;
   };
 
 }

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_openni_kinect.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_openni_kinect.h
@@ -77,6 +77,9 @@ namespace gazebo
     /// \param take in SDF root element
     public: virtual void Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf);
 
+    /// \brief Advertise point cloud and depth image
+    public: virtual void Advertise();
+
     /// \brief Update the controller
     protected: virtual void OnNewDepthFrame(const float *_image, 
                    unsigned int _width, unsigned int _height, 
@@ -139,6 +142,8 @@ namespace gazebo
 
     using GazeboRosCameraUtils::PublishCameraInfo;
     protected: virtual void PublishCameraInfo();
+
+    private: bool advertised_;
   };
 
 }

--- a/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
@@ -70,8 +70,6 @@ void GazeboRosDepthCamera::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf
   this->format_ = this->format;
   this->camera_ = this->depthCamera;
 
-  GazeboRosCameraUtils::Load(_parent, _sdf);
-
   // using a different default
   if (!_sdf->GetElement("imageTopicName"))
     this->image_topic_name_ = "ir/image_raw";
@@ -100,6 +98,11 @@ void GazeboRosDepthCamera::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf
   else
     this->point_cloud_cutoff_ = _sdf->GetElement("pointCloudCutoff")->GetValueDouble();
 
+  GazeboRosCameraUtils::Load(_parent, _sdf);
+}
+
+void GazeboRosDepthCamera::Advertise()
+{
   ros::AdvertiseOptions point_cloud_ao =
     ros::AdvertiseOptions::create<sensor_msgs::PointCloud2 >(
       this->point_cloud_topic_name_,1,
@@ -123,7 +126,10 @@ void GazeboRosDepthCamera::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf
         boost::bind( &GazeboRosDepthCamera::DepthInfoDisconnect,this),
         ros::VoidPtr(), &this->camera_queue_);
   this->depth_image_camera_info_pub_ = this->rosnode_->advertise(depth_image_camera_info_ao);
+
+  this->advertised_ = true;
 }
+
 
 ////////////////////////////////////////////////////////////////////////////////
 // Increment count
@@ -176,6 +182,12 @@ void GazeboRosDepthCamera::OnNewDepthFrame(const float *_image,
     unsigned int _width, unsigned int _height, unsigned int _depth,
     const std::string &_format)
 {
+  if (!this->initialized_ || this->height_ <=0 || this->width_ <=0)
+    return;
+
+  if (!this->advertised_)
+    Advertise();
+
   this->depth_sensor_update_time_ = this->parentSensor->GetLastUpdateTime();
   if (this->parentSensor->IsActive())
   {
@@ -209,6 +221,12 @@ void GazeboRosDepthCamera::OnNewRGBPointCloud(const float *_pcd,
     unsigned int _width, unsigned int _height, unsigned int _depth,
     const std::string &_format)
 {
+  if (!this->initialized_ || this->height_ <=0 || this->width_ <=0)
+    return;
+
+  if (!this->advertised_)
+    Advertise();
+
   this->depth_sensor_update_time_ = this->parentSensor->GetLastUpdateTime();
   if (!this->parentSensor->IsActive())
   {
@@ -268,6 +286,12 @@ void GazeboRosDepthCamera::OnNewImageFrame(const unsigned char *_image,
     unsigned int _width, unsigned int _height, unsigned int _depth,
     const std::string &_format)
 {
+  if (!this->initialized_ || this->height_ <=0 || this->width_ <=0)
+    return;
+
+  if (!this->advertised_)
+    Advertise();
+
   //ROS_ERROR("camera_ new frame %s %s",this->parentSensor_->GetName().c_str(),this->frame_name_.c_str());
   this->sensor_update_time_ = this->parentSensor->GetLastUpdateTime();
 

--- a/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
@@ -48,6 +48,7 @@ GazeboRosDepthCamera::GazeboRosDepthCamera()
   this->point_cloud_connect_count_ = 0;
   this->depth_info_connect_count_ = 0;
   this->last_depth_image_camera_info_update_time_ = common::Time(0);
+  this->advertised_ = false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The current version of the gazebo_ros_openni_kinect plugin in gazebo_ros_pkg uses the this->rosnode_ pointer to advertise point clouds and depth images in its `GazeboRosOpenniKinect::Load` method ([line 110](https://github.com/osrf/gazebo_ros_pkgs/blob/hydro-devel/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp#L110)), but this pointer might not have been initialized yet as initialization happens in a separate thread in `GazeboRosCameraUtils::LoadThread` ([line 259](https://github.com/osrf/gazebo_ros_pkgs/blob/hydro-devel/gazebo_plugins/src/gazebo_ros_camera_utils.cpp#L259)) without synchronization.
