### PR TITLE
[gazebo_ros_control] support hwinterface switching

### DIFF
--- a/gazebo_ros_control/include/gazebo_ros_control/gazebo_ros_control_plugin.h
+++ b/gazebo_ros_control/include/gazebo_ros_control/gazebo_ros_control_plugin.h
@@ -62,10 +62,6 @@
 
 
 
-
-
-
-
 namespace gazebo_ros_control
 {
 
@@ -81,13 +77,12 @@ public:
                           const ros::NodeHandle& nh=ros::NodeHandle())
                         : controller_manager::ControllerManager(robot_hw, nh), robot_hw_sim_(robot_hw) {}
   
-  bool readyForSwitch(const std::list<hardware_interface::ControllerInfo> &info_list) 
+  bool notifyHardwareInterface(const std::list<hardware_interface::ControllerInfo> &info_list) 
   {
-    ROS_WARN("Need to switch HW-Interface");
-    for (std::list<hardware_interface::ControllerInfo>::const_iterator it=info_list.begin(); it != info_list.end(); ++it)
-    {
-      ROS_INFO_STREAM("Name: " << it->name << ", Type: " << it->type << ", Hardware-Interface: " << it->hardware_interface);
-    }
+    //for (std::list<hardware_interface::ControllerInfo>::const_iterator it=info_list.begin(); it != info_list.end(); ++it)
+    //{
+      //ROS_DEBUG_STREAM("Name: " << it->name << ", Type: " << it->type << ", Hardware-Interface: " << it->hardware_interface);
+    //}
     
     //canSwitchHWInterface
     for (std::list<hardware_interface::ControllerInfo>::const_iterator list_it=info_list.begin(); list_it != info_list.end(); ++list_it)
@@ -109,7 +104,7 @@ public:
       }
     }
     
-    ROS_INFO("Done switching HW-Interface! Ready to switch Controllers!");
+    ROS_DEBUG("Done switching HW-Interface! Ready to switch Controllers!");
     return true;
   }
 };

--- a/gazebo_ros_control/include/gazebo_ros_control/robot_hw_sim.h
+++ b/gazebo_ros_control/include/gazebo_ros_control/robot_hw_sim.h
@@ -79,6 +79,9 @@ namespace gazebo_ros_control {
     virtual void readSim(ros::Time time, ros::Duration period) = 0;
 
     virtual void writeSim(ros::Time time, ros::Duration period) = 0;
+    
+    virtual bool canSwitchHWInterface(const std::string &joint_name, const std::string &hwinterface_name) { return true; }
+    virtual bool doSwitchHWInterface(const std::string &joint_name, const std::string &hwinterface_name) { return true; }
 
   };
 

--- a/gazebo_ros_control/src/default_robot_hw_sim.cpp
+++ b/gazebo_ros_control/src/default_robot_hw_sim.cpp
@@ -103,14 +103,23 @@ public:
     joint_upper_limits_.resize(n_dof_);
     joint_effort_limits_.resize(n_dof_);
     joint_control_methods_.resize(n_dof_);
-    hw_interfaces_available_.clear();
     pid_controllers_.resize(n_dof_);
+    map_hwinterface_to_joints_.clear();
+    map_hwinterface_to_controlmethod_.clear();
+    map_controlmethod_to_pidcontrollers_.clear();
     joint_position_.resize(n_dof_);
     joint_velocity_.resize(n_dof_);
     joint_effort_.resize(n_dof_);
     joint_effort_command_.resize(n_dof_);
     joint_position_command_.resize(n_dof_);
     joint_velocity_command_.resize(n_dof_);
+    
+    std::vector<control_toolbox::Pid> pid_controllers_pos;
+    pid_controllers_pos.resize(n_dof_);
+    map_controlmethod_to_pidcontrollers_.insert( std::pair< ControlMethod, std::vector<control_toolbox::Pid> >(POSITION_PID, pid_controllers_pos) );
+    std::vector<control_toolbox::Pid> pid_controllers_vel;
+    pid_controllers_vel.resize(n_dof_);
+    map_controlmethod_to_pidcontrollers_.insert( std::pair< ControlMethod, std::vector<control_toolbox::Pid> >(VELOCITY_PID, pid_controllers_vel) );
 
     // Initialize values
     for(unsigned int j=0; j < n_dof_; j++)
