### PR TITLE
Remove unneeded dependency on pcl_ros

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -18,7 +18,6 @@ find_package(catkin REQUIRED COMPONENTS
   driver_base 
   rosgraph_msgs 
   trajectory_msgs 
-  pcl_ros 
   pcl_conversions
   image_transport 
   rosconsole
@@ -112,7 +111,6 @@ catkin_package(
   driver_base 
   rosgraph_msgs 
   trajectory_msgs 
-  pcl_ros 
   pcl_conversions
   image_transport 
   rosconsole

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
@@ -32,7 +32,6 @@
 #include <ros/callback_queue.h>
 #include <ros/advertise_options.h>
 
-#include <pcl_ros/point_cloud.h>
 #include <pcl/point_types.h>
 
 // ros messages stuff

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_openni_kinect.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_openni_kinect.h
@@ -32,7 +32,6 @@
 #include <ros/callback_queue.h>
 #include <ros/advertise_options.h>
 
-#include <pcl_ros/point_cloud.h>
 #include <pcl/point_types.h>
 
 // ros messages stuff

--- a/gazebo_plugins/package.xml
+++ b/gazebo_plugins/package.xml
@@ -34,7 +34,6 @@
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>driver_base</build_depend>
   <build_depend>rosgraph_msgs</build_depend>
-  <build_depend>pcl_ros</build_depend>
   <build_depend>pcl_conversions</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>rosconsole</build_depend>
@@ -59,7 +58,6 @@
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>driver_base</run_depend>
   <run_depend>rosgraph_msgs</run_depend>
-  <run_depend>pcl_ros</run_depend>
   <run_depend>pcl_conversions</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>rosconsole</run_depend>


### PR DESCRIPTION
pcl_ros hasn't been released yet into indigo. I asked @wjwwood about
its status, and he pointed out that our dependency on pcl_ros
probably isn't necessary. Lo and behold, we removed it from the
header files, package.xml and CMakeLists.txt and gazebo_plugins
still compiles.
