### PR TITLE
gazebo_ros_control: default_robot_hw_sim: Suppressing pid error message

### DIFF
--- a/gazebo_ros_control/src/default_robot_hw_sim.cpp
+++ b/gazebo_ros_control/src/default_robot_hw_sim.cpp
@@ -217,7 +217,7 @@ public:
         // joint->SetVelocity() to control the joint.
         const ros::NodeHandle nh(model_nh, robot_namespace + "/gazebo_ros_control/pid_gains/" +
                                  joint_names_[j]);
-        if (pid_controllers_[j].init(nh))
+        if (pid_controllers_[j].init(nh,true))
         {
           switch (joint_control_methods_[j])
           {


### PR DESCRIPTION
This depends on ros-controls/control_toolbox#21
