### PR TITLE
Made POSIX compatible to work with dash

### DIFF
--- a/gazebo_ros/scripts/debug
+++ b/gazebo_ros/scripts/debug
@@ -2,7 +2,7 @@
 final="$@"
 
 EXT=so
-if [ $(uname) == "Darwin" ]; then
+if [ $(uname) = "Darwin" ]; then
     EXT=dylib
 fi
 

--- a/gazebo_ros/scripts/gzclient
+++ b/gazebo_ros/scripts/gzclient
@@ -2,7 +2,7 @@
 final="$@"
 
 EXT=so
-if [ $(uname) == "Darwin" ]; then
+if [ $(uname) = "Darwin" ]; then
     EXT=dylib
 fi
 

--- a/gazebo_ros/scripts/gzserver
+++ b/gazebo_ros/scripts/gzserver
@@ -2,7 +2,7 @@
 final="$@"
 
 EXT=so
-if [ $(uname) == "Darwin" ]; then
+if [ $(uname) = "Darwin" ]; then
     EXT=dylib
 fi
 

--- a/gazebo_ros/scripts/perf
+++ b/gazebo_ros/scripts/perf
@@ -2,7 +2,7 @@
 final="$@"
 
 EXT=so
-if [ $(uname) == "Darwin" ]; then
+if [ $(uname) = "Darwin" ]; then
     EXT=dylib
 fi
 


### PR DESCRIPTION
I noticed these errors when running Gazebo:

process[gazebo-2]: started with pid [12052]
/home/isura/catkin_ws/src/gazebo_ros_pkgs/gazebo_ros/scripts/gzserver: 5: [: Linux: unexpected operator
process[gazebo_gui-3]: started with pid [12061]
/home/isura/catkin_ws/src/gazebo_ros_pkgs/gazebo_ros/scripts/gzclient: 5: [: Linux: unexpected operator

It turns out that /bin/sh used to be a symlink to bash which is okay with "==" for string compare. In later versions of Debian/Ubuntu /bin/sh points to a lighter alternative to bash called dash. Dash is more strict in its POSIX compliance and thus will not accept "==" for string compare.

See references:
http://askubuntu.com/questions/141928/what-is-difference-between-bin-sh-and-bin-bash
http://stackoverflow.com/questions/1089813/bash-dash-and-string-comparison
