### PR TITLE
Reverse gazebo_ros dependency on gazebo_plugins

### DIFF
--- a/gazebo_plugins/package.xml
+++ b/gazebo_plugins/package.xml
@@ -44,6 +44,7 @@
 
   <run_depend>gazebo</run_depend>
   <run_depend>gazebo_msgs</run_depend>
+  <run_depend>gazebo_ros</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>trajectory_msgs</run_depend>

--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -49,7 +49,6 @@ catkin_package(
   message_generation
   std_msgs
   gazebo_msgs
-  gazebo_plugins
 
   DEPENDS
     TinyXML

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -25,7 +25,6 @@
   <build_depend>cmake_modules</build_depend>
   <build_depend>gazebo</build_depend>
   <build_depend>gazebo_msgs</build_depend>
-  <build_depend>gazebo_plugins</build_depend>
   <build_depend>roslib</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>tf</build_depend>
@@ -40,7 +39,6 @@
 
   <run_depend>gazebo</run_depend>
   <run_depend>gazebo_msgs</run_depend>
-  <run_depend>gazebo_plugins</run_depend>
   <run_depend>roslib</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>tf</run_depend>


### PR DESCRIPTION
gazebo_ros doesn't actually depend on anything in gazebo_plugins, so let's remove the spurious dependency.
