### PR TITLE
Should fix build error for binary releases.

### DIFF
--- a/gazebo_ros_control/package.xml
+++ b/gazebo_ros_control/package.xml
@@ -26,7 +26,8 @@
   <build_depend>urdf</build_depend>
   <build_depend>angles</build_depend>
   
-  <run_depend>roscpp</run_depend> 
+  <run_depend>roscpp</run_depend>
+  <run_depend>gazebo</run_depend>
   <run_depend>gazebo_ros</run_depend> 
   <run_depend>control_toolbox</run_depend> 
   <run_depend>controller_manager</run_depend> 


### PR DESCRIPTION
See: http://www.ros.org/debbuild/indigo.html?q=gazebo_ros_control
