### PR TITLE
Initialize depth_image_connect_count_ in openni_kinect plugin

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
+++ b/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
@@ -48,6 +48,7 @@ GazeboRosOpenniKinect::GazeboRosOpenniKinect()
 {
   this->point_cloud_connect_count_ = 0;
   this->depth_info_connect_count_ = 0;
+  this->depth_image_connect_count_ = 0;
   this->last_depth_image_camera_info_update_time_ = common::Time(0);
 }
 


### PR DESCRIPTION
The field depth_image_connect_count_ wasn't initialized.

This caused the **/camera/depth_registered/image_raw** topic to randomly be published or not when launching the simulated kinect, depending on the random initial value of this field.
