### PR TITLE
Fix iterator-related things

### DIFF
--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -81,16 +81,12 @@ GazeboRosApiPlugin::~GazeboRosApiPlugin()
   // Delete Force and Wrench Jobs
   lock_.lock();
   for (std::vector<GazeboRosApiPlugin::ForceJointJob*>::iterator iter=force_joint_jobs_.begin();iter!=force_joint_jobs_.end();)
-  {
     delete (*iter);
-    force_joint_jobs_.erase(iter);
-  }
+  force_joint_jobs_.clear();
   ROS_DEBUG_STREAM_NAMED("api_plugin","ForceJointJobs deleted");
   for (std::vector<GazeboRosApiPlugin::WrenchBodyJob*>::iterator iter=wrench_body_jobs_.begin();iter!=wrench_body_jobs_.end();)
-  {
     delete (*iter);
-    wrench_body_jobs_.erase(iter);
-  }
+  wrench_body_jobs_.clear();
   lock_.unlock();
   ROS_DEBUG_STREAM_NAMED("api_plugin","WrenchBodyJobs deleted");
 
@@ -1661,7 +1657,7 @@ void GazeboRosApiPlugin::wrenchBodySchedulerSlot()
     {
       // remove from queue once expires
       delete (*iter);
-      wrench_body_jobs_.erase(iter);
+      iter = wrench_body_jobs_.erase(iter);
     }
     else
       iter++;
@@ -1691,7 +1687,7 @@ void GazeboRosApiPlugin::forceJointSchedulerSlot()
         (*iter)->duration.toSec() >= 0.0)
     {
       // remove from queue once expires
-      force_joint_jobs_.erase(iter);
+      iter = force_joint_jobs_.erase(iter);
     }
     else
       iter++;

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -1319,7 +1319,7 @@ bool GazeboRosApiPlugin::clearJointForces(std::string joint_name)
   while(search)
   {
     search = false;
-    for (std::vector<GazeboRosApiPlugin::ForceJointJob*>::iterator iter=force_joint_jobs_.begin();iter!=force_joint_jobs_.end();iter++)
+    for (std::vector<GazeboRosApiPlugin::ForceJointJob*>::iterator iter=force_joint_jobs_.begin();iter!=force_joint_jobs_.end();++iter)
     {
       if ((*iter)->joint->GetName() == joint_name)
       {
@@ -1347,7 +1347,7 @@ bool GazeboRosApiPlugin::clearBodyWrenches(std::string body_name)
   while(search)
   {
     search = false;
-    for (std::vector<GazeboRosApiPlugin::WrenchBodyJob*>::iterator iter=wrench_body_jobs_.begin();iter!=wrench_body_jobs_.end();iter++)
+    for (std::vector<GazeboRosApiPlugin::WrenchBodyJob*>::iterator iter=wrench_body_jobs_.begin();iter!=wrench_body_jobs_.end();++iter)
     {
       //ROS_ERROR("search %s %s",(*iter)->body->GetScopedName().c_str(), body_name.c_str());
       if ((*iter)->body->GetScopedName() == body_name)


### PR DESCRIPTION
After using erase() on an iterator, the iterator is invalided. It should either receive a new value from the erase() method or not be used anymore.

The other issue is minor, but generates warnings with cppcheck: using pre-increments for iterators is recommended.
