### PR TITLE
Make gazebo includes use full path

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_skid_steer_drive.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_skid_steer_drive.h
@@ -41,8 +41,8 @@
 
 #include <map>
 
-#include <common/common.hh>
-#include <physics/physics.hh>
+#include <gazebo/common/common.hh>
+#include <gazebo/physics/physics.hh>
 
 // ROS
 #include <ros/ros.h>

--- a/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
@@ -43,7 +43,7 @@
 
 #include <gazebo_plugins/gazebo_ros_diff_drive.h>
 
-#include <math/gzmath.hh>
+#include <gazebo/math/gzmath.hh>
 #include <sdf/sdf.hh>
 
 #include <ros/ros.h>

--- a/gazebo_plugins/src/gazebo_ros_skid_steer_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_skid_steer_drive.cpp
@@ -42,7 +42,7 @@
 
 #include <gazebo_plugins/gazebo_ros_skid_steer_drive.h>
 
-#include <math/gzmath.hh>
+#include <gazebo/math/gzmath.hh>
 #include <sdf/sdf.hh>
 
 #include <ros/ros.h>

--- a/gazebo_ros/src/gazebo_ros_paths_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_paths_plugin.cpp
@@ -38,8 +38,8 @@
  * Desc: External interfaces for Gazebo
  */
 
-#include <common/SystemPaths.hh>
-#include <common/Plugin.hh>
+#include <gazebo/common/SystemPaths.hh>
+#include <gazebo/common/Plugin.hh>
 
 #include <ros/ros.h>
 #include <ros/package.h>


### PR DESCRIPTION
In the next release of gazebo, it will be required to use the
full path for include files. For example,
`#include <physics/physics.hh>` will not be valid
`#include <gazebo/physics/physics.hh>` must be done instead.
