### PR TITLE
Fix depth and openni kinect camera plugin segfaults

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
@@ -79,6 +79,8 @@ namespace gazebo
                       const std::string &_camera_name_suffix,
                       double _hack_baseline);
 
+    public: event::ConnectionPtr OnLoad(const boost::function<void()>&);
+
     private: void Init();
 
     /// \brief Put camera data to the ROS topic
@@ -196,6 +198,7 @@ namespace gazebo
     private: sdf::ElementPtr sdf;
     private: void LoadThread();
     private: boost::thread deferred_load_thread_;
+    private: event::EventT<void()> load_event_;
 
     /// \brief True if camera util is initialized
     protected: bool initialized_;

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
@@ -150,7 +150,7 @@ namespace gazebo
     private: common::Time depth_sensor_update_time_;
     protected: ros::Publisher depth_image_camera_info_pub_;
 
-    private: bool advertised_;
+    private: event::ConnectionPtr load_connection_;
   };
 
 }

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_openni_kinect.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_openni_kinect.h
@@ -143,7 +143,7 @@ namespace gazebo
     using GazeboRosCameraUtils::PublishCameraInfo;
     protected: virtual void PublishCameraInfo();
 
-    private: bool advertised_;
+    private: event::ConnectionPtr load_connection_;
   };
 
 }

--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -239,6 +239,11 @@ void GazeboRosCameraUtils::Load(sensors::SensorPtr _parent,
     boost::bind(&GazeboRosCameraUtils::LoadThread, this));
 }
 
+event::ConnectionPtr GazeboRosCameraUtils::OnLoad(const boost::function<void()>& load_function)
+{
+  return load_event_.Connect(load_function);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Load the controller
 void GazeboRosCameraUtils::LoadThread()
@@ -463,6 +468,7 @@ void GazeboRosCameraUtils::Init()
   this->callback_queue_thread_ = boost::thread(
     boost::bind(&GazeboRosCameraUtils::CameraQueueThread, this));
 
+  load_event_();
   this->initialized_ = true;
 }
 

--- a/gazebo_plugins/src/gazebo_ros_multicamera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_multicamera.cpp
@@ -22,9 +22,9 @@
 
 #include <string>
 
-#include <sensors/Sensor.hh>
-#include <sensors/MultiCameraSensor.hh>
-#include <sensors/SensorTypes.hh>
+#include <gazebo/sensors/Sensor.hh>
+#include <gazebo/sensors/MultiCameraSensor.hh>
+#include <gazebo/sensors/SensorTypes.hh>
 
 #include <gazebo_plugins/gazebo_ros_multicamera.h>
 

--- a/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
+++ b/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
@@ -49,7 +49,6 @@ GazeboRosOpenniKinect::GazeboRosOpenniKinect()
   this->point_cloud_connect_count_ = 0;
   this->depth_info_connect_count_ = 0;
   this->last_depth_image_camera_info_update_time_ = common::Time(0);
-  this->advertised_ = false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -100,6 +99,7 @@ void GazeboRosOpenniKinect::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sd
   else
     this->point_cloud_cutoff_ = _sdf->GetElement("pointCloudCutoff")->GetValueDouble();
 
+  load_connection_ = GazeboRosCameraUtils::OnLoad(boost::bind(&GazeboRosOpenniKinect::Advertise, this));
   GazeboRosCameraUtils::Load(_parent, _sdf);
 }
 
@@ -128,8 +128,6 @@ void GazeboRosOpenniKinect::Advertise()
         boost::bind( &GazeboRosOpenniKinect::DepthInfoDisconnect,this), 
         ros::VoidPtr(), &this->camera_queue_);
   this->depth_image_camera_info_pub_ = this->rosnode_->advertise(depth_image_camera_info_ao);
-
-  this->advertised_ = true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -186,9 +184,6 @@ void GazeboRosOpenniKinect::OnNewDepthFrame(const float *_image,
   if (!this->initialized_ || this->height_ <=0 || this->width_ <=0)
     return;
 
-  if (!this->advertised_)
-    Advertise();
-
   this->depth_sensor_update_time_ = this->parentSensor->GetLastUpdateTime();
   if (this->parentSensor->IsActive())
   {
@@ -224,9 +219,6 @@ void GazeboRosOpenniKinect::OnNewImageFrame(const unsigned char *_image,
 {
   if (!this->initialized_ || this->height_ <=0 || this->width_ <=0)
     return;
-
-  if (!this->advertised_)
-    Advertise();
 
   //ROS_ERROR("camera_ new frame %s %s",this->parentSensor_->GetName().c_str(),this->frame_name_.c_str());
   this->sensor_update_time_ = this->parentSensor_->GetLastUpdateTime();

--- a/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
+++ b/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
@@ -28,9 +28,9 @@
 
 #include <gazebo_plugins/gazebo_ros_openni_kinect.h>
 
-#include <sensors/Sensor.hh>
-#include <sdf/interface/SDF.hh>
-#include <sensors/SensorTypes.hh>
+#include <gazebo/sensors/Sensor.hh>
+#include <gazebo/sdf/interface/SDF.hh>
+#include <gazebo/sensors/SensorTypes.hh>
 
 // for creating PointCloud2 from pcl point cloud
 #include "pcl/ros/conversions.h"

--- a/gazebo_plugins/src/gazebo_ros_projector.cpp
+++ b/gazebo_plugins/src/gazebo_ros_projector.cpp
@@ -26,10 +26,10 @@
 #include <utility>
 #include <sstream>
 
-#include <rendering/Rendering.hh>
-#include <rendering/Scene.hh>
-#include <rendering/Visual.hh>
-#include <rendering/RTShaderSystem.hh>
+#include <gazebo/rendering/Rendering.hh>
+#include <gazebo/rendering/Scene.hh>
+#include <gazebo/rendering/Visual.hh>
+#include <gazebo/rendering/RTShaderSystem.hh>
 #include <gazebo_plugins/gazebo_ros_projector.h>
 
 #include <std_msgs/String.h>


### PR DESCRIPTION
Unfortunately there was a new chicken and egg problem introduced with the solution from my pull request #31. I am not sure why this did not happen when I tested the patch some days before. 

The depth topics will never been advertised before the first OnNew...Frame callback has been executed, but on the other hand the sensor is not activated before the first subscriber connects to the relevant topics. I now added an OnLoad() method to the GazeboRosCameraUtils class that plugins can use to register a callback that is executed in the load thread after the initialization has been completed.

I also added the gazebo/ prefix to some include directories. This did not cause any compiler errors, but I noticed the difference while I compared the openni and depth camera plugins.
