### PR TITLE
gazebo_ros: GazeboRosApiPlugin is not properly unloaded during destruction

### DIFF
--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -145,6 +145,7 @@ void GazeboRosApiPlugin::Load(int argc, char** argv)
   // below needs the world to be created first
   load_gazebo_ros_api_plugin_event_ = gazebo::event::Events::ConnectWorldCreated(boost::bind(&GazeboRosApiPlugin::loadGazeboRosApiPlugin,this,_1));
 
+  plugin_loaded_ = true;
   ROS_INFO("Finished loading Gazebo ROS API Plugin.");
 }
 


### PR DESCRIPTION
The GazeboRosApiPlugin checks if the plugin_loaded_ flag is true in its destructor, but this flag was never set before. This results in a lock_error if the callback queue is destroyed without having terminated the `gazeboQueueThread` thread properly first.

I am not sure if simply setting the flag is a 100% clean solution as some connections are established in the `GazeboRosApiPlugin::loadGazeboRosApiPlugin()` function called from the WorldCreated event and the plugin could be deconstructed before the world is fully created in case other plugins fail to load.

See http://answers.gazebosim.org/question/3444/gazebo-aborts-with-boostlock_error-when-adding-a/ for an example with stack traces.
