### PR TITLE
[gazebo_plugins] Fix gazebo plugins bumper

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_bumper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_bumper.cpp
@@ -208,7 +208,7 @@ void GazeboRosBumper::OnContact()
     // For each collision contact
     // Create a ContactState
     gazebo_msgs::ContactState state;
-    /// \TODO:
+    /// \TODO: 
     gazebo::msgs::Contact contact = contacts.contact(i);
 
     state.collision1_name = contact.collision1();

--- a/gazebo_plugins/src/gazebo_ros_bumper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_bumper.cpp
@@ -121,6 +121,9 @@ void GazeboRosBumper::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
   // simulation iteration.
   this->update_connection_ = this->parentSensor->ConnectUpdated(
      boost::bind(&GazeboRosBumper::OnContact, this));
+
+  // Make sure the parent sensor is active.
+  this->parentSensor->SetActive(true);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -205,7 +208,7 @@ void GazeboRosBumper::OnContact()
     // For each collision contact
     // Create a ContactState
     gazebo_msgs::ContactState state;
-    /// \TODO: 
+    /// \TODO:
     gazebo::msgs::Contact contact = contacts.contact(i);
 
     state.collision1_name = contact.collision1();


### PR DESCRIPTION
In addition to the fix that needs to be done on gazebo (https://bitbucket.org/osrf/gazebo/pull-request/882/fixing-the-contactsensor-in-gazebo), the parent sensor (gazebo `ContactSensor`) of the `GazeboRosBumper` has to be activated, otherwise we're not getting any data.
