### PR TITLE
Fix for multiple plugin install locations

### DIFF
--- a/gazebo_ros/scripts/debug
+++ b/gazebo_ros/scripts/debug
@@ -4,13 +4,13 @@ final="$@"
 # add ros path plugin if it does not already exist in the passed in arguments
 if [ `expr "$final" : '.*libgazebo_ros_paths_plugin\.so.*'` -eq 0 ]
 then
-    final="$final -s `catkin_find libgazebo_ros_paths_plugin.so`"
+    final="$final -s `catkin_find --first-only libgazebo_ros_paths_plugin.so`"
 fi
 
 # add ros api plugin if it does not already exist in the passed in arguments
 if [ `expr "$final" : '.*libgazebo\_ros\_api\_plugin\.so.*'` -eq 0 ]
 then
-    final="$final -s `catkin_find libgazebo_ros_api_plugin.so`"
+    final="$final -s `catkin_find --first-only libgazebo_ros_api_plugin.so`"
 fi
 
 setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/

--- a/gazebo_ros/scripts/gazebo
+++ b/gazebo_ros/scripts/gazebo
@@ -4,16 +4,16 @@ final="$@"
 # add ros path plugin if it does not already exist in the passed in arguments
 if [ `expr "$final" : '.*libgazebo_ros_paths_plugin\.so.*'` -eq 0 ]
 then
-    final="$final -s `catkin_find libgazebo_ros_paths_plugin.so`"
+    final="$final -s `catkin_find --first-only libgazebo_ros_paths_plugin.so`"
 fi
 
 # add ros api plugin if it does not already exist in the passed in arguments
 if [ `expr "$final" : '.*libgazebo\_ros\_api\_plugin\.so.*'` -eq 0 ]
 then
-    final="$final -s `catkin_find libgazebo_ros_api_plugin.so`"
+    final="$final -s `catkin_find --first-only libgazebo_ros_api_plugin.so`"
 fi
 
-client_final="-g `catkin_find libgazebo_ros_paths_plugin.so`"
+client_final="-g `catkin_find --first-only libgazebo_ros_paths_plugin.so`"
 
 # Combine the commands
 setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/

--- a/gazebo_ros/scripts/gzclient
+++ b/gazebo_ros/scripts/gzclient
@@ -4,7 +4,7 @@ final="$@"
 # add ros plugin if does not exist
 if [ `expr "$final" : '.*libgazebo_ros_paths_plugin\.so.*'` -eq 0 ]
 then
-    final="$final -g `catkin_find libgazebo_ros_paths_plugin.so`"
+    final="$final -g `catkin_find --first-only libgazebo_ros_paths_plugin.so`"
 fi
 
 # Combine the commands

--- a/gazebo_ros/scripts/gzserver
+++ b/gazebo_ros/scripts/gzserver
@@ -4,13 +4,13 @@ final="$@"
 # add ros path plugin if it does not already exist in the passed in arguments
 if [ `expr "$final" : '.*libgazebo_ros_paths_plugin\.so.*'` -eq 0 ]
 then
-    final="$final -s `catkin_find libgazebo_ros_paths_plugin.so`"
+    final="$final -s `catkin_find --first-only libgazebo_ros_paths_plugin.so`"
 fi
 
 # add ros api plugin if it does not already exist in the passed in arguments
 if [ `expr "$final" : '.*libgazebo\_ros\_api\_plugin\.so.*'` -eq 0 ]
 then
-    final="$final -s `catkin_find libgazebo_ros_api_plugin.so`"
+    final="$final -s `catkin_find --first-only libgazebo_ros_api_plugin.so`"
 fi
 
 setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/

--- a/gazebo_ros/scripts/perf
+++ b/gazebo_ros/scripts/perf
@@ -4,12 +4,12 @@ final="$@"
 # add ros plugin if does not exist
 if [ `expr "$final" : '.*libgazebo_ros_paths_plugin\.so.*'` -eq 0 ]
 then
-    final="$final -s `catkin_find libgazebo_ros_paths_plugin.so`"
+    final="$final -s `catkin_find --first-only libgazebo_ros_paths_plugin.so`"
 fi
 
 if [ `expr "$final" : '.*libgazebo\_ros\_api\_plugin\.so.*'` -eq 0 ]
 then
-    final="$final -s `catkin_find libgazebo_ros_api_plugin.so`"
+    final="$final -s `catkin_find --first-only libgazebo_ros_api_plugin.so`"
 fi
 
 setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/


### PR DESCRIPTION
Fixed issue where catkin_find returns more than one library if it is installed from both source and debian. Just needed to add a `--first-only` flag.
