### PR TITLE
[gazebo_plugins] made depth camera and openni kinect plugins behave according to REP 117

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
@@ -394,13 +394,19 @@ bool GazeboRosDepthCamera::FillPointCloudHelper(
       pcl::PointXYZRGB point;
       point.x      = depth * tan(yAngle);
       point.y      = depth * tan(pAngle);
-      if(depth > this->point_cloud_cutoff_)
+      if (depth == 0.0f) // gazebo returns 0.0 when no object was rendered 
+      {
+        // set "no returns" to +infinity according to REP-117
+        point.z = std::numeric_limits<float>::infinity();
+      }
+      else if(depth > this->point_cloud_cutoff_)
       {
         point.z    = depth;
       }
-      else //point in the unseeable range
+      else //point in the unusable range
       {
-        point.x = point.y = point.z = std::numeric_limits<float>::quiet_NaN ();
+        // set "too close" measurements to -inf according to REP-117
+        point.x = point.y = point.z = -std::numeric_limits<float>::infinity();
         point_cloud.is_dense = false;
       }
 
@@ -451,8 +457,6 @@ bool GazeboRosDepthCamera::FillDepthImageHelper(
   image_msg.data.resize(rows_arg * cols_arg * sizeof(float));
   image_msg.is_bigendian = 0;
 
-  const float bad_point = std::numeric_limits<float>::quiet_NaN();
-
   float* dest = (float*)(&(image_msg.data[0]));
   float* toCopyFrom = (float*)data_arg;
   int index = 0;
@@ -463,15 +467,17 @@ bool GazeboRosDepthCamera::FillDepthImageHelper(
     for (uint32_t i = 0; i < cols_arg; i++)
     {
       float depth = toCopyFrom[index++];
-
-      if (depth > this->point_cloud_cutoff_)
+      if (depth == 0.0f) // gazebo returns 0.0 when no object was rendered 
       {
-        dest[i + j * cols_arg] = depth;
+        // set "no returns" to +infinity according to REP-117
+        depth = std::numeric_limits<float>::infinity();
       }
-      else //point in the unseeable range
+      else if (depth <= this->point_cloud_cutoff_) //point in the unusable range
       {
-        dest[i + j * cols_arg] = bad_point;
+        // set "too close" measurements to -inf according to REP-117
+        depth = -std::numeric_limits<float>::infinity();
       }
+      dest[i + j * cols_arg] = depth;
     }
   }
   return true;

--- a/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
+++ b/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
@@ -333,13 +333,19 @@ bool GazeboRosOpenniKinect::FillPointCloudHelper(
       pcl::PointXYZRGB point;
       point.x      = depth * tan(yAngle);
       point.y      = depth * tan(pAngle);
-      if(depth > this->point_cloud_cutoff_)
+      if (depth == 0.0f) // gazebo returns 0.0 when no object was rendered 
+      {
+        // set "no returns" to +infinity according to REP-117
+        point.z = std::numeric_limits<float>::infinity();
+      }
+      else if(depth > this->point_cloud_cutoff_)
       {
         point.z    = depth;
       }
-      else //point in the unseeable range
+      else //point in the unusable range
       {
-        point.x = point.y = point.z = std::numeric_limits<float>::quiet_NaN ();
+        // set "too close" measurements to -inf according to REP-117
+        point.x = point.y = point.z = -std::numeric_limits<float>::infinity();
         point_cloud.is_dense = false;
       }
 
@@ -390,8 +396,6 @@ bool GazeboRosOpenniKinect::FillDepthImageHelper(
   image_msg.data.resize(rows_arg * cols_arg * sizeof(float));
   image_msg.is_bigendian = 0;
 
-  const float bad_point = std::numeric_limits<float>::quiet_NaN();
-
   float* dest = (float*)(&(image_msg.data[0]));
   float* toCopyFrom = (float*)data_arg;
   int index = 0;
@@ -402,15 +406,17 @@ bool GazeboRosOpenniKinect::FillDepthImageHelper(
     for (uint32_t i = 0; i < cols_arg; i++)
     {
       float depth = toCopyFrom[index++];
-
-      if (depth > this->point_cloud_cutoff_)
+      if (depth == 0.0f) // gazebo returns 0.0 when no object was rendered 
       {
-        dest[i + j * cols_arg] = depth;
+        // set "no returns" to +infinity according to REP-117
+        depth = std::numeric_limits<float>::infinity();
       }
-      else //point in the unseeable range
+      else if (depth <= this->point_cloud_cutoff_) //point in the unusable range
       {
-        dest[i + j * cols_arg] = bad_point;
+        // set "too close" measurements to -inf according to REP-117
+        depth = -std::numeric_limits<float>::infinity();
       }
+      dest[i + j * cols_arg] = depth;
     }
   }
   return true;


### PR DESCRIPTION
[REP-117](http://www.ros.org/reps/rep-0117.html) defines how distance measurements should be represented in ROS. The depth images coming from gazebo do not follow this convention.
In the plugin, all values below a threshold parameter are set to `std::numeric_limits<float>::quiet_NaN()`. According to the REP all "too close" measurements should return -inf instead.
Gazebo returns 0.0 as depth value for pixels that do not contain any object. Those are translated into NaNs as well but should be set to +inf instead.

This PR changes the behavior of the depth camera and the openni kinect plugin to match the REP.

What I don't like much is the check for `depth == 0.0f` to get the pixels that shoud have +inf. Gazebo itself should return +inf for pixels that have no object behind them.
Maybe the fragment shader that is used [here](https://bitbucket.org/osrf/gazebo/src/0c7d0c7b9a221aa512aaa6ec88c5e9104b62ca2e/gazebo/rendering/DepthCamera.cc?at=default#cl-95) should be adapted?

@chadrockey Could you check the REP conformity please?
