### PR TITLE
gazebo_ros_control: Use the model NodeHandle to get the robot_description parameter

### DIFF
--- a/gazebo_ros_control/include/gazebo_ros_control/gazebo_ros_control_plugin.h
+++ b/gazebo_ros_control/include/gazebo_ros_control/gazebo_ros_control_plugin.h
@@ -81,7 +81,6 @@ public:
 protected:
 
   // Node Handles
-  ros::NodeHandle nh_; // no namespace
   ros::NodeHandle model_nh_; // namespaces to robot name
 
   // Pointer to the model

--- a/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
+++ b/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
@@ -140,7 +140,6 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
 
   // Get parameters/settings for controllers from ROS param server
   model_nh_ = ros::NodeHandle(robot_namespace_);
-  nh_ = ros::NodeHandle();
   ROS_INFO_NAMED("gazebo_ros_control", "Starting gazebo_ros_control plugin in namespace: %s", robot_namespace_.c_str());
 
   // Read urdf from ros parameter server then
@@ -224,19 +223,19 @@ std::string GazeboRosControlPlugin::getURDF(std::string param_name) const
   while (urdf_string.empty())
   {
     std::string search_param_name;
-    if (nh_.searchParam(param_name, search_param_name))
+    if (model_nh_.searchParam(param_name, search_param_name))
     {
       ROS_INFO_ONCE_NAMED("gazebo_ros_control", "gazebo_ros_control plugin is waiting for model"
         " URDF in parameter [%s] on the ROS param server.", search_param_name.c_str());
 
-      nh_.getParam(search_param_name, urdf_string);
+      model_nh_.getParam(search_param_name, urdf_string);
     }
     else
     {
       ROS_INFO_ONCE_NAMED("gazebo_ros_control", "gazebo_ros_control plugin is waiting for model"
         " URDF in parameter [%s] on the ROS param server.", robot_description_.c_str());
 
-      nh_.getParam(param_name, urdf_string);
+      model_nh_.getParam(param_name, urdf_string);
     }
 
     usleep(100000);


### PR DESCRIPTION
I replaced the default NodeHandle `nh_` by the model's NodeHandle `model_nh_` in `GazeboRosControlPlugin::getURDF()`. Otherwise it would not be possible to set a per-robot description on the parameter server. I cannot use the `robotParam` parameter for that as I would like to use the same plugin config for all models. The `robotNamespace` parameter is set automatically by the [spawn_model](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/hydro-devel/gazebo_ros/scripts/spawn_model) script based on the namespace in which the script itself has been called.

Due to the usage of `searchParam()` the plugin still uses the global `/robot_description` parameter if `<robotNamespace>/robot_description` is not set.