@@ -153,7 +162,7 @@ public:
       {
         ROS_INFO_STREAM_NAMED("default_robot_hw_sim", "Joint " << transmissions[j].joints_[0].name_ <<
           " of transmission " << transmissions[j].name_ << " specifies multiple hardware interfaces. " <<
-          "This feature is now being added.");
+          "This feature is now available.");
         //ROS_WARN_STREAM_NAMED("default_robot_hw_sim", "Joint " << transmissions[j].joints_[0].name_ <<
           //" of transmission " << transmissions[j].name_ << " specifies multiple hardware interfaces. " <<
           //"Currently the default robot hardware simulation interface only supports one.");
@@ -177,7 +186,9 @@ public:
       // Decide what kind of command interface this actuator/joint has
       hardware_interface::JointHandle joint_handle;
       
-      //const std::string& hardware_interface = joint_interfaces.front();
+      ////const std::string& hardware_interface = joint_interfaces.front();
+      
+      // Parse all HW-Interfaces available for each joint and store information
       for(unsigned int i=0; i<joint_interfaces.size(); i++)
       {
         // Debug
@@ -185,28 +196,30 @@ public:
           << "' of type '" << joint_interfaces[i] << "'");
         
         
-        //add hardware interface and joint to map of hw_interfaces_available_
+        
+        // Add hardware interface and joint to map of map_hwinterface_to_joints_
+        // ToDo: hardcoded namespace 'hardware_interface'?
         std::string hw_interface_type = "hardware_interface::"+joint_interfaces[i];
