### PR TITLE
Fixed #125: gazebo_ros_control: controlPeriod greater than the simulation period causes unexpected results

### DIFF
--- a/gazebo_ros_control/include/gazebo_ros_control/gazebo_ros_control_plugin.h
+++ b/gazebo_ros_control/include/gazebo_ros_control/gazebo_ros_control_plugin.h
@@ -72,6 +72,9 @@ public:
   // Called by the world update start event
   void Update();
 
+  // Called on world reset
+  virtual void Reset();
+
   // Get the URDF XML from the parameter server
   std::string getURDF(std::string param_name) const;
 

--- a/gazebo_ros_control/include/gazebo_ros_control/gazebo_ros_control_plugin.h
+++ b/gazebo_ros_control/include/gazebo_ros_control/gazebo_ros_control_plugin.h
@@ -114,7 +114,8 @@ protected:
 
   // Timing
   ros::Duration control_period_;
-  ros::Time last_sim_time_ros_;
+  ros::Time last_update_sim_time_ros_;
+  ros::Time last_write_sim_time_ros_;
 
 };
 

--- a/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
+++ b/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
@@ -196,23 +196,24 @@ void GazeboRosControlPlugin::Update()
   // Get the simulation time and period
   gazebo::common::Time gz_time_now = parent_model_->GetWorld()->GetSimTime();
   ros::Time sim_time_ros(gz_time_now.sec, gz_time_now.nsec);
-  ros::Duration sim_period = sim_time_ros - last_sim_time_ros_;
+  ros::Duration sim_period = sim_time_ros - last_update_sim_time_ros_;
 
   // Check if we should update the controllers
   if(sim_period >= control_period_) {
     // Store this simulation time
-    last_sim_time_ros_ = sim_time_ros;
+    last_update_sim_time_ros_ = sim_time_ros;
 
     // Update the robot simulation with the state of the gazebo model
     robot_hw_sim_->readSim(sim_time_ros, sim_period);
 
     // Compute the controller commands
     controller_manager_->update(sim_time_ros, sim_period);
-
-    // Update the gazebo model with the result of the controller
-    // computation
-    robot_hw_sim_->writeSim(sim_time_ros, sim_period);
   }
+
+  // Update the gazebo model with the result of the controller
+  // computation
+  robot_hw_sim_->writeSim(sim_time_ros, sim_time_ros - last_write_sim_time_ros_);
+  last_write_sim_time_ros_ = sim_time_ros;
 }
 
 // Get the URDF XML from the parameter server

--- a/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
+++ b/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
@@ -216,6 +216,14 @@ void GazeboRosControlPlugin::Update()
   last_write_sim_time_ros_ = sim_time_ros;
 }
 
+// Called on world reset
+void GazeboRosControlPlugin::Reset()
+{
+  // Reset timing variables to not pass negative update periods to controllers on world reset
+  last_update_sim_time_ros_ = ros::Time();
+  last_write_sim_time_ros_ = ros::Time();
+}
+
 // Get the URDF XML from the parameter server
 std::string GazeboRosControlPlugin::getURDF(std::string param_name) const
 {


### PR DESCRIPTION
This is a fix for #125.

I also added a Reset() method, which is required to prevent that controllers are called with negative update periods when the world is reset and sim time starts at zero again.
