### PR TITLE
Camera util cannot find tf_prefix

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -119,6 +119,9 @@ void GazeboRosCameraUtils::Load(sensors::SensorPtr _parent,
   this->robot_namespace_ = "";
   if (this->sdf->HasElement("robotNamespace"))
     this->robot_namespace_ = this->sdf->Get<std::string>("robotNamespace") + "/";
+  else{
+    ROS_INFO("No robot namespace found.");
+  }
 
   this->image_topic_name_ = "image_raw";
   if (this->sdf->HasElement("imageTopicName"))
@@ -267,9 +270,10 @@ void GazeboRosCameraUtils::LoadThread()
 
   this->itnode_ = new image_transport::ImageTransport(*this->rosnode_);
 
-  // resolve tf prefix
+  // resolve tf prefix that is in the robot node!
+  ros::NodeHandle* robotnode = new ros::NodeHandle(this->robot_namespace_);
   std::string prefix;
-  this->rosnode_->getParam(std::string("tf_prefix"), prefix);
+  robotnode->getParam(std::string("tf_prefix"), prefix);
   this->frame_name_ = tf::resolve(prefix, this->frame_name_);
 
   if (!this->camera_name_.empty())

--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -267,12 +267,13 @@ void GazeboRosCameraUtils::LoadThread()
 
   this->itnode_ = new image_transport::ImageTransport(*this->rosnode_);
 
-  // resolve tf prefix that is in the robot node!
-  ros::NodeHandle* robotnode = new ros::NodeHandle(this->robot_namespace_);
-  std::string prefix;
-  robotnode->getParam(std::string("tf_prefix"), prefix);
-  this->frame_name_ = tf::resolve(prefix, this->frame_name_);
-  delete robotnode;
+  // resolve tf prefix
+  std::string key;
+  if(this->rosnode_->searchParam("tf_prefix", key)){
+    std::string prefix;
+    this->rosnode_->getParam(key, prefix);
+    this->frame_name_ = tf::resolve(prefix, this->frame_name_);
+  }
 
   if (!this->camera_name_.empty())
   {

--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -119,9 +119,6 @@ void GazeboRosCameraUtils::Load(sensors::SensorPtr _parent,
   this->robot_namespace_ = "";
   if (this->sdf->HasElement("robotNamespace"))
     this->robot_namespace_ = this->sdf->Get<std::string>("robotNamespace") + "/";
-  else{
-    ROS_INFO("No robot namespace found.");
-  }
 
   this->image_topic_name_ = "image_raw";
   if (this->sdf->HasElement("imageTopicName"))

--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -272,6 +272,7 @@ void GazeboRosCameraUtils::LoadThread()
   std::string prefix;
   robotnode->getParam(std::string("tf_prefix"), prefix);
   this->frame_name_ = tf::resolve(prefix, this->frame_name_);
+  delete robotnode;
 
   if (!this->camera_name_.empty())
   {


### PR DESCRIPTION
Usually the tf_prefix param is set in the robot node. The camera util creates a node with path "/robot_namespace/camera_name" and searches for the tf_prefix in that node.

This patch creates a temporary node with path "/robot_namespace" and looks for tf_prefix param in that node.
