### PR TITLE
Replace reference to `sceneNode` with function call in gazebo_ros_video

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_video.cpp
+++ b/gazebo_plugins/src/gazebo_ros_video.cpp
@@ -74,7 +74,7 @@ namespace gazebo
     mo.convertToMesh(name + "__VideoMesh__");
 
     Ogre::MovableObject *obj = (Ogre::MovableObject*)
-      this->sceneNode->getCreator()->createEntity(
+      this->GetSceneNode()->getCreator()->createEntity(
           name + "__VideoEntity__",
           name + "__VideoMesh__");
     obj->setCastShadows(false);


### PR DESCRIPTION
issue #166
