### PR TITLE
Fix repo names in package.xmls (groovy-devel branch)

### DIFF
--- a/gazebo_msgs/package.xml
+++ b/gazebo_msgs/package.xml
@@ -11,8 +11,8 @@
   <license>BSD</license>
 
   <url type="website">http://gazebosim.org/wiki/Tutorials#ROS_Integration</url>
-  <url type="bugtracker">https://github.com/osrf/gazebo_ros_pkgs/issues</url>
-  <url type="repository">https://github.com/osrf/gazebo_ros_pkgs</url>
+  <url type="bugtracker">https://github.com/ros-simulation/gazebo_ros_pkgs/issues</url>
+  <url type="repository">https://github.com/ros-simulation/gazebo_ros_pkgs</url>
 
   <author>John Hsu</author>
 

--- a/gazebo_plugins/package.xml
+++ b/gazebo_plugins/package.xml
@@ -11,8 +11,8 @@
   <license>BSD</license>
 
   <url type="website">http://gazebosim.org/wiki/Tutorials#ROS_Integration</url>
-  <url type="bugtracker">https://github.com/osrf/gazebo_ros_pkgs/issues</url>
-  <url type="repository">https://github.com/osrf/gazebo_ros_pkgs</url>
+  <url type="bugtracker">https://github.com/ros-simulation/gazebo_ros_pkgs/issues</url>
+  <url type="repository">https://github.com/ros-simulation/gazebo_ros_pkgs</url>
 
   <author>John Hsu</author>
 

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -13,8 +13,8 @@
   <license>Apache 2.0</license>
 
   <url type="website">http://gazebosim.org/wiki/Tutorials#ROS_Integration</url>
-  <url type="bugtracker">https://github.com/osrf/gazebo_ros_pkgs/issues</url>
-  <url type="repository">https://github.com/osrf/gazebo_ros_pkgs</url>
+  <url type="bugtracker">https://github.com/ros-simulation/gazebo_ros_pkgs/issues</url>
+  <url type="repository">https://github.com/ros-simulation/gazebo_ros_pkgs</url>
 
   <author>John Hsu</author>
   <author>Nate Koenig</author>

--- a/gazebo_ros_pkgs/package.xml
+++ b/gazebo_ros_pkgs/package.xml
@@ -10,8 +10,8 @@
   <license>BSD,LGPL,Apache 2.0</license>
 
   <url type="website">http://gazebosim.org/wiki/Tutorials#ROS_Integration</url>
-  <url type="bugtracker">https://github.com/osrf/gazebo_ros_pkgs/issues</url>
-  <url type="repository">https://github.com/osrf/gazebo_ros_pkgs</url>
+  <url type="bugtracker">https://github.com/ros-simulation/gazebo_ros_pkgs/issues</url>
+  <url type="repository">https://github.com/ros-simulation/gazebo_ros_pkgs</url>
 
   <author>John Hsu, Nate Koenig, Dave Coleman</author>>
 


### PR DESCRIPTION
Addresses https://github.com/ros-simulation/gazebo_ros_pkgs/issues/200 for the groovy-devel branch
