### PR TITLE
Spawn model pose fix

### DIFF
--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -1984,6 +1984,8 @@ void GazeboRosApiPlugin::updateSDFAttributes(TiXmlDocument &gazebo_model_xml, st
     // Pose is set at bottom of function
   }
 
+	
+
   // Set the pose value for both SDFs types here
   if (pose_element)
   {
@@ -1992,9 +1994,78 @@ void GazeboRosApiPlugin::updateSDFAttributes(TiXmlDocument &gazebo_model_xml, st
     gazebo::math::Vector3 initial_rpy = initial_q.GetAsEuler(); // convert to Euler angles for Gazebo XML
     pose_stream << initial_xyz.x << " " << initial_xyz.y << " " << initial_xyz.z << " "
                 << initial_rpy.x << " " << initial_rpy.y << " " << initial_rpy.z;
+    
+    // Add argument pose relatively to sdf pose
+    std::string sdf_pose=pose_element->GetText();
+    std::string arg_pose=pose_stream.str();
+    std::string temp_str;
+    float p_x,p_y,p_z,p_R,p_P,p_Y;
+    int runner_prev=0,runner_next=0;
+    
+    runner_next=sdf_pose.find(' ',runner_prev);
+    temp_str=sdf_pose.substr(runner_prev,runner_next);
+    p_x=atof(temp_str.c_str());
+    runner_prev=runner_next+1;
+    
+    runner_next=sdf_pose.find(' ',runner_prev);
+    temp_str=sdf_pose.substr(runner_prev,runner_next);
+    p_y=atof(temp_str.c_str());
+    runner_prev=runner_next+1;
+    
+    runner_next=sdf_pose.find(' ',runner_prev);
+    temp_str=sdf_pose.substr(runner_prev,runner_next);
+    p_z=atof(temp_str.c_str());
+    runner_prev=runner_next+1;
+    
+    runner_next=sdf_pose.find(' ',runner_prev);
+    temp_str=sdf_pose.substr(runner_prev,runner_next);
+    p_R=atof(temp_str.c_str());
+    runner_prev=runner_next+1;
+    
+    runner_next=sdf_pose.find(' ',runner_prev);
+    temp_str=sdf_pose.substr(runner_prev,runner_next);
+    p_P=atof(temp_str.c_str());
+    runner_prev=runner_next+1;
+    
+    temp_str=sdf_pose.substr(runner_prev,sdf_pose.size()-1);
+    p_Y=atof(temp_str.c_str());
+	
+	runner_prev=runner_next=0;
+	
+	runner_next=arg_pose.find(' ',runner_prev);
+    temp_str=arg_pose.substr(runner_prev,runner_next);
+    p_x+=atof(temp_str.c_str());
+    runner_prev=runner_next+1;
+    
+    runner_next=arg_pose.find(' ',runner_prev);
+    temp_str=arg_pose.substr(runner_prev,runner_next);
+    p_y+=atof(temp_str.c_str());
+    runner_prev=runner_next+1;
+    
+    runner_next=arg_pose.find(' ',runner_prev);
+    temp_str=arg_pose.substr(runner_prev,runner_next);
+    p_z+=atof(temp_str.c_str());
+    runner_prev=runner_next+1;
+    
+    runner_next=arg_pose.find(' ',runner_prev);
+    temp_str=arg_pose.substr(runner_prev,runner_next);
+    p_R+=atof(temp_str.c_str());
+    runner_prev=runner_next+1;
+    
+    runner_next=arg_pose.find(' ',runner_prev);
+    temp_str=arg_pose.substr(runner_prev,runner_next);
+    p_P+=atof(temp_str.c_str());
+    runner_prev=runner_next+1;
+    
+    temp_str=arg_pose.substr(runner_prev,arg_pose.size()-1);
+    p_Y+=atof(temp_str.c_str());
+
+	std::ostringstream final_pose_stream;
+	final_pose_stream<<p_x<<" "<<p_y<<" "<<p_z<<" "<<p_R<<" "<<p_P<<" "<<p_Y;
 
     // Add value to pose element
-    TiXmlText* text = new TiXmlText(pose_stream.str());      
+    pose_element = new TiXmlElement("pose");
+    TiXmlText* text = new TiXmlText(final_pose_stream.str());      
     pose_element->LinkEndChild( text );
   }
 


### PR DESCRIPTION
Altered function GazeboRosApiPlugin::updateSDFAttributes in order to apply the user-defined robot pose (given by arguments when spawninga model) relatively to the sdf file where the model is included.

For example when a robot had an sdf pose `[0 0 0.18 0 0 0]` and when spawning it the args `-x 3 -y -3 -z 0.5` were given the following error occured : 

`Error [Param.cc:181] Unable to set value [0 0 0.180 0 0 03 -3 0.5 0 -0 0] for key[pose]`

Since one can not detect if a value is not set in arguments or it was set equal to 0, I got the two poses and added them relatively. Now when gazebo starts no errors are thrown and the models spawn in place.

If you think this approach is not correct, please inform me!

Manos
