### PR TITLE
fix compiler warning

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
@@ -107,7 +107,7 @@ void GazeboRosDiffDrive::Load ( physics::ModelPtr _parent, sdf::ElementPtr _sdf 
 
     this->publish_tf_ = true;
     if (!_sdf->HasElement("publishTf")) {
-      ROS_WARN("GazeboRosDiffDrive Plugin (ns = %s) missing <publishTf>, defaults to %f",
+      ROS_WARN("GazeboRosDiffDrive Plugin (ns = %s) missing <publishTf>, defaults to %d",
           this->robot_namespace_.c_str(), this->publish_tf_);
     } else {
       this->publish_tf_ = _sdf->GetElement("publishTf")->Get<bool>();


### PR DESCRIPTION
fixes compiler warnings:

```
In file included from /opt/ros/indigo/include/ros/ros.h:40:0,
                 from
/home/caguero/catkin_haptix/src/gazebo_ros_pkgs/gazebo_plugins/include/gazebo_plugins/gazebo_ros_utils.h:42,
                 from
/home/caguero/catkin_haptix/src/gazebo_ros_pkgs/gazebo_plugins/include/gazebo_plugins/gazebo_ros_diff_drive.h:49,
                 from
/home/caguero/catkin_haptix/src/gazebo_ros_pkgs/gazebo_plugins/src/gazebo_ros_diff_drive.cpp:53:
/home/caguero/catkin_haptix/src/gazebo_ros_pkgs/gazebo_plugins/src/gazebo_ros_diff_drive.cpp:
In member function ‘virtual void
gazebo::GazeboRosDiffDrive::Load(gazebo::physics::ModelPtr,
sdf::ElementPtr)’:
/opt/ros/indigo/include/ros/console.h:342:176: warning: format ‘%f’
expects argument of type ‘double’, but argument 9 has type ‘int’
[-Wformat=]
     ::ros::console::print(filter,
__rosconsole_define_location__loc.logger_,
__rosconsole_define_location__loc.level_, __FILE__, __LINE__,
__ROSCONSOLE_FUNCTION__, __VA_ARGS__)


                                  ^
/opt/ros/indigo/include/ros/console.h:345:5: note: in expansion of
macro ‘ROSCONSOLE_PRINT_AT_LOCATION_WITH_FILTER’
     ROSCONSOLE_PRINT_AT_LOCATION_WITH_FILTER(0, __VA_ARGS__)
     ^
/opt/ros/indigo/include/ros/console.h:375:7: note: in expansion of
macro ‘ROSCONSOLE_PRINT_AT_LOCATION’
       ROSCONSOLE_PRINT_AT_LOCATION(__VA_ARGS__); \
       ^
/opt/ros/indigo/include/ros/console.h:516:35: note: in expansion of
macro ‘ROS_LOG_COND’
 #define ROS_LOG(level, name, ...) ROS_LOG_COND(true, level, name, __VA_ARGS__)
                                   ^
/opt/ros/indigo/include/rosconsole/macros_generated.h:142:23: note: in
expansion of macro ‘ROS_LOG’
 #define ROS_WARN(...) ROS_LOG(::ros::console::levels::Warn,
ROSCONSOLE_DEFAULT_NAME, __VA_ARGS__)
                       ^
/home/caguero/catkin_haptix/src/gazebo_ros_pkgs/gazebo_plugins/src/gazebo_ros_diff_drive.cpp:110:7:
note: in expansion of macro ‘ROS_WARN’
       ROS_WARN("GazeboRosDiffDrive Plugin (ns = %s) missing
<publishTf>, defaults to %f",
```
