### PR TITLE
Specify physics engine in args to empty_world.launch

### DIFF
--- a/gazebo_ros/launch/empty_world.launch
+++ b/gazebo_ros/launch/empty_world.launch
@@ -3,9 +3,11 @@
   <!-- these are the arguments you can pass this launch file, for example paused:=true -->
   <arg name="paused" default="false"/>
   <arg name="use_sim_time" default="true"/>
+  <arg name="extra_gazebo_args" default=""/>
   <arg name="gui" default="true"/>
   <arg name="headless" default="false"/>
   <arg name="debug" default="false"/>
+  <arg name="physics" default="ode"/>
   <arg name="verbose" default="false"/>
   <arg name="world_name" default="worlds/empty.world"/> <!-- Note: the world_name is with respect to GAZEBO_RESOURCE_PATH environmental variable -->
 
@@ -26,7 +28,7 @@
 
   <!-- start gazebo server-->
   <node name="gazebo" pkg="gazebo_ros" type="$(arg script_type)" respawn="false" output="screen"
-	args="$(arg command_arg1) $(arg command_arg2) $(arg command_arg3) $(arg world_name)" />
+	args="$(arg command_arg1) $(arg command_arg2) $(arg command_arg3) -e $(arg physics) $(arg extra_gazebo_args) $(arg world_name)" />
 	
   <!-- start gazebo client -->
   <group if="$(arg gui)">


### PR DESCRIPTION
As of gazebo3, there is support for multiple physics engines in gazebo using the `-e` parameter. This pull request exposes that parameter to the empty_world launch file. The following should load the empty world in bullet:

```
roslaunch gazebo_ros empty_world.launch physics:=bullet verbose:=true
```