-        if(hw_interfaces_available_.find(hw_interface_type)!=hw_interfaces_available_.end())
+        if(map_hwinterface_to_joints_.find(hw_interface_type)!=map_hwinterface_to_joints_.end())
         {
-          ROS_INFO_STREAM("Hardware-Interface " << hw_interface_type << " already available. Adding joint " << joint_names_[j] << " to list.");
+          ROS_DEBUG_STREAM_NAMED("default_robot_hw_sim", "HW-Interface " << hw_interface_type << " already registered. Adding joint " << joint_names_[j] << " to list.");
           std::map< std::string, std::set<std::string> >::iterator it;
-          it=hw_interfaces_available_.find(hw_interface_type);
+          it=map_hwinterface_to_joints_.find(hw_interface_type);
           it->second.insert(joint_names_[j]);
         }
         else
         {
-          ROS_INFO_STREAM("Adding Hardware-Interface " << hw_interface_type << ". Adding joint " << joint_names_[j] << " to list.");
+          ROS_INFO_STREAM_NAMED("default_robot_hw_sim", "New HW-Interface registered " << hw_interface_type << ". Adding joint " << joint_names_[j] << " to list.");
           std::set<std::string> supporting_joints;
           supporting_joints.insert(joint_names_[j]);
-          hw_interfaces_available_.insert( std::pair< std::string, std::set<std::string> >(hw_interface_type, supporting_joints) );
+          map_hwinterface_to_joints_.insert( std::pair< std::string, std::set<std::string> >(hw_interface_type, supporting_joints) );
         }
         
         if(joint_interfaces[i] == "EffortJointInterface")
         {
           // Create effort joint interface
           if(i==0){ joint_control_methods_[j] = EFFORT; } //use first entry for startup
-          map_control_method_to_hw_interface_.insert( std::pair<std::string, ControlMethod>(hw_interface_type,EFFORT) );
+          map_hwinterface_to_controlmethod_.insert( std::pair<std::string, ControlMethod>(hw_interface_type, EFFORT) );
           
           joint_handle = hardware_interface::JointHandle(js_interface_.getHandle(joint_names_[j]),
                                                         &joint_effort_command_[j]);
@@ -219,30 +232,56 @@ public:
         }
         else if(joint_interfaces[i] == "PositionJointInterface")
         {
+          ControlMethod control_method = POSITION;
+          control_toolbox::Pid pid_controller;
+          
+          // Initialize the PID controller. If no PID gain values are found, use joint->SetAngle() or
+          // joint->SetVelocity() to control the joint.
+          const ros::NodeHandle nh(model_nh, robot_namespace + "/gazebo_ros_control/pid_gains/position/" +
+                                   joint_names_[j]);
+          if (pid_controller.init(nh, true))
+          {
+            control_method = POSITION_PID;
+            map_controlmethod_to_pidcontrollers_.find(control_method)->second[j]=pid_controller;
+          }
+          
           // Create position joint interface
-          if(i==0){ joint_control_methods_[j] = POSITION; } //use first entry for startup
-          map_control_method_to_hw_interface_.insert( std::pair<std::string, ControlMethod>(hw_interface_type,POSITION) );
+          if(i==0){ joint_control_methods_[j] = control_method; } //use first entry for startup
+          map_hwinterface_to_controlmethod_.insert( std::pair<std::string, ControlMethod>(hw_interface_type, control_method) );
           
           joint_handle = hardware_interface::JointHandle(js_interface_.getHandle(joint_names_[j]),
                                                         &joint_position_command_[j]);
           pj_interface_.registerHandle(joint_handle);
           
-          registerJointLimits(joint_names_[j], joint_handle, POSITION,
+          registerJointLimits(joint_names_[j], joint_handle, control_method,
                           joint_limit_nh, urdf_model,
                           &joint_types_[j], &joint_lower_limits_[j], &joint_upper_limits_[j],
                           &joint_effort_limits_[j]);
         }
         else if(joint_interfaces[i] == "VelocityJointInterface")
         {
+          ControlMethod control_method = VELOCITY;
+          control_toolbox::Pid pid_controller;
+          
+          // Initialize the PID controller. If no PID gain values are found, use joint->SetAngle() or
+          // joint->SetVelocity() to control the joint.
+          const ros::NodeHandle nh(model_nh, robot_namespace + "/gazebo_ros_control/pid_gains/velocity/" +
+                                   joint_names_[j]);
+          if (pid_controller.init(nh, true))
+          {
+            control_method = VELOCITY_PID;
+            map_controlmethod_to_pidcontrollers_.find(control_method)->second[j]=pid_controller;
+          }
+          
           // Create velocity joint interface
-          if(i==0){ joint_control_methods_[j] = VELOCITY; } //use first entry for startup
-          map_control_method_to_hw_interface_.insert( std::pair<std::string, ControlMethod>(hw_interface_type,VELOCITY) );
+          if(i==0){ joint_control_methods_[j] = control_method; } //use first entry for startup
+          map_hwinterface_to_controlmethod_.insert( std::pair<std::string, ControlMethod>(hw_interface_type, control_method) );
           
           joint_handle = hardware_interface::JointHandle(js_interface_.getHandle(joint_names_[j]),
                                                         &joint_velocity_command_[j]);
           vj_interface_.registerHandle(joint_handle);
           
-          registerJointLimits(joint_names_[j], joint_handle, VELOCITY,
+          registerJointLimits(joint_names_[j], joint_handle, control_method,
                           joint_limit_nh, urdf_model,
                           &joint_types_[j], &joint_lower_limits_[j], &joint_upper_limits_[j],
                           &joint_effort_limits_[j]);
@@ -261,42 +300,20 @@ public:
       gazebo::physics::JointPtr joint = parent_model->GetJoint(joint_names_[j]);
       if (!joint)
       {
-        ROS_ERROR_STREAM("This robot has a joint named \"" << joint_names_[j]
+        ROS_ERROR_STREAM_NAMED("default_robot_hw_sim", "This robot has a joint named \"" << joint_names_[j]
           << "\" which is not in the gazebo model.");
         return false;
       }
       sim_joints_.push_back(joint);
-            
-      //ToDo: Can a joint (gazebo::physics::JointPtr) be used for EFFORT if joint->SetMaxForce has been called before?
-      //ToDo: How to handle pid_gains if both POSITION and VELOCITY joint_control_methods_ are registered?
-      if (joint_control_methods_[j] != EFFORT)
+      
+      
+      // ToDo: Can a joint (gazebo::physics::JointPtr) be used for EFFORT if joint->SetMaxForce has been called before?
+      if (joint_control_methods_[j] == VELOCITY || joint_control_methods_[j] == POSITION)
       {
-        // Initialize the PID controller. If no PID gain values are found, use joint->SetAngle() or
-        // joint->SetVelocity() to control the joint.
-        const ros::NodeHandle nh(model_nh, robot_namespace + "/gazebo_ros_control/pid_gains/" +
-                                 joint_names_[j]);
-        if (pid_controllers_[j].init(nh, true))
-        {
-          //switch (joint_control_methods_[j])
-          //{
-            //case POSITION:
-              //joint_control_methods_[j] = POSITION_PID;
-              //break;
-            //case VELOCITY:
-              //joint_control_methods_[j] = VELOCITY_PID;
-              //break;
-          //}
-          
-          ROS_WARN("POSITION_PID and VELOCITY_PID currently not supported!");
-          joint->SetMaxForce(0, joint_effort_limits_[j]);
-        }
-        else
-        {
-          // joint->SetMaxForce() must be called if joint->SetAngle() or joint->SetVelocity() are
-          // going to be called. joint->SetMaxForce() must *not* be called if joint->SetForce() is
-          // going to be called.
-          joint->SetMaxForce(0, joint_effort_limits_[j]);
-        }
+        // joint->SetMaxForce() must be called if joint->SetAngle() or joint->SetVelocity() are
+        // going to be called. joint->SetMaxForce() must *not* be called if joint->SetForce() is
+        // going to be called.
+        joint->SetMaxForce(0, joint_effort_limits_[j]);
       }
     }
 
@@ -398,27 +415,35 @@ public:
     }
   }
   
-  
-  bool canSwitchHWInterface(std::string joint_name, std::string hw_interface_type)
+  bool canSwitchHWInterface(const std::string &joint_name, const std::string &hwinterface_name)
   {
-    std::map< std::string, std::set<std::string> >::iterator it = hw_interfaces_available_.find(hw_interface_type);
+    ROS_INFO_STREAM_NAMED("canSwitchHWInterface", "Joint " << joint_name << " requests HW-Interface of type " << hwinterface_name);
+    std::map< std::string, std::set<std::string> >::iterator it = map_hwinterface_to_joints_.find(hwinterface_name);
     if(it->second.find(joint_name)!=it->second.end()) { return true; }
+    
+    ROS_ERROR_STREAM_NAMED("default_robot_hw_sim", "Joint " << joint_name << " does not provide a HW-Interface of type " << hwinterface_name);
     return false;
   }
   
-  bool doSwitchHWInterface(std::string joint_name, std::string hw_interface_type)
+  bool doSwitchHWInterface(const std::string &joint_name, const std::string &hwinterface_name)
   {
+    ROS_INFO_STREAM_NAMED("doSwitchHWInterface", "Joint " << joint_name << " requests HW-Interface of type " << hwinterface_name);
     for(unsigned int i=0; i<joint_names_.size(); i++)
     {
       if(joint_names_[i] == joint_name)
       {
-        if(map_control_method_to_hw_interface_.find(hw_interface_type)!=map_control_method_to_hw_interface_.end())
+        if(map_hwinterface_to_controlmethod_.find(hwinterface_name)!=map_hwinterface_to_controlmethod_.end())
         {
-          joint_control_methods_[i] = map_control_method_to_hw_interface_.find(hw_interface_type)->second;
+          ControlMethod current_control_method = map_hwinterface_to_controlmethod_.find(hwinterface_name)->second;
+          joint_control_methods_[i] = current_control_method;
+          pid_controllers_ = map_controlmethod_to_pidcontrollers_.find(current_control_method)->second;
+          ROS_INFO_STREAM_NAMED("default_robot_hw_sim", "Joint " << joint_name << " now uses HW-Interface type: " << hwinterface_name);
           return true;
         }
       }
     }
+    
+    ROS_ERROR_STREAM_NAMED("default_robot_hw_sim", "An error occured while trying to switch HW-Interface for Joint " << joint_name << " (HW-Interface type: " << hwinterface_name << ")");
     return false;
   }
   
@@ -570,8 +595,9 @@ private:
   std::vector<double> joint_upper_limits_;
   std::vector<double> joint_effort_limits_;
   std::vector<ControlMethod> joint_control_methods_;
-  std::map< std::string, std::set<std::string> > hw_interfaces_available_;
-  std::map< std::string, ControlMethod > map_control_method_to_hw_interface_;
+  std::map< std::string, std::set<std::string> > map_hwinterface_to_joints_;
+  std::map< std::string, ControlMethod > map_hwinterface_to_controlmethod_;
+  std::map< ControlMethod, std::vector<control_toolbox::Pid> > map_controlmethod_to_pidcontrollers_;
   std::vector<control_toolbox::Pid> pid_controllers_;
   std::vector<double> joint_position_;
   std::vector<double> joint_velocity_;

--- a/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
+++ b/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
@@ -173,7 +173,7 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
     // Create the controller manager
     ROS_DEBUG_STREAM_NAMED("ros_control_plugin","Loading controller_manager");
     controller_manager_.reset
-      (new controller_manager::ControllerManager(robot_hw_sim_.get(), model_nh_));
+      (new gazebo_ros_control::GazeboControllerManager(robot_hw_sim_.get(), model_nh_));
 
     // Listen to the update event. This event is broadcast every simulation iteration.
     update_connection_ =


### PR DESCRIPTION
This PR requires [ros_control#184](https://github.com/ros-controls/ros_control/pull/184).

Before giving details on the changes proposed in this PR, I will point out the motiviation for this PR and the use-case we had in mind.

**Motivation**
The current `gazebo_ros_control_plugin` uses the `DefaultRobotHWSim` class to implement a HardwareInterface  that connects gazebo with ros_control. The `DefaultRobotHWSim` offers all `hardware_interface::PositionJointInterface`, `hardware_interface::VelocityJointInterface`and `hardware_interface::EffortJointInterface` in a single class. Thus allowing to use `position_controllers`, `velocity_controllers` and `effort_controllers` to be used with gazebo.
Unfortunately, with the current implmentation only one HardwareInterface can be used at a time!
This is due to how  `DefaultRobotHWSim::initSim()` currently handles `hardwareInterface`-tag of the transmissions. Although, all `hardwareInterface`-tags from the transmissions are parsed, only the first is used lateron.

This PR now extends `DefaultRobotHWSim::initSim()` in a way that several HardwareInterfaces can be specified for a joint, e.g. like this:

```
    <transmission name="arm_1_trans">
      <type>transmission_interface/SimpleTransmission</type>
      <joint name="arm_1_joint">
        <hardwareInterface>PositionJointInterface</hardwareInterface>
        <hardwareInterface>VelocityJointInterface</hardwareInterface>
      </joint>
      <actuator name="arm_1_motor">
        <mechanicalReduction>1</mechanicalReduction>
      </actuator>
    </transmission>
```

This PR introduces means to keep track of the currently selected HardwareInterface by providing according data structures. 

This PR also provides a specific `GazeboControllerManager` which derives from the base `controller_manager::ControllerManager` class. This new class implements the `notifyHardwareInterface()`-function proposed in [ros_control#184](https://github.com/ros-controls/ros_control/pull/184).
The `notifyHardwareInterface()`-function is called during `switchController()`-function, i.e. when a new controller is meant to be started, Before switching the actual controllers, the new `notifyHardwareInterface()`-function allows the `GazeboControllerManager` to also switch the HardwareInterface required by a resource of the controller to be started. 

With this, it is also possible to have controllers requiring different HardwareInterface within the same gazebo session without needing to change the `hardwareInterface`-tag in the  transmission (URDF).

For example:

```
#position controller
arm_1_joint_position_controller:
  type: position_controllers/JointPositionController
  joint: arm_1_joint

#velocity controller
arm_1_joint_velocity_controller:
  type: velocity_controllers/JointVelocityController
  joint: arm_1_joint
```

can be loaded to the parameter server and then those two controllers can be switched using the ControllerManagers `switch_controller`-Service "on-the-fly".

Note: With this, no "PID-Parameter-Tuning" would be required for simulation anymore, as gazebo supports all the (Standard-)HardwareInterfaces.

This PR does not change the `DefaultRobotHWSim::readSim()` and `DefaultRobotHWSim::writeSim()` functions as those are already capable of handling various HardwareInterfaces, i.e. `joint_control_methods_`.

---

**I would like to thank @ipa-mdl for his help implementing this feature!**
