### PR TITLE
gazebo_plugins: moveit planning scene publisher

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(catkin REQUIRED COMPONENTS
   cv_bridge
   polled_camera
   diagnostic_updater
+  moveit_msgs
 )
 
 include (FindPkgConfig)
@@ -116,6 +117,7 @@ catkin_package(
   pcl_conversions
   image_transport 
   rosconsole
+  moveit_msgs
   DEPENDS 
     gazebo 
     SDF
@@ -137,7 +139,9 @@ add_dependencies(camera_synchronizer ${PROJECT_NAME}_gencfg)
 target_link_libraries(camera_synchronizer vision_reconfigure ${catkin_LIBRARIES})
 
 add_executable(pub_joint_trajectory_test test/pub_joint_trajectory_test.cpp)
-target_link_libraries(pub_joint_trajectory_test ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+# NOTE: QtGui and QtCore are required when using the GNU GoLD linker with Gazebo 2.2.2 which has poorly-specified so deps
+# More info here: https://bitbucket.org/osrf/gazebo/pull-request/1029/fix-second-order-dynamic-library/diff
+target_link_libraries(pub_joint_trajectory_test ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES} QtGui QtCore)
 add_dependencies(pub_joint_trajectory_test ${catkin_EXPORTED_TARGETS}) # don't build until gazebo_msgs is done
 
 add_definitions(-fPIC) # what is this for?
@@ -174,6 +178,9 @@ target_link_libraries(gazebo_ros_laser ${GAZEBO_LIBRARIES} RayPlugin ${catkin_LI
 
 add_library(gazebo_ros_block_laser src/gazebo_ros_block_laser.cpp)
 target_link_libraries(gazebo_ros_block_laser ${GAZEBO_LIBRARIES} RayPlugin ${catkin_LIBRARIES})
+
+add_library(gazebo_ros_moveit_planning_scene src/gazebo_ros_moveit_planning_scene.cpp)
+target_link_libraries(gazebo_ros_moveit_planning_scene ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
 
 add_library(gazebo_ros_p3d src/gazebo_ros_p3d.cpp)
 target_link_libraries(gazebo_ros_p3d ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
@@ -243,6 +250,7 @@ install(TARGETS
   gazebo_ros_openni_kinect
   gazebo_ros_openni_kinect
   gazebo_ros_laser
+  gazebo_ros_moveit_planning_scene
   gazebo_ros_block_laser
   gazebo_ros_p3d
   gazebo_ros_imu

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_moveit_planning_scene.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_moveit_planning_scene.h
@@ -1,0 +1,163 @@
+/*
+ *  Gazebo - Outdoor Multi-Robot Simulator
+ *  Copyright (C) 2003  
+ *     Nate Koenig & Andrew Howard
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+/*
+ * Desc: A plugin which publishes the gazebo world state as a MoveIt! planning scene
+ * Author: Jonathan Bohren
+ * Date: 15 May 2014
+ */
+#ifndef GAZEBO_ROS_MOVEIT_PLANNING_SCENE_H
+#define GAZEBO_ROS_MOVEIT_PLANNING_SCENE_H
+
+#include <string>
+
+// Custom Callback Queue
+#include <ros/callback_queue.h>
+#include <ros/subscribe_options.h>
+#include <geometry_msgs/Pose.h>
+
+#include <ros/ros.h>
+#include <boost/thread.hpp>
+#include <boost/thread/mutex.hpp>
+
+#include <gazebo/physics/physics.hh>
+#include <gazebo/transport/TransportTypes.hh>
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/common/Events.hh>
+
+#include <std_srvs/Empty.h>
+#include <moveit_msgs/PlanningScene.h>
+
+namespace gazebo
+{
+/// @addtogroup gazebo_dynamic_plugins Gazebo ROS Dynamic Plugins
+/// @{
+/** \defgroup GazeboRosMoveItPlanningScene Plugin XML Reference and Example
+
+  \brief Ros MoveIt Planning Scene Plugin.
+  
+  This is a model plugin which broadcasts MoveIt PlanningScene messages so
+  that the planning scene stays up-to-date with the world simulation.  This is
+  useful if you want to "fake" perfect perception of the environment.
+
+  Example Usage:
+
+  \verbatim
+      <gazebo>
+        <plugin filename="libgazebo_ros_moveit_planning_scene.so" name="gazebo_ros_moveit_planning_scene">
+          <topicName>/planning_scene</topicName>
+          <sceneName>laboratory</sceneName>
+          <robotName>my_robot</robotName>
+          <updatePeriod>0.5</updatePeriod>
+        </plugin>
+      </gazebo>
+  \endverbatim
+
+  Design:
+
+  Note that while this is a _model_ plugin, its primary purpose is to advertize
+  information about the gazebo world. It's designed as a model plugin, however,
+  since that information is relevant to the context of a single robot's planner.
+  As such, this plugin should be loaded in the model representing the robot
+  performing the planning.
+
+  At some period specified by <updatePeriod>, the plugin will publish the
+  complete world state. If this period is 0, then periodic messages will not be
+  published.
+
+  You can manually re-synch the world state by calling the publish_planning_scene
+  service.
+\{
+*/
+
+/**
+           .
+ 
+*/
+
+class GazeboRosMoveItPlanningScene : public ModelPlugin
+{
+  /// \brief Constructor
+  public: GazeboRosMoveItPlanningScene();
+
+  /// \brief Destructor
+  public: virtual ~GazeboRosMoveItPlanningScene();
+
+  // Documentation inherited
+  protected: void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
+
+  // Documentation inherited
+  protected: virtual void UpdateCB();
+
+  /// \brief publish the complete planning scene
+  private: bool PublishPlanningSceneCB(
+               std_srvs::Empty::Request& req,
+               std_srvs::Empty::Response& resp);
+
+  /// \brief The custom callback queue thread function.
+  private: void QueueThread();
+
+  /// \brief A pointer to the gazebo world.
+  private: physics::WorldPtr world_;
+
+  /// \brief A pointer to the Model of the robot doing the planning
+  private: physics::ModelPtr model_;
+
+  /// \brief A pointer to the ROS node.  A node will be instantiated if it does not exist.
+  private: boost::scoped_ptr<ros::NodeHandle> rosnode_;
+  private: ros::Publisher planning_scene_pub_;
+           ros::ServiceServer publish_planning_scene_service_;
+
+  /// \brief A mutex to lock access to fields that are used in ROS message callbacks
+  private: boost::mutex mutex_;
+
+  /// \brief ROS Wrench topic name inputs
+  private: std::string topic_name_;
+  /// \brief The MoveIt scene name
+  private: std::string scene_name_;
+  private: std::string robot_name_;
+  private: std::string model_name_;
+
+  /// \brief for setting ROS name space
+  private: std::string robot_namespace_;
+
+  // Custom Callback Queue
+  private: ros::CallbackQueue queue_;
+  /// \brief Thead object for the running callback Thread.
+  private: boost::thread callback_queue_thread_;
+  /// \brief Container for the wrench force that this plugin exerts on the body.
+  private: moveit_msgs::PlanningScene planning_scene_msg_;
+           std::map<std::string, moveit_msgs::CollisionObject> collision_object_map_;
+
+  // Pointer to the update event connection
+  private: event::ConnectionPtr update_connection_;
+  private: event::ConnectionPtr add_connection_;
+  private: event::ConnectionPtr delete_connection_;
+
+  private:
+           bool publish_full_scene_;
+
+           ros::Duration publish_period_;
+           ros::Time last_publish_time_;
+};
+/** \} */
+/// @}
+}
+#endif

--- a/gazebo_plugins/package.xml
+++ b/gazebo_plugins/package.xml
@@ -42,6 +42,7 @@
   <build_depend>cv_bridge</build_depend>
   <build_depend>polled_camera</build_depend>
   <build_depend>diagnostic_updater</build_depend>
+  <build_depend>moveit_msgs</build_depend>
 
   <run_depend>gazebo</run_depend>
   <run_depend>gazebo_msgs</run_depend>
@@ -66,5 +67,6 @@
   <run_depend>message_generation</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>polled_camera</run_depend>
+  <run_depend>moveit_msgs</run_depend>
 
 </package>

--- a/gazebo_plugins/src/gazebo_ros_moveit_planning_scene.cpp
+++ b/gazebo_plugins/src/gazebo_ros_moveit_planning_scene.cpp
@@ -1,0 +1,478 @@
+/*
+ * Copyright 2013 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+/*
+ * Desc: A plugin which publishes the gazebo world state as a MoveIt! planning scene
+ * Author: Jonathan Bohren
+ * Date: 15 May 2014
+ */
+
+#include <algorithm>
+#include <assert.h>
+
+#include <boost/bind.hpp>
+#include <boost/thread/mutex.hpp>
+
+#include <gazebo/common/common.hh>
+
+#include <gazebo_plugins/gazebo_ros_moveit_planning_scene.h>
+
+namespace gazebo
+{
+GZ_REGISTER_MODEL_PLUGIN(GazeboRosMoveItPlanningScene);
+
+////////////////////////////////////////////////////////////////////////////////
+// Constructor
+GazeboRosMoveItPlanningScene::GazeboRosMoveItPlanningScene()
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Destructor
+GazeboRosMoveItPlanningScene::~GazeboRosMoveItPlanningScene()
+{
+  event::Events::DisconnectWorldUpdateBegin(this->update_connection_);
+
+  // Custom Callback Queue
+  this->queue_.clear();
+  this->queue_.disable();
+  this->rosnode_->shutdown();
+  this->callback_queue_thread_.join();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Load the controller
+void GazeboRosMoveItPlanningScene::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
+{
+  // Get the world name.
+  this->world_ = _model->GetWorld();
+
+  this->model_name_ = _model->GetName();
+  
+  // load parameters
+  if (_sdf->HasElement("robotNamespace")) {
+    this->robot_namespace_ = _sdf->GetElement("robotNamespace")->Get<std::string>() + "/";
+  } else {
+    this->robot_namespace_ = "";
+  }
+
+  if (!_sdf->HasElement("robotName")) {
+    this->robot_name_ = _model->GetName();
+  } else {
+    this->robot_name_ = _sdf->GetElement("robotName")->Get<std::string>();
+  }
+
+  if (!_sdf->HasElement("topicName")) {
+    this->topic_name_ = "planning_scene";
+  }  else {
+    this->topic_name_ = _sdf->GetElement("topicName")->Get<std::string>();
+  }
+
+  if (!_sdf->HasElement("sceneName")) {
+    this->scene_name_ = "";
+  } else {
+    this->scene_name_ = _sdf->GetElement("sceneName")->Get<std::string>();
+  }
+
+  if (!_sdf->HasElement("updatePeriod")) {
+    this->publish_period_ = ros::Duration(0.0);
+  } else {
+    this->publish_period_ = ros::Duration(_sdf->GetElement("updatePeriod")->Get<double>());
+  }
+
+
+  // Make sure the ROS node for Gazebo has already been initialized
+  if (!ros::isInitialized())
+  {
+    ROS_FATAL_STREAM("A ROS node for Gazebo has not been initialized, unable to load plugin. "
+      << "Load the Gazebo system plugin 'libgazebo_ros_api_plugin.so' in the gazebo_ros package)");
+    return;
+  }
+
+  this->rosnode_.reset(new ros::NodeHandle(this->robot_namespace_));
+
+  last_publish_time_ = ros::Time(0,0);
+
+  planning_scene_pub_ = this->rosnode_->advertise<moveit_msgs::PlanningScene>(this->topic_name_, 1);
+
+  // Custom Callback Queue
+  /*
+   *ros::SubscribeOptions so = ros::SubscribeOptions::create<geometry_msgs::Wrench>(
+   *  this->topic_name_,1,
+   *  boost::bind( &GazeboRosMoveItPlanningScene::UpdateObjectForce,this,_1),
+   *  ros::VoidPtr(), &this->queue_);
+   *this->sub_ = this->rosnode_->subscribe(so);
+   */
+
+  // Custom Callback Queue
+  this->callback_queue_thread_ = boost::thread( boost::bind( &GazeboRosMoveItPlanningScene::QueueThread,this ) );
+
+  // Create service server
+  ros::AdvertiseServiceOptions aso;
+  boost::function<bool(std_srvs::Empty::Request&, std_srvs::Empty::Response&)> srv_cb =
+    boost::bind(&GazeboRosMoveItPlanningScene::PublishPlanningSceneCB, this, _1, _2);
+  aso.init("publish_planning_scene", srv_cb);
+  aso.callback_queue = &this->queue_;
+
+  publish_planning_scene_service_ = this->rosnode_->advertiseService(aso);
+
+  // Publish the full scene on the next update
+  publish_full_scene_ = false;
+
+  // New Mechanism for Updating every World Cycle
+  // Listen to the update event. This event is broadcast every
+  // simulation iteration.
+  this->update_connection_ = event::Events::ConnectWorldUpdateBegin(
+      boost::bind(&GazeboRosMoveItPlanningScene::UpdateCB, this));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Manually publish the full planninc scene
+bool GazeboRosMoveItPlanningScene::PublishPlanningSceneCB(
+    std_srvs::Empty::Request& req,
+    std_srvs::Empty::Response& resp)
+{
+  boost::mutex::scoped_lock lock(this->mutex_);
+
+  // Set flag to re-publish full scene
+  publish_full_scene_ = true;
+
+  return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Update the controller
+void GazeboRosMoveItPlanningScene::UpdateCB()
+{
+  boost::mutex::scoped_lock lock(this->mutex_);
+
+  using namespace gazebo::common;
+  using namespace gazebo::physics;
+
+  if(!publish_full_scene_) {
+    if(publish_period_.isZero() || (ros::Time::now() - last_publish_time_) < publish_period_) {
+      return;
+    } else {
+      last_publish_time_ = ros::Time::now();
+    }
+  } else {
+    publish_full_scene_ = false;
+  }
+
+  // Iterate through the tracked models and clear their dynamic information
+  // This also sets objects to be removed if they currently aren't in the scene
+  for(std::map<std::string,moveit_msgs::CollisionObject>::iterator object_it = collision_object_map_.begin();
+      object_it != collision_object_map_.end();
+      ++object_it)
+  {
+    // Convenience reference
+    moveit_msgs::CollisionObject &object = object_it->second;
+
+    // Mark for removal unless it's found in the gazebo world
+    object.operation = moveit_msgs::CollisionObject::REMOVE;
+
+    // Clear shape information
+    object.primitives.clear();
+    object.primitive_poses.clear();
+
+    object.meshes.clear();
+    object.mesh_poses.clear();
+
+    object.planes.clear();
+    object.plane_poses.clear();
+  }
+
+  // Iterate over all the models currently in the world
+  std::vector<ModelPtr> models = this->world_->GetModels();
+  for(std::vector<ModelPtr>::const_iterator model_it = models.begin();
+      model_it != models.end();
+      ++model_it)
+  {
+    const ModelPtr &model = *model_it;
+    const std::string model_name = model->GetName();
+
+    // Don't declare the robot as a collision object
+    if(model_name == model_name_) { 
+      continue;
+    }
+
+    // Check if the gazebo model is already in the collision object map
+    std::map<std::string, moveit_msgs::CollisionObject>::iterator found_collision_object = 
+      collision_object_map_.find(model_name);
+
+    // Create a new collision object representing this gazebo model if it's not in the map
+    if(found_collision_object == collision_object_map_.end()) {
+      moveit_msgs::CollisionObject new_object;
+      new_object.id = model_name;
+      new_object.header.frame_id = "world";
+      new_object.operation = moveit_msgs::CollisionObject::ADD;
+
+      collision_object_map_[model_name] = new_object;
+      ROS_DEBUG_STREAM_NAMED("GazeboRosMoveItPlanningScene","Adding object: "<<model_name);
+    } else {
+
+      collision_object_map_[model_name].operation = moveit_msgs::CollisionObject::MOVE;
+      ROS_DEBUG_STREAM_NAMED("GazeboRosMoveItPlanningScene","Moving object: "<<model_name);
+    }
+
+    // Get a reference to the object from the map
+    moveit_msgs::CollisionObject &object = collision_object_map_[model_name];
+
+    // Iterate over all links in the model, and add collision objects from each one
+    // This adds meshes and primitives to:
+    //  object.meshes,
+    //  object.primitives, and
+    //  object.planes
+    std::vector<LinkPtr> links = model->GetLinks(); 
+    for(std::vector<LinkPtr>::const_iterator link_it = links.begin();
+        link_it != links.end();
+        ++link_it)
+    {
+      const LinkPtr &link = *link_it;
+
+      gazebo::math::Pose link_pose = link->GetWorldPose();
+      geometry_msgs::Pose link_pose_msg;
+      link_pose_msg.position.x = link_pose.pos.x;
+      link_pose_msg.position.y = link_pose.pos.y;
+      link_pose_msg.position.z = link_pose.pos.z;
+      link_pose_msg.orientation.x = link_pose.rot.x;
+      link_pose_msg.orientation.y = link_pose.rot.y;
+      link_pose_msg.orientation.z = link_pose.rot.z;
+      link_pose_msg.orientation.w = link_pose.rot.w;
+      //ROS_DEBUG_STREAM_NAMED("GazeboRosMoveItPlanningScene",model_name << " (link): " <<link_pose_msg);
+
+      // Get all the collision objects for this link
+      std::vector<CollisionPtr> collisions = link->GetCollisions();
+      for(std::vector<CollisionPtr>::const_iterator coll_it = collisions.begin();
+          coll_it != collisions.end();
+          ++coll_it)
+      {
+        const CollisionPtr &collision = *coll_it;
+        const ShapePtr shape = collision->GetShape();
+
+        // NOTE: In gazebo 2.2.2 Collision::GetWorldPose() does not work
+        gazebo::math::Pose collision_pose = collision->GetRelativePose()*link_pose;
+        geometry_msgs::Pose collision_pose_msg;
+        collision_pose_msg.position.x = collision_pose.pos.x;
+        collision_pose_msg.position.y = collision_pose.pos.y;
+        collision_pose_msg.position.z = collision_pose.pos.z;
+        collision_pose_msg.orientation.x = collision_pose.rot.x;
+        collision_pose_msg.orientation.y = collision_pose.rot.y;
+        collision_pose_msg.orientation.z = collision_pose.rot.z;
+        collision_pose_msg.orientation.w = collision_pose.rot.w;
+        //ROS_DEBUG_STREAM_NAMED("GazeboRosMoveItPlanningScene",model_name << " (collision): " <<collision_pose_msg);
+        
+        // Always add pose information
+        if(shape->HasType(Base::MESH_SHAPE)) {
+          object.mesh_poses.push_back(collision_pose_msg);
+        } else if(shape->HasType(Base::PLANE_SHAPE)) {
+          object.plane_poses.push_back(collision_pose_msg);
+        } else {
+          object.primitive_poses.push_back(collision_pose_msg);
+        }
+
+        // Only add geometric info if we haven't published it before
+        if(object.operation == moveit_msgs::CollisionObject::ADD || object.operation == moveit_msgs::CollisionObject::APPEND) 
+        {
+          if(shape->HasType(Base::MESH_SHAPE)) 
+          {
+            // Get the mesh structure from the mesh shape
+            boost::shared_ptr<MeshShape> mesh_shape = boost::dynamic_pointer_cast<MeshShape>(shape);
+            std::string name = mesh_shape->GetName();
+            std::string uri = mesh_shape->GetMeshURI();
+            const Mesh *mesh = MeshManager::Instance()->GetMesh(uri);
+
+            if(!mesh) {
+              gzwarn << "Shape has mesh type but mesh could not be retried from the MeshManager. Loading ad-hoc!" << std::endl;
+              gzwarn << " mesh uri: " <<uri<< std::endl;
+
+              // Load the mesh ad-hoc if the manager doesn't have it
+              // this happens with model:// uris
+              mesh = MeshManager::Instance()->Load(uri);
+
+              if(!mesh) {
+                gzwarn << "Mesh could not be loded: " << uri << std::endl;
+                continue;
+              }
+            } 
+
+            // Iterate over submeshes
+            unsigned n_submeshes = mesh->GetSubMeshCount();
+
+            for(unsigned m=0; m < n_submeshes; m++) {
+
+              const SubMesh *submesh = mesh->GetSubMesh(m);
+              unsigned n_vertices = submesh->GetVertexCount();
+
+              switch(submesh->GetPrimitiveType()) 
+              {
+                case SubMesh::POINTS:
+                case SubMesh::LINES:
+                case SubMesh::LINESTRIPS:
+                  // These aren't supported
+                  break;
+                case SubMesh::TRIANGLES:
+                  {
+                    //gzwarn<<"TRIANGLES"<<std::endl;
+                    shape_msgs::Mesh mesh_msg;
+                    mesh_msg.vertices.resize(n_vertices);
+                    mesh_msg.triangles.resize(n_vertices/3);
+
+                    for(size_t v=0; v < n_vertices; v++) {
+
+                      const int index = submesh->GetIndex(v);
+                      const gazebo::math::Vector3 vertex = submesh->GetVertex(v);
+
+                      mesh_msg.vertices[index].x = vertex.x;
+                      mesh_msg.vertices[index].y = vertex.y;
+                      mesh_msg.vertices[index].z = vertex.z;
+
+                      mesh_msg.triangles[v/3].vertex_indices[v%3] = index;
+                    }
+
+                    object.meshes.push_back(mesh_msg);
+                    break;
+                  }
+                case SubMesh::TRISTRIPS:
+                  {
+                    //gzwarn<<"TRISTRIPS"<<std::endl;
+                    shape_msgs::Mesh mesh_msg;
+                    mesh_msg.vertices.resize(n_vertices);
+                    mesh_msg.triangles.resize(n_vertices-2);
+
+                    for(size_t v=0; v < n_vertices; v++) {
+                      const int index = submesh->GetIndex(v);
+                      const gazebo::math::Vector3 vertex = submesh->GetVertex(v);
+
+                      mesh_msg.vertices[index].x = vertex.x;
+                      mesh_msg.vertices[index].y = vertex.y;
+                      mesh_msg.vertices[index].z = vertex.z;
+
+                      if(v < n_vertices-2) mesh_msg.triangles[v].vertex_indices[0] = index;
+                      if(v > 0 && v < n_vertices-1) mesh_msg.triangles[v-1].vertex_indices[1] = index;
+                      if(v > 1) mesh_msg.triangles[v-2].vertex_indices[2] = index;
+                    }
+
+                    object.meshes.push_back(mesh_msg);
+                    break;
+                  }
+                case SubMesh::TRIFANS:
+                  // Unsupported
+                  gzerr << "TRIFANS not supported yet." << std::endl;
+                  break;
+              };
+            }
+          } 
+          else if(shape->HasType(Base::PLANE_SHAPE)) 
+          {
+            // Plane
+            boost::shared_ptr<PlaneShape> plane_shape = boost::dynamic_pointer_cast<PlaneShape>(shape);
+            shape_msgs::Plane plane_msg;
+
+            plane_msg.coef[0] = plane_shape->GetNormal().x;
+            plane_msg.coef[1] = plane_shape->GetNormal().y;
+            plane_msg.coef[2] = plane_shape->GetNormal().z;
+            plane_msg.coef[3] = 0; // This should be handled by the position of the collision object
+
+            object.planes.push_back(plane_msg);
+          }
+          else 
+          {
+            // Solid primitive
+            shape_msgs::SolidPrimitive primitive_msg;
+
+            if(shape->HasType(Base::BOX_SHAPE)) {
+
+              boost::shared_ptr<BoxShape> box_shape = boost::dynamic_pointer_cast<BoxShape>(shape);
+
+              primitive_msg.type = primitive_msg.BOX;
+              primitive_msg.dimensions.resize(3);
+              primitive_msg.dimensions[0] = box_shape->GetSize().x;
+              primitive_msg.dimensions[1] = box_shape->GetSize().y;
+              primitive_msg.dimensions[2] = box_shape->GetSize().z;
+
+            } else if(shape->HasType(Base::CYLINDER_SHAPE)) {
+
+              boost::shared_ptr<CylinderShape> cylinder_shape = boost::dynamic_pointer_cast<CylinderShape>(shape);
+
+              primitive_msg.type = primitive_msg.CYLINDER;
+              primitive_msg.dimensions.resize(2);
+              primitive_msg.dimensions[0] = cylinder_shape->GetLength();
+              primitive_msg.dimensions[1] = cylinder_shape->GetRadius();
+
+            } else if(shape->HasType(Base::SPHERE_SHAPE)) {
+
+              boost::shared_ptr<SphereShape> sphere_shape = boost::dynamic_pointer_cast<SphereShape>(shape);
+
+              primitive_msg.type = primitive_msg.SPHERE;
+              primitive_msg.dimensions.resize(1);
+              primitive_msg.dimensions[0] = sphere_shape->GetRadius();
+
+            } else {
+              // HEIGHTMAP_SHAPE, MAP_SHAPE, MULTIRAY_SHAPE, RAY_SHAPE   
+              // Unsupported
+              continue;
+            }
+
+            object.primitives.push_back(primitive_msg);
+          }
+        }
+      }
+    }
+  }
+  
+  // Clear the list of collision objects
+  planning_scene_msg_.name = scene_name_;
+  planning_scene_msg_.robot_model_name = robot_name_;
+  planning_scene_msg_.is_diff = true;
+  planning_scene_msg_.world.collision_objects.clear();
+
+  // Iterate through the objects we're already tracking
+  for(std::map<std::string,moveit_msgs::CollisionObject>::iterator object_it = collision_object_map_.begin();
+      object_it != collision_object_map_.end();)
+  {
+    // Add the object to the planning scene message
+    planning_scene_msg_.world.collision_objects.push_back(object_it->second);
+    
+    // Actually remove objects from being tracked
+    if(object_it->second.operation == moveit_msgs::CollisionObject::REMOVE) {
+      // Actually remove the collision object from the map
+      ROS_DEBUG_STREAM_NAMED("GazeboRosMoveItPlanningScene","Removing object: "<<object_it->second.id);
+      collision_object_map_.erase(object_it++);
+    } else {
+      ++object_it;
+    }
+
+  }
+
+  planning_scene_pub_.publish(planning_scene_msg_);
+}
+
+// Custom Callback Queue
+////////////////////////////////////////////////////////////////////////////////
+// custom callback queue thread
+void GazeboRosMoveItPlanningScene::QueueThread()
+{
+  static const double timeout = 0.01;
+
+  while (this->rosnode_->ok())
+  {
+    this->queue_.callAvailable(ros::WallDuration(timeout));
+  }
+}
+
+}


### PR DESCRIPTION
This gazebo plugin publishes all of the objects in a gazebo world to a moveit planning scene topic. It can either publish at a given rate, or be polled manually.

Example usage:

``` xml
      <gazebo>
        <plugin filename="libgazebo_ros_moveit_planning_scene.so" name="gazebo_ros_moveit_planning_scene">
          <topicName>/planning_scene</topicName>
          <sceneName>laboratory</sceneName>
          <robotName>my_robot</robotName>
          <updatePeriod>0.5</updatePeriod>
        </plugin>
      </gazebo>

```
- [ ] subscribe to published planning scene in order to make sure that models have already been added

Shoutout @davetcoleman @isucan
