### PR TITLE
Fix build failures

### DIFF
--- a/gazebo_ros_control/CMakeLists.txt
+++ b/gazebo_ros_control/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
   pluginlib
   joint_limits_interface
   urdf
+  angles
 )
 
 # Depend on system install of Gazebo 

--- a/gazebo_ros_control/package.xml
+++ b/gazebo_ros_control/package.xml
@@ -18,6 +18,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>roscpp</build_depend> 
+  <build_depend>gazebo</build_depend>
   <build_depend>control_toolbox</build_depend> 
   <build_depend>controller_manager</build_depend> 
   <build_depend>pluginlib</build_depend> 

--- a/gazebo_ros_control/package.xml
+++ b/gazebo_ros_control/package.xml
@@ -25,6 +25,7 @@
   <build_depend>transmission_interface</build_depend> 
   <build_depend>joint_limits_interface</build_depend>
   <build_depend>urdf</build_depend>
+  <build_depend>angles</build_depend>
   
   <run_depend>roscpp</run_depend> 
   <run_depend>gazebo_ros</run_depend> 
@@ -33,6 +34,7 @@
   <run_depend>pluginlib</run_depend> 
   <run_depend>transmission_interface</run_depend> 
   <run_depend>urdf</run_depend>
+  <run_depend>angles</run_depend>
 
   <export>
     <gazebo_ros_control plugin="${prefix}/robot_hw_sim_plugins.xml"/>


### PR DESCRIPTION
The first fix is for a regression caused by a889ef8b768861231a67b78781514d834f631b8e. Gazebo is clearly still needed at https://github.com/ros-simulation/gazebo_ros_pkgs/blob/indigo-devel/gazebo_ros_control/CMakeLists.txt#L17 and was available at build time because of `gazebo_ros`.

The second fix adds `angles` as a dependency. I've seen this in other packages in Indigo, so I'm pretty sure an upstream package changed. In any case, it is referenced at https://github.com/ros-simulation/gazebo_ros_pkgs/blob/indigo-devel/gazebo_ros_control/src/default_robot_hw_sim.cpp#L60 and should therefore be a dependency.

This is causing failures on the buildfarm: http://jenkins.ros.org/job/ros-indigo-gazebo-ros-control_binarydeb_saucy_amd64/14/console

Thanks!

--scott
