### PR TITLE
gazebo_ros_control: add urdf to downstream catkin deps

### DIFF
--- a/gazebo_ros_control/CMakeLists.txt
+++ b/gazebo_ros_control/CMakeLists.txt
@@ -23,6 +23,7 @@ catkin_package(
     controller_manager
     pluginlib
     transmission_interface
+    urdf
   INCLUDE_DIRS include
   DEPENDS gazebo
 )


### PR DESCRIPTION
The urdf headers are referenced in deployed header files (for instance, at [1]). On Fedora (and possibly other distros), the urdf headers are placed in a subdirectory of `/usr/include` and therefore have an include directory which must be added to the project for the code to build.

While `gazebo_ros_control` references this correctly for itself to build, it does not get passed to downstream packages which may consume the aforementioned headers.

Example build failure: http://csc.mcs.sdsmt.edu/jenkins/job/ros-indigo-hector-quadrotor-controller-gazebo_binaryrpm_heisenbug_x86_64/4/console

Thanks,

--scott

PS: The ROSCon talk on ROS control that was given today was very helpful in understanding the toolchain :)

[1] https://github.com/ros-simulation/gazebo_ros_pkgs/blob/hydro-devel/gazebo_ros_control/include/gazebo_ros_control/robot_hw_sim.h#L49
