### PR TITLE
gazebo_plugins: Adding ForceTorqueSensor Plugin

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -83,6 +83,7 @@ catkin_package(
   gazebo_ros_p3d 
   gazebo_ros_imu 
   gazebo_ros_f3d 
+  gazebo_ros_ft_sensor
   gazebo_ros_bumper 
   gazebo_ros_template 
   gazebo_ros_projector 
@@ -223,6 +224,9 @@ set_target_properties(gazebo_ros_hand_of_god PROPERTIES LINK_FLAGS "${ld_flags}"
 set_target_properties(gazebo_ros_hand_of_god PROPERTIES COMPILE_FLAGS "${cxx_flags}")
 target_link_libraries(gazebo_ros_hand_of_god ${GAZEBO_LIBRARIES} ${SDFormat_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
+add_library(gazebo_ros_ft_sensor src/gazebo_ros_ft_sensor.cpp)
+target_link_libraries(gazebo_ros_ft_sensor ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
 ##
 ## Add your new plugin here
 ##
@@ -247,6 +251,7 @@ install(TARGETS
   gazebo_ros_p3d
   gazebo_ros_imu
   gazebo_ros_f3d
+  gazebo_ros_ft_sensor
   gazebo_ros_bumper
   gazebo_ros_hand_of_god
   gazebo_ros_template

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_ft_sensor.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_ft_sensor.h
@@ -1,0 +1,127 @@
+/*
+ *  Copyright (C) 2014
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+/*
+ * Desc: Force Torque Sensor Plugin
+ * Author: Francisco Suarez-Ruiz
+ * Date: 5 June 2014
+ */
+ 
+#ifndef GAZEBO_ROS_FT_HH
+#define GAZEBO_ROS_FT_HH
+
+// Custom Callback Queue
+#include <ros/callback_queue.h>
+#include <ros/advertise_options.h>
+
+#include <gazebo/physics/physics.hh>
+#include <gazebo/transport/TransportTypes.hh>
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/common/Events.hh>
+
+#include <ros/ros.h>
+#include <boost/thread.hpp>
+#include <boost/thread/mutex.hpp>
+#include <geometry_msgs/WrenchStamped.h>
+
+namespace gazebo
+{
+
+/// \brief GazeboRosFT controller
+/// This is a controller that simulates a 6 dof force sensor
+class GazeboRosFT : public ModelPlugin
+{
+  /// \brief Constructor
+  /// \param parent The parent entity must be a Model
+  public: GazeboRosFT();
+
+  /// \brief Destructor
+  public: virtual ~GazeboRosFT();
+
+  /// \brief Load the controller
+  public: void Load( physics::ModelPtr _parent, sdf::ElementPtr _sdf );
+
+  /// \brief Update the controller
+  protected: virtual void UpdateChild();
+
+  /// \brief A pointer to the Gazebo joint
+  private: physics::JointPtr joint_;
+  
+  /// \brief A pointer to the Gazebo parent link
+  private: physics::LinkPtr parent_link_;
+  
+  /// \brief A pointer to the Gazebo child link
+  private: physics::LinkPtr child_link_;
+  
+  /// \brief A pointer to the Gazebo model
+  private: physics::ModelPtr model_;
+  
+  /// \brief A pointer to the Gazebo world
+  private: physics::WorldPtr world_;
+
+  /// \brief A pointer to the ROS node.  A node will be instantiated if it does not exist.
+  private: ros::NodeHandle* rosnode_;
+  private: ros::Publisher pub_;
+
+  /// \brief ROS WrenchStamped message
+  private: geometry_msgs::WrenchStamped wrench_msg_;
+
+  /// \brief store bodyname
+  private: std::string joint_name_;
+
+  /// \brief ROS WrenchStamped topic name
+  private: std::string topic_name_;
+
+  /// \brief ROS frame transform name to use in the image message header.
+  /// FIXME: extract link name directly?
+  private: std::string frame_name_;
+
+  /// \brief for setting ROS name space
+  private: std::string robot_namespace_;
+
+  /// \brief A mutex to lock access to fields that are used in message callbacks
+  private: boost::mutex lock_;
+  
+  /// \brief save last_time
+  private: common::Time last_time_;
+  
+  // rate control
+  private: double update_rate_;
+
+  /// \brief: keep track of number of connections
+  private: int ft_connect_count_;
+  private: void FTConnect();
+  private: void FTDisconnect();
+
+  // Custom Callback Queue
+  private: ros::CallbackQueue queue_;
+  private: void QueueThread();
+  private: boost::thread callback_queue_thread_;
+
+  // Pointer to the update event connection
+  private: event::ConnectionPtr update_connection_;
+
+};
+
+/** \} */
+/// @}
+
+
+}
+
+#endif

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_ft_sensor.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_ft_sensor.h
@@ -1,29 +1,28 @@
 /*
- *  Gazebo - Outdoor Multi-Robot Simulator
- *  Copyright (C) 2003  
- *     Nate Koenig & Andrew Howard
- *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- *
- */
+* Gazebo - Outdoor Multi-Robot Simulator
+* Copyright (C) 2003
+* Nate Koenig & Andrew Howard
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*
+*/
 /*
- * Desc: Force Torque Sensor Plugin
- * Author: Francisco Suarez-Ruiz
- * Date: 5 June 2014
- */
- 
+* Desc: Force Torque Sensor Plugin
+* Author: Francisco Suarez-Ruiz
+* Date: 5 June 2014
+*/
 #ifndef GAZEBO_ROS_FT_HH
 #define GAZEBO_ROS_FT_HH
 
@@ -47,30 +46,28 @@ namespace gazebo
 /// @{
 /** \defgroup GazeboRosFTSensor Plugin XML Reference and Example
 
-  \brief Ros Gazebo Ros Force/Torque Sensor Plugin.
-  
-  This is a model plugin which broadcasts geometry_msgs/WrenchStamped messages
-  with measured force and torque on a specified joint.
-  
-  The wrench is reported in the joint CHILD link frame and the measure direction 
-  is child-to-parent link.
+\brief Ros Gazebo Ros Force/Torque Sensor Plugin.
+This is a model plugin which broadcasts geometry_msgs/WrenchStamped messages
+with measured force and torque on a specified joint.
+The wrench is reported in the joint CHILD link frame and the measure direction
+is child-to-parent link.
 
-  Example Usage:
+Example Usage:
 
-  \verbatim
-      <!-- Enable the Joint Feedback -->
-      <gazebo reference="JOINT_NAME">
-        <provideFeedback>true</provideFeedback>
-      </gazebo>
-      <!-- The ft_sensor plugin -->
-      <gazebo>
-        <plugin name="ft_sensor" filename="libgazebo_ros_ft_sensor.so">
-          <updateRate>100.0</updateRate>
-          <topicName>ft_sensor_topic</topicName>
-          <jointName>JOINT_NAME</jointName>
-        </plugin>
-      </gazebo>
-  \endverbatim
+\verbatim
+<!-- Enable the Joint Feedback -->
+<gazebo reference="JOINT_NAME">
+<provideFeedback>true</provideFeedback>
+</gazebo>
+<!-- The ft_sensor plugin -->
+<gazebo>
+<plugin name="ft_sensor" filename="libgazebo_ros_ft_sensor.so">
+<updateRate>100.0</updateRate>
+<topicName>ft_sensor_topic</topicName>
+<jointName>JOINT_NAME</jointName>
+</plugin>
+</gazebo>
+\endverbatim
 \{
 */
 
@@ -91,6 +88,12 @@ class GazeboRosFT : public ModelPlugin
 
   /// \brief Update the controller
   protected: virtual void UpdateChild();
+  
+  /// \brief Gaussian noise
+  private: double gaussian_noise_;
+  private: unsigned int seed;
+  /// \brief Gaussian noise generator
+  private: double GaussianKernel(double mu, double sigma);
 
   /// \brief A pointer to the Gazebo joint
   private: physics::JointPtr joint_;
@@ -107,7 +110,7 @@ class GazeboRosFT : public ModelPlugin
   /// \brief A pointer to the Gazebo world
   private: physics::WorldPtr world_;
 
-  /// \brief A pointer to the ROS node.  A node will be instantiated if it does not exist.
+  /// \brief A pointer to the ROS node. A node will be instantiated if it does not exist.
   private: ros::NodeHandle* rosnode_;
   private: ros::Publisher pub_;
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_ft_sensor.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_ft_sensor.h
@@ -1,28 +1,25 @@
 /*
-* Gazebo - Outdoor Multi-Robot Simulator
-* Copyright (C) 2003
-* Nate Koenig & Andrew Howard
-*
-* This program is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation; either version 2 of the License, or
-* (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program; if not, write to the Free Software
-* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-*
+ * Copyright (C) 2012-2014 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
 */
 /*
-* Desc: Force Torque Sensor Plugin
-* Author: Francisco Suarez-Ruiz
-* Date: 5 June 2014
-*/
+ * Desc: Force Torque Sensor Plugin
+ * Author: Francisco Suarez-Ruiz
+ * Date: 5 June 2014
+ */
+
 #ifndef GAZEBO_ROS_FT_HH
 #define GAZEBO_ROS_FT_HH
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_ft_sensor.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_ft_sensor.h
@@ -1,5 +1,7 @@
 /*
- *  Copyright (C) 2014
+ *  Gazebo - Outdoor Multi-Robot Simulator
+ *  Copyright (C) 2003  
+ *     Nate Koenig & Andrew Howard
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -41,6 +43,37 @@
 
 namespace gazebo
 {
+/// @addtogroup gazebo_dynamic_plugins Gazebo ROS Dynamic Plugins
+/// @{
+/** \defgroup GazeboRosFTSensor Plugin XML Reference and Example
+
+  \brief Ros Gazebo Ros Force/Torque Sensor Plugin.
+  
+  This is a model plugin which broadcasts geometry_msgs/WrenchStamped messages
+  with measured force and torque on a specified joint.
+  
+  The wrench is reported in the joint CHILD link frame and the measure direction 
+  is child-to-parent link.
+
+  Example Usage:
+
+  \verbatim
+      <!-- Enable the Joint Feedback -->
+      <gazebo reference="JOINT_NAME">
+        <provideFeedback>true</provideFeedback>
+      </gazebo>
+      <!-- The ft_sensor plugin -->
+      <gazebo>
+        <plugin name="ft_sensor" filename="libgazebo_ros_ft_sensor.so">
+          <updateRate>100.0</updateRate>
+          <topicName>ft_sensor_topic</topicName>
+          <jointName>JOINT_NAME</jointName>
+        </plugin>
+      </gazebo>
+  \endverbatim
+\{
+*/
+
 
 /// \brief GazeboRosFT controller
 /// This is a controller that simulates a 6 dof force sensor

--- a/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
@@ -1,28 +1,24 @@
 /*
-* Gazebo - Outdoor Multi-Robot Simulator
-* Copyright (C) 2003
-* Nate Koenig & Andrew Howard
-*
-* This program is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation; either version 2 of the License, or
-* (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program; if not, write to the Free Software
-* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-*
+ * Copyright (C) 2012-2014 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
 */
 /*
-* Desc: Force Torque Sensor Plugin
-* Author: Francisco Suarez-Ruiz
-* Date: 5 June 2014
-*/
+ * Desc: Force Torque Sensor Plugin
+ * Author: Francisco Suarez-Ruiz
+ * Date: 5 June 2014
+ */
 
 #include <gazebo_plugins/gazebo_ros_ft_sensor.h>
 #include <tf/tf.h>

--- a/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
@@ -1,0 +1,210 @@
+/*
+ *  Copyright (C) 2014
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+/*
+ * Desc: Force Torque Sensor Plugin
+ * Author: Francisco Suarez-Ruiz
+ * Date: 5 June 2014
+ */
+
+#include <gazebo_plugins/gazebo_ros_ft_sensor.h>
+#include <tf/tf.h>
+
+namespace gazebo
+{
+GZ_REGISTER_MODEL_PLUGIN(GazeboRosFT);
+
+////////////////////////////////////////////////////////////////////////////////
+// Constructor
+GazeboRosFT::GazeboRosFT()
+{
+  this->ft_connect_count_ = 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Destructor
+GazeboRosFT::~GazeboRosFT()
+{
+  event::Events::DisconnectWorldUpdateBegin(this->update_connection_);
+  // Custom Callback Queue
+  this->queue_.clear();
+  this->queue_.disable();
+  this->rosnode_->shutdown();
+  this->callback_queue_thread_.join();
+  delete this->rosnode_;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Load the controller
+void GazeboRosFT::Load( physics::ModelPtr _model, sdf::ElementPtr _sdf )
+{
+  // Save pointers
+  this->model_ = _model;
+  this->world_ = this->model_->GetWorld();
+  
+  // load parameters
+  this->robot_namespace_ = "";
+  if (_sdf->HasElement("robotNamespace"))
+    this->robot_namespace_ = _sdf->GetElement("robotNamespace")->Get<std::string>() + "/";
+
+  if (!_sdf->HasElement("jointName"))
+  {
+    ROS_FATAL("ft_sensor plugin missing <jointName>, cannot proceed");
+    return;
+  }
+  else
+    this->joint_name_ = _sdf->GetElement("jointName")->Get<std::string>();
+
+  this->joint_ = this->model_->GetJoint(this->joint_name_);
+  if (!this->joint_)
+  {
+    ROS_FATAL("gazebo_ros_ft_sensor plugin error: jointName: %s does not exist\n",this->joint_name_.c_str());
+    return;
+  }
+  
+  this->parent_link_ = this->joint_->GetParent();
+  this->child_link_ = this->joint_->GetChild();
+  this->frame_name_ = this->child_link_->GetName();
+  
+  ROS_INFO("ft_sensor plugin reporting wrench values to the frame [%s]", this->frame_name_.c_str());
+
+  if (!_sdf->HasElement("topicName"))
+  {
+    ROS_FATAL("ft_sensor plugin missing <topicName>, cannot proceed");
+    return;
+  }
+  else
+    this->topic_name_ = _sdf->GetElement("topicName")->Get<std::string>();
+  
+  if (!_sdf->HasElement("updateRate"))
+  {
+    ROS_DEBUG("ft_sensor plugin missing <updateRate>, defaults to 0.0"
+             " (as fast as possible)");
+    this->update_rate_ = 0;
+  }
+  else
+    this->update_rate_ = _sdf->GetElement("updateRate")->Get<double>();
+
+  // Make sure the ROS node for Gazebo has already been initialized
+  if (!ros::isInitialized())
+  {
+    ROS_FATAL_STREAM("A ROS node for Gazebo has not been initialized, unable to load plugin. "
+      << "Load the Gazebo system plugin 'libgazebo_ros_api_plugin.so' in the gazebo_ros package)");
+    return;
+  }
+
+  this->rosnode_ = new ros::NodeHandle(this->robot_namespace_);
+  
+  // resolve tf prefix
+  std::string prefix;
+  this->rosnode_->getParam(std::string("tf_prefix"), prefix);
+  this->frame_name_ = tf::resolve(prefix, this->frame_name_);
+
+  // Custom Callback Queue
+  ros::AdvertiseOptions ao = ros::AdvertiseOptions::create<geometry_msgs::WrenchStamped>(
+    this->topic_name_,1,
+    boost::bind( &GazeboRosFT::FTConnect,this),
+    boost::bind( &GazeboRosFT::FTDisconnect,this), ros::VoidPtr(), &this->queue_);
+  this->pub_ = this->rosnode_->advertise(ao);
+  
+  // Custom Callback Queue
+  this->callback_queue_thread_ = boost::thread( boost::bind( &GazeboRosFT::QueueThread,this ) );
+  
+  // New Mechanism for Updating every World Cycle
+  // Listen to the update event. This event is broadcast every
+  // simulation iteration.
+  this->update_connection_ = event::Events::ConnectWorldUpdateBegin(
+      boost::bind(&GazeboRosFT::UpdateChild, this));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Someone subscribes to me
+void GazeboRosFT::FTConnect()
+{
+  this->ft_connect_count_++;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Someone subscribes to me
+void GazeboRosFT::FTDisconnect()
+{
+  this->ft_connect_count_--;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Update the controller
+void GazeboRosFT::UpdateChild()
+{
+  common::Time cur_time = this->world_->GetSimTime();
+
+  // rate control
+  if (this->update_rate_ > 0 &&
+      (cur_time-this->last_time_).Double() < (1.0/this->update_rate_))
+    return;
+    
+  if (this->ft_connect_count_ == 0)
+    return;
+
+  physics::JointWrench wrench;
+  math::Vector3 torque;
+  math::Vector3 force;
+
+  // FIXME: Should include options for diferent frames and measure directions
+  // E.g: https://bitbucket.org/osrf/gazebo/raw/default/gazebo/sensors/ForceTorqueSensor.hh
+  // Get force torque at the joint
+  // The wrench is reported in the CHILD <frame>
+  // The <measure_direction> is child_to_parent
+  wrench = this->joint_->GetForceTorque(0);
+  force = wrench.body2Force;
+  torque = wrench.body2Torque;
+
+
+  this->lock_.lock();
+  // copy data into wrench message
+  this->wrench_msg_.header.frame_id = this->frame_name_;
+  this->wrench_msg_.header.stamp.sec = (this->world_->GetSimTime()).sec;
+  this->wrench_msg_.header.stamp.nsec = (this->world_->GetSimTime()).nsec;
+
+  this->wrench_msg_.wrench.force.x    = force.x;
+  this->wrench_msg_.wrench.force.y    = force.y;
+  this->wrench_msg_.wrench.force.z    = force.z;
+  this->wrench_msg_.wrench.torque.x   = torque.x;
+  this->wrench_msg_.wrench.torque.y   = torque.y;
+  this->wrench_msg_.wrench.torque.z   = torque.z;
+
+  this->pub_.publish(this->wrench_msg_);
+  this->lock_.unlock();
+  
+  // save last time stamp
+  this->last_time_ = cur_time;
+}
+
+// Custom Callback Queue
+////////////////////////////////////////////////////////////////////////////////
+// custom callback queue thread
+void GazeboRosFT::QueueThread()
+{
+  static const double timeout = 0.01;
+
+  while (this->rosnode_->ok())
+  {
+    this->queue_.callAvailable(ros::WallDuration(timeout));
+  }
+}
+
+}

--- a/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
@@ -170,10 +170,10 @@ void GazeboRosFT::UpdateChild()
   // E.g: https://bitbucket.org/osrf/gazebo/raw/default/gazebo/sensors/ForceTorqueSensor.hh
   // Get force torque at the joint
   // The wrench is reported in the CHILD <frame>
-  // The <measure_direction> is child_to_parent
+  // The <measure_direction> is parent_to_child
   wrench = this->joint_->GetForceTorque(0);
-  force = wrench.body2Force;
-  torque = wrench.body2Torque;
+  force = -wrench.body2Force;
+  torque = -wrench.body2Torque;
 
 
   this->lock_.lock();

--- a/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
@@ -1,5 +1,7 @@
 /*
- *  Copyright (C) 2014
+ *  Gazebo - Outdoor Multi-Robot Simulator
+ *  Copyright (C) 2003  
+ *     Nate Koenig & Andrew Howard
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This gazebo plugin broadcasts `geometry_msgs/WrenchStamped` messages with measured force and torque on a specified joint. It publishes at a given rate.
The wrench is reported in the joint child-link frame and the measure direction is child-to-parent link.

Example usage:

``` xml
<!-- Enable the Joint Feedback -->
<gazebo reference="JOINT_NAME">
  <provideFeedback>true</provideFeedback>
</gazebo>
<!-- The ft_sensor plugin -->
<gazebo>
  <plugin name="ft_sensor" filename="libgazebo_ros_ft_sensor.so">
    <updateRate>100.0</updateRate>
    <topicName>ft_sensor_topic</topicName>
    <jointName>JOINT_NAME</jointName>
  </plugin>
</gazebo>
```
