### PR TITLE
Remove find_package(SDF) from CMakeLists.txt

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -33,7 +33,6 @@ endif()
 
 # Depend on system install of Gazebo and SDFormat
 find_package(gazebo REQUIRED)
-find_package(SDF REQUIRED)
 find_package(PCL REQUIRED)
 find_package(Boost REQUIRED COMPONENTS thread)
 

--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -23,7 +23,6 @@ endif()
 
 # Depend on system install of Gazebo and SDFormat
 find_package(gazebo REQUIRED)
-find_package(SDF REQUIRED)
 find_package(Boost REQUIRED COMPONENTS thread)
 
 catkin_python_setup()

--- a/gazebo_ros_control/CMakeLists.txt
+++ b/gazebo_ros_control/CMakeLists.txt
@@ -14,7 +14,6 @@ find_package(catkin REQUIRED COMPONENTS
 
 # Depend on system install of Gazebo and SDFormat
 find_package(gazebo REQUIRED)
-find_package(SDF REQUIRED)
 
 catkin_package(
   CATKIN_DEPENDS


### PR DESCRIPTION
It is sufficient to find gazebo, which will export the information about the SDFormat package.

Actually the current code isn't doing anything, since the SDF package was renamed ti SDFormat.
