### PR TITLE
gazebo_ros: Fixed a minor typo in spawn_model error message when -model not specified

### DIFF
--- a/gazebo_ros/scripts/spawn_model
+++ b/gazebo_ros/scripts/spawn_model
@@ -178,7 +178,7 @@ class SpawnModel():
           print "Error: you must specify incoming format as either urdf or sdf format xml"
           sys.exit(0)
         if self.model_name == "":
-          print "Error: you must specify robot name"
+          print "Error: you must specify model name"
           sys.exit(0)
 
     def checkForModel(self,model):


### PR DESCRIPTION
There is a -model parameter, not a -robot parameter. The error message is printed if you don't specify -model and haven't set self.model_name, so changing the error to reference the "model name" as opposed to "robot name" seems to be a good idea.
