### PR TITLE
Fix dependency issues

### DIFF
--- a/gazebo_ros_control/package.xml
+++ b/gazebo_ros_control/package.xml
@@ -29,7 +29,6 @@
   <run_depend>gazebo_ros</run_depend> 
   <run_depend>controller_manager</run_depend> 
   <run_depend>pluginlib</run_depend> 
-  <run_depend>ros_controllers</run_depend> 
   <run_depend>transmission_interface</run_depend> 
 
   <export>

--- a/gazebo_ros_control/package.xml
+++ b/gazebo_ros_control/package.xml
@@ -30,6 +30,7 @@
   <run_depend>controller_manager</run_depend> 
   <run_depend>pluginlib</run_depend> 
   <run_depend>transmission_interface</run_depend> 
+  <run_depend>urdf</run_depend>
 
   <export>
     <gazebo_ros_control plugin="${prefix}/robot_hw_sim_plugins.xml"/>


### PR DESCRIPTION
- [critical] `ros_controllers` is a meta-package. Packages can not depend on meta-packages. Removed.
- Added transitive dependency on urdf in gazebo_ros_control
