### PR TITLE
Include <sdf/sdf.hh> instead of <sdf/SDF.hh>

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_bumper.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_bumper.h
@@ -37,7 +37,7 @@
 #include <gazebo/sensors/sensors.hh>
 #include <gazebo/msgs/msgs.hh>
 #include <gazebo/physics/physics.hh>
-#include <sdf/SDF.hh>
+#include <sdf/sdf.hh>
 #include <gazebo/transport/TransportTypes.hh>
 #include <gazebo/msgs/MessageTypes.hh>
 #include <gazebo/common/Time.hh>

--- a/gazebo_plugins/src/gazebo_ros_block_laser.cpp
+++ b/gazebo_plugins/src/gazebo_ros_block_laser.cpp
@@ -28,7 +28,7 @@
 #include <gazebo/physics/World.hh>
 #include <gazebo/physics/HingeJoint.hh>
 #include <gazebo/sensors/Sensor.hh>
-#include <sdf/SDF.hh>
+#include <sdf/sdf.hh>
 #include <sdf/Param.hh>
 #include <gazebo/common/Exception.hh>
 #include <gazebo/sensors/RaySensor.hh>

--- a/gazebo_plugins/src/gazebo_ros_bumper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_bumper.cpp
@@ -28,7 +28,7 @@
 #include <gazebo/physics/HingeJoint.hh>
 #include <gazebo/physics/Contact.hh>
 #include <gazebo/sensors/Sensor.hh>
-#include <sdf/SDF.hh>
+#include <sdf/sdf.hh>
 #include <sdf/Param.hh>
 #include <gazebo/common/Exception.hh>
 #include <gazebo/sensors/SensorTypes.hh>

--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -31,7 +31,7 @@
 #include <gazebo/physics/World.hh>
 #include <gazebo/physics/HingeJoint.hh>
 #include <gazebo/sensors/Sensor.hh>
-#include <sdf/SDF.hh>
+#include <sdf/sdf.hh>
 #include <sdf/Param.hh>
 #include <gazebo/common/Exception.hh>
 #include <gazebo/sensors/CameraSensor.hh>

--- a/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
@@ -28,7 +28,7 @@
 #include <gazebo_plugins/gazebo_ros_depth_camera.h>
 
 #include <gazebo/sensors/Sensor.hh>
-#include <sdf/SDF.hh>
+#include <sdf/sdf.hh>
 #include <gazebo/sensors/SensorTypes.hh>
 
 // for creating PointCloud2 from pcl point cloud

--- a/gazebo_plugins/src/gazebo_ros_gpu_laser.cpp
+++ b/gazebo_plugins/src/gazebo_ros_gpu_laser.cpp
@@ -28,7 +28,7 @@
 #include <gazebo/physics/World.hh>
 #include <gazebo/physics/HingeJoint.hh>
 #include <gazebo/sensors/Sensor.hh>
-#include <sdf/SDF.hh>
+#include <sdf/sdf.hh>
 #include <sdf/Param.hh>
 #include <gazebo/common/Exception.hh>
 #include <gazebo/sensors/GpuRaySensor.hh>

--- a/gazebo_plugins/src/gazebo_ros_laser.cpp
+++ b/gazebo_plugins/src/gazebo_ros_laser.cpp
@@ -28,7 +28,7 @@
 #include <gazebo/physics/World.hh>
 #include <gazebo/physics/HingeJoint.hh>
 #include <gazebo/sensors/Sensor.hh>
-#include <sdf/SDF.hh>
+#include <sdf/sdf.hh>
 #include <sdf/Param.hh>
 #include <gazebo/common/Exception.hh>
 #include <gazebo/sensors/RaySensor.hh>

--- a/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
+++ b/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
@@ -29,7 +29,7 @@
 #include <gazebo_plugins/gazebo_ros_openni_kinect.h>
 
 #include <gazebo/sensors/Sensor.hh>
-#include <sdf/SDF.hh>
+#include <sdf/sdf.hh>
 #include <gazebo/sensors/SensorTypes.hh>
 
 // for creating PointCloud2 from pcl point cloud


### PR DESCRIPTION
The sdformat package recently changed the name of an sdf header
file from SDF.hh to SDFImpl.hh; this change will use the lower-case
header file which should work with old and new versions of sdformat
or gazebo.
