### PR TITLE
gazebo_ros_pkgs: use GetMaxStepSize() for the Gazebo simulation period

### DIFF
--- a/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
+++ b/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
@@ -111,7 +111,7 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
   }
 
   // Get the Gazebo simulation period
-  ros::Duration gazebo_period(parent_model_->GetWorld()->GetPhysicsEngine()->GetUpdatePeriod());
+  ros::Duration gazebo_period(parent_model_->GetWorld()->GetPhysicsEngine()->GetMaxStepSize());
 
   // Decide the plugin control period
   if(sdf_->HasElement("controlPeriod"))


### PR DESCRIPTION
`GetUpdatePeriod()` will return the (desired) wall update period, not the step size in terms of simulated time. As most users will run Gazebo in real-time and this API call is only used for parameter checking, this is not a bug issue, but IMHO should be fixed anyway.

The correct API call is `GetMaxStepSize()`, which returns the increment of simulation time for each update step. The method name is somehow misleading, and from looking at the source code of [PhysicsEngine.cc](https://bitbucket.org/osrf/gazebo/src/32c3022375ccf0ccd60efe2167e9b54f8167206f/gazebo/physics/PhysicsEngine.cc) Gazebo never makes smaller steps than `GetMaxStepSize()`.
