### PR TITLE
Fix #175: dynamic reconfigure dependency error

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -120,6 +120,7 @@ catkin_package(
     gazebo 
     SDF
   )
+add_dependencies(${PROJECT_NAME}_gencfg ${catkin_EXPORTED_TARGETS})
 
 ## Executables
 add_executable(hokuyo_node src/hokuyo_node.cpp)


### PR DESCRIPTION
I was having trouble building gazebo_ros_pkgs on saucy/indigo (as detailed in #175). @dirk-thomas helped me fix the problem. This may be relevant for hydro as well.
