### PR TITLE
debug script does not work in install space

### DIFF
--- a/gazebo_ros/scripts/debug
+++ b/gazebo_ros/scripts/debug
@@ -14,4 +14,4 @@ then
 fi
 
 setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
-. $setup_path/setup.sh && `rospack find gazebo_ros`/scripts/gdbrun gzserver $final
+. $setup_path/setup.sh && rosrun gazebo_ros gdbrun gzserver $final


### PR DESCRIPTION
Only a minor issue: The debug script does not work if gazebo_ros is installed, as ``rospack find gazebo_ros`/scripts` does not exists.
