### PR TITLE
Segfaults in camera gazebo plugins due to uninitialized shared pointers

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_multicamera.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_multicamera.h
@@ -54,9 +54,9 @@ namespace gazebo
     /// Bookkeeping flags that will be passed into the underlying
     /// GazeboRosCameraUtils objects to let them share state about the parent
     /// sensor.
-    private: int imageConnectCount;
-    private: boost::mutex imageConnectCountLock;
-    private: bool wasActive;
+    private: boost::shared_ptr<int> image_connect_count_;
+    private: boost::shared_ptr<boost::mutex> image_connect_count_lock_;
+    private: boost::shared_ptr<bool> was_active_;
   };
 }
 #endif

--- a/gazebo_plugins/src/gazebo_ros_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera.cpp
@@ -66,11 +66,7 @@ void GazeboRosCamera::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
   this->depth_ = this->depth;
   this->format_ = this->format;
   this->camera_ = this->camera;
-  this->image_connect_count_ = boost::shared_ptr<int>(new int);
-  *this->image_connect_count_ = 0;
-  this->image_connect_count_lock_ = boost::shared_ptr<boost::mutex>(new boost::mutex);
-  this->was_active_ = boost::shared_ptr<bool>(new bool);
-  *this->was_active_ = false;
+
   GazeboRosCameraUtils::Load(_parent, _sdf);
 }
 

--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -234,6 +234,11 @@ void GazeboRosCameraUtils::Load(sensors::SensorPtr _parent,
              " distortion parameters right now, your simulation maybe wrong.");
   }
 
+  // initialize shared_ptr members
+  if (!this->image_connect_count_) this->image_connect_count_ = boost::shared_ptr<int>(new int(0));
+  if (!this->image_connect_count_lock_) this->image_connect_count_lock_ = boost::shared_ptr<boost::mutex>(new boost::mutex);
+  if (!this->was_active_) this->was_active_ = boost::shared_ptr<bool>(new bool(false));
+
   // ros callback queue for processing subscription
   this->deferred_load_thread_ = boost::thread(
     boost::bind(&GazeboRosCameraUtils::LoadThread, this));

--- a/gazebo_plugins/src/gazebo_ros_multicamera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_multicamera.cpp
@@ -58,6 +58,11 @@ void GazeboRosMultiCamera::Load(sensors::SensorPtr _parent,
     return;
   }
 
+  // initialize shared_ptr members
+  this->image_connect_count_ = boost::shared_ptr<int>(new int(0));
+  this->image_connect_count_lock_ = boost::shared_ptr<boost::mutex>(new boost::mutex);
+  this->was_active_ = boost::shared_ptr<bool>(new bool(false));
+
   // copying from CameraPlugin into GazeboRosCameraUtils
   for (unsigned i = 0; i < this->camera.size(); ++i)
   {
@@ -69,13 +74,9 @@ void GazeboRosMultiCamera::Load(sensors::SensorPtr _parent,
     util->format_  = this->format[i];
     util->camera_  = this->camera[i];
     // Set up a shared connection counter
-    this->imageConnectCount = 0;
-    util->image_connect_count_ = boost::shared_ptr<int>(&this->imageConnectCount);
-    util->image_connect_count_lock_ =
-      boost::shared_ptr<boost::mutex>(&this->imageConnectCountLock);
-    this->wasActive = false;
-    util->was_active_ =
-      boost::shared_ptr<bool>(&this->wasActive);
+    util->image_connect_count_ = this->image_connect_count_;
+    util->image_connect_count_lock_ = this->image_connect_count_lock_;
+    util->was_active_ = this->was_active_;
     if (this->camera[i]->GetName().find("left") != std::string::npos)
     {
       // FIXME: hardcoded, left hack_baseline_ 0

--- a/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
+++ b/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
@@ -70,7 +70,6 @@ void GazeboRosOpenniKinect::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sd
   this->depth_ = this->depth;
   this->format_ = this->format;
   this->camera_ = this->depthCamera;
-  this->image_connect_count_ = boost::shared_ptr<int>(new int);
 
   // using a different default
   if (!_sdf->GetElement("imageTopicName"))


### PR DESCRIPTION
The new shared pointer members introduced in bd078a095da8723347a26fbb007c64bbf49dbb22 (`image_connect_count_`, `image_connect_count_lock_` and `was_active_`) have not properly been initialized in most camera plugins except gazebo_ros_camera.cpp and gazebo_ros_multicamera.cpp. Gazebo therefore segfaults when someone connects to an image subscriber.

cb950af9410e80b833dc5749eac6fbeb900b4cbd added initialization of `image_connect_count_` in the openni plugin, but the other two pointers have still been left uninitialized. The pointers must be initialized before `GazeboRosCameraUtils::LoadThread()` is executed, as they are dereferenced in `GazeboRosCameraUtils::ImageConnect()`.

Additionally in the multi camera plugin the shared pointers have been constructed from pointers to member variables, which is forbidden as the shared_ptr cannot take ownership of this pointer.

I only tested this patch with the gazebo_ros_camera and gazebo_ros_openni_kinect plugins!
