### PR TITLE
add missing build dependency on diagnostic_updater

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -24,6 +24,7 @@ find_package(catkin REQUIRED COMPONENTS
   rosconsole
   cv_bridge
   polled_camera
+  diagnostic_updater
 )
 
 include (FindPkgConfig)

--- a/gazebo_plugins/package.xml
+++ b/gazebo_plugins/package.xml
@@ -41,6 +41,7 @@
   <build_depend>message_generation</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>polled_camera</build_depend>
+  <build_depend>diagnostic_updater</build_depend>
 
   <run_depend>gazebo</run_depend>
   <run_depend>gazebo_msgs</run_depend>


### PR DESCRIPTION
which is used in src/gazebo_ros_prosilica.cpp

Please release a fixed package into Hydro since the missing dependency breaks catkin_make_isolated builds of desktop_full.
