### PR TITLE
Header for GetModelState service request

### DIFF
--- a/gazebo_msgs/srv/GetModelState.srv
+++ b/gazebo_msgs/srv/GetModelState.srv
@@ -4,6 +4,10 @@ string relative_entity_name          # return pose and twist relative to this en
                                      # be sure to use gazebo scoped naming notation (e.g. [model_name::body_name])
                                      # leave empty or "world" will use inertial world frame
 ---
+Header header                        # Standard metadata for higher-level stamped data types.
+                                     # * header.seq holds the number of requests since the plugin started
+                                     # * header.stamp timestamp related to the pose
+                                     # * header.frame_id not used but currently filled with the relative_entity_name
 geometry_msgs/Pose pose              # pose of model in relative entity frame
 geometry_msgs/Twist twist            # twist of model in relative entity frame
 bool success                         # return true if get successful

--- a/gazebo_msgs/srv/GetModelState.srv
+++ b/gazebo_msgs/srv/GetModelState.srv
@@ -4,10 +4,6 @@ string relative_entity_name          # return pose and twist relative to this en
                                      # be sure to use gazebo scoped naming notation (e.g. [model_name::body_name])
                                      # leave empty or "world" will use inertial world frame
 ---
-Header header                        # Standard metadata for higher-level stamped data types.
-                                     # * header.seq holds the number of requests since the plugin started
-                                     # * header.stamp timestamp related to the pose
-                                     # * header.frame_id not used but currently filled with the relative_entity_name
 geometry_msgs/Pose pose              # pose of model in relative entity frame
 geometry_msgs/Twist twist            # twist of model in relative entity frame
 bool success                         # return true if get successful

--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -65,6 +65,7 @@ include_directories(include
 
 link_directories(
   ${GAZEBO_LIBRARY_DIRS}
+  ${OGRE_LIBRARY_DIRS}
 )
 
 catkin_package(

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_diff_drive.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_diff_drive.h
@@ -92,7 +92,7 @@ private:
     void getWheelVelocities();
     void publishWheelTF(); /// publishes the wheel tf's
     void publishWheelJointState();
-    void UpdateOdometryEncoder();
+    void updateOdometryEncoder();
 
 
     GazeboRosPtr gazebo_ros_;

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_diff_drive.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_diff_drive.h
@@ -103,8 +103,9 @@ private:
     double wheel_diameter_;
     double wheel_torque;
     double wheel_speed_[2];
-    double wheel_accel;
-    double wheel_speed_instr_[2];
+    double accel[2];
+    double vr,va;
+    double instr_vr, instr_va;
 
     std::vector<physics::JointPtr> joints_;
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_diff_drive.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_diff_drive.h
@@ -29,7 +29,7 @@
 /*
  * \file  gazebo_ros_diff_drive.h
  *
- * \brief A differential drive plugin for gazebo. Based on the diffdrive plugin 
+ * \brief A differential drive plugin for gazebo. Based on the diffdrive plugin
  * developed for the erratic robot (see copyright notice above). The original
  * plugin can be found in the ROS package gazebo_erratic_plugins.
  *
@@ -56,6 +56,7 @@
 #include <geometry_msgs/Pose2D.h>
 #include <nav_msgs/Odometry.h>
 #include <sensor_msgs/JointState.h>
+#include <std_msgs/UInt64.h>
 
 // Custom Callback Queue
 #include <ros/callback_queue.h>
@@ -67,89 +68,100 @@
 
 namespace gazebo {
 
-  class Joint;
-  class Entity;
+class Joint;
+class Entity;
 
-  class GazeboRosDiffDrive : public ModelPlugin {
+class GazeboRosDiffDrive : public ModelPlugin {
 
-    enum OdomSource
-    {
+    enum OdomSource {
         ENCODER = 0,
         WORLD = 1,
     };
-    public:
-      GazeboRosDiffDrive();
-      ~GazeboRosDiffDrive();
-      void Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf);
+public:
+    GazeboRosDiffDrive();
+    ~GazeboRosDiffDrive();
+    void Load ( physics::ModelPtr _parent, sdf::ElementPtr _sdf );
 
-    protected:
-      virtual void UpdateChild();
-      virtual void FiniChild();
+protected:
+    virtual void UpdateChild();
+    virtual void FiniChild();
 
-    private:
-      void publishOdometry(double step_time);
-      void getWheelVelocities();
-      void publishWheelTF(); /// publishes the wheel tf's
-      void publishWheelJointState();
-      void UpdateOdometryEncoder();
+private:
+    void publishOdometry ();
+    void publishAgentState ();  /// publishes the agent state current and target command as well as distance moved
+    void getWheelVelocities();
+    void publishWheelTF(); /// publishes the wheel tf's
+    void publishWheelJointState();
+    void UpdateOdometryEncoder();
 
 
-      GazeboRosPtr gazebo_ros_;
-      physics::ModelPtr parent;
-      event::ConnectionPtr update_connection_;
+    GazeboRosPtr gazebo_ros_;
+    physics::ModelPtr parent;
+    event::ConnectionPtr update_connection_;
 
-      double wheel_separation_;
-      double wheel_diameter_;
-      double wheel_torque;
-      double wheel_speed_[2];
-	  double wheel_accel;
-      double wheel_speed_instr_[2];
+    double wheel_separation_;
+    double wheel_diameter_;
+    double wheel_torque;
+    double wheel_speed_[2];
+    double wheel_accel;
+    double wheel_speed_instr_[2];
 
-      std::vector<physics::JointPtr> joints_;
+    std::vector<physics::JointPtr> joints_;
 
-      // ROS STUFF
-      ros::Publisher odometry_publisher_;
-      ros::Subscriber cmd_vel_subscriber_;
-      boost::shared_ptr<tf::TransformBroadcaster> transform_broadcaster_;
-      sensor_msgs::JointState joint_state_;
-      ros::Publisher joint_state_publisher_;      
-      nav_msgs::Odometry odom_;
-      std::string tf_prefix_;
+    // ROS STUFF
+    ros::Publisher odometry_publisher_;
+    ros::Subscriber cmd_vel_subscriber_;
+    boost::shared_ptr<tf::TransformBroadcaster> transform_broadcaster_;
+    sensor_msgs::JointState joint_state_;
+    ros::Publisher joint_state_publisher_;
+    nav_msgs::Odometry odom_;
+    std::string tf_prefix_;
+    ros::Publisher trip_recorder_publisher_;
+    ros::Publisher command_current_publisher_;
+    ros::Publisher command_target_publisher_;
+    double trip_recorder_scale_;
+    double trip_recorder_sub_meter_;
+    uint64_t  trip_recorder_;
+    geometry_msgs::Twist command_current_;
+    geometry_msgs::Twist command_target_;
 
-      boost::mutex lock;
+    boost::mutex lock;
 
-      std::string robot_namespace_;
-      std::string command_topic_;
-      std::string odometry_topic_;
-      std::string odometry_frame_;
-      std::string robot_base_frame_;
-      bool publish_tf_;
-      // Custom Callback Queue
-      ros::CallbackQueue queue_;
-      boost::thread callback_queue_thread_;
-      void QueueThread();
+    std::string robot_namespace_;
+    std::string command_topic_;
+    std::string odometry_topic_;
+    std::string trip_recorder_topic_;
+    std::string command_current_topic_;
+    std::string command_target_topic_;
+    std::string odometry_frame_;
+    std::string odometry_frame_resolved_;
+    std::string robot_base_frame_;
+    std::string robot_base_frame_resolved_;
+    bool publish_tf_;
+    // Custom Callback Queue
+    ros::CallbackQueue queue_;
+    boost::thread callback_queue_thread_;
+    void QueueThread();
 
-      // DiffDrive stuff
-      void cmdVelCallback(const geometry_msgs::Twist::ConstPtr& cmd_msg);
+    // DiffDrive stuff
+    void cmdVelCallback ( const geometry_msgs::Twist::ConstPtr& cmd_msg );
 
-      double x_;
-      double rot_;
-      bool alive_;
+    bool alive_;
 
-      // Update Rate
-      double update_rate_;
-      double update_period_;
-      common::Time last_update_time_;
-      
-      OdomSource odom_source_;
-      geometry_msgs::Pose2D pose_encoder_;
-      common::Time last_odom_update_;
-      
+    // Update Rate
+    double update_rate_;
+    double update_period_;
+    common::Time last_update_time_;
+
+    OdomSource odom_source_;
+    geometry_msgs::Pose2D pose_encoder_;
+    common::Time last_odom_update_;
+
     // Flags
     bool publishWheelTF_;
     bool publishWheelJointState_;
 
-  };
+};
 
 }
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_diff_drive.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_diff_drive.h
@@ -29,7 +29,7 @@
 /*
  * \file  gazebo_ros_diff_drive.h
  *
- * \brief A differential drive plugin for gazebo. Based on the diffdrive plugin
+ * \brief A differential drive plugin for gazebo. Based on the diffdrive plugin 
  * developed for the erratic robot (see copyright notice above). The original
  * plugin can be found in the ROS package gazebo_erratic_plugins.
  *
@@ -68,36 +68,37 @@
 
 namespace gazebo {
 
-class Joint;
-class Entity;
+  class Joint;
+  class Entity;
 
-class GazeboRosDiffDrive : public ModelPlugin {
+  class GazeboRosDiffDrive : public ModelPlugin {
 
-    enum OdomSource {
+    enum OdomSource
+    {
         ENCODER = 0,
         WORLD = 1,
     };
-public:
-    GazeboRosDiffDrive();
-    ~GazeboRosDiffDrive();
-    void Load ( physics::ModelPtr _parent, sdf::ElementPtr _sdf );
+    public:
+      GazeboRosDiffDrive();
+      ~GazeboRosDiffDrive();
+      void Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf);
 
-protected:
-    virtual void UpdateChild();
-    virtual void FiniChild();
+    protected:
+      virtual void UpdateChild();
+      virtual void FiniChild();
 
-private:
-    void publishOdometry ();
-    void publishAgentState ();  /// publishes the agent state current and target command as well as distance moved
-    void getWheelVelocities();
-    void publishWheelTF(); /// publishes the wheel tf's
-    void publishWheelJointState();
-    void updateOdometryEncoder();
+    private:
+      void publishOdometry();
+      void publishAgentState ();  /// publishes the agent state current and target command as well as distance moved
+      void getWheelVelocities();
+      void publishWheelTF(); /// publishes the wheel tf's
+      void publishWheelJointState();
+      void updateOdometryEncoder();
 
 
-    GazeboRosPtr gazebo_ros_;
-    physics::ModelPtr parent;
-    event::ConnectionPtr update_connection_;
+      GazeboRosPtr gazebo_ros_;
+      physics::ModelPtr parent;
+      event::ConnectionPtr update_connection_;
 
     double wheel_separation_;
     double wheel_diameter_;
@@ -107,62 +108,62 @@ private:
     double vr,va;
     double instr_vr, instr_va;
 
-    std::vector<physics::JointPtr> joints_;
+      std::vector<physics::JointPtr> joints_;
 
-    // ROS STUFF
-    ros::Publisher odometry_publisher_;
-    ros::Subscriber cmd_vel_subscriber_;
-    boost::shared_ptr<tf::TransformBroadcaster> transform_broadcaster_;
-    sensor_msgs::JointState joint_state_;
-    ros::Publisher joint_state_publisher_;
-    nav_msgs::Odometry odom_;
-    std::string tf_prefix_;
-    ros::Publisher trip_recorder_publisher_;
-    ros::Publisher command_current_publisher_;
-    ros::Publisher command_target_publisher_;
-    double trip_recorder_scale_;
-    double trip_recorder_sub_meter_;
-    uint64_t  trip_recorder_;
-    geometry_msgs::Twist command_current_;
-    geometry_msgs::Twist command_target_;
+      // ROS STUFF
+      ros::Publisher odometry_publisher_;
+      ros::Subscriber cmd_vel_subscriber_;
+      boost::shared_ptr<tf::TransformBroadcaster> transform_broadcaster_;
+      sensor_msgs::JointState joint_state_;
+      ros::Publisher joint_state_publisher_;      
+      nav_msgs::Odometry odom_;
+      std::string tf_prefix_;
+      ros::Publisher trip_recorder_publisher_;  /// publishes the distance moved
+      ros::Publisher command_current_publisher_;  /// publishes the current executed command
+      ros::Publisher command_target_publisher_;   /// publishes the target command
+      double trip_recorder_scale_;
+      double trip_recorder_sub_meter_;
+      uint64_t  trip_recorder_;
+      geometry_msgs::Twist command_current_;
+      geometry_msgs::Twist command_target_;
 
-    boost::mutex lock;
+      boost::mutex lock;
 
-    std::string robot_namespace_;
-    std::string command_topic_;
-    std::string odometry_topic_;
-    std::string trip_recorder_topic_;
-    std::string command_current_topic_;
-    std::string command_target_topic_;
-    std::string odometry_frame_;
-    std::string odometry_frame_resolved_;
-    std::string robot_base_frame_;
-    std::string robot_base_frame_resolved_;
-    bool publish_tf_;
-    // Custom Callback Queue
-    ros::CallbackQueue queue_;
-    boost::thread callback_queue_thread_;
-    void QueueThread();
+      std::string robot_namespace_;
+      std::string command_topic_;
+      std::string odometry_topic_;
+      std::string trip_recorder_topic_;
+      std::string command_current_topic_;
+      std::string command_target_topic_;
+      std::string odometry_frame_;
+      std::string odometry_frame_resolved_;
+      std::string robot_base_frame_;
+      std::string robot_base_frame_resolved_;
+      bool publish_tf_;
+      // Custom Callback Queue
+      ros::CallbackQueue queue_;
+      boost::thread callback_queue_thread_;
+      void QueueThread();
 
-    // DiffDrive stuff
-    void cmdVelCallback ( const geometry_msgs::Twist::ConstPtr& cmd_msg );
+      // DiffDrive stuff
+      void cmdVelCallback(const geometry_msgs::Twist::ConstPtr& cmd_msg);
 
-    bool alive_;
+       bool alive_;
 
-    // Update Rate
-    double update_rate_;
-    double update_period_;
-    common::Time last_update_time_;
-
-    OdomSource odom_source_;
-    geometry_msgs::Pose2D pose_encoder_;
-    common::Time last_odom_update_;
-
+      // Update Rate
+      double update_rate_;
+      double update_period_;
+      common::Time last_update_time_;
+      
+      OdomSource odom_source_;
+      geometry_msgs::Pose2D pose_encoder_;
+      common::Time last_odom_update_;
+      
     // Flags
     bool publishWheelTF_;
     bool publishWheelJointState_;
 
-};
+  };
 
 }
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_diff_drive.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_diff_drive.h
@@ -102,8 +102,8 @@ namespace gazebo {
       double wheel_diameter_;
       double wheel_torque;
       double wheel_speed_[2];
-	  double wheel_accel;
-      double wheel_speed_instr_[2];
+      double accel[2];
+      double instr_vr, instr_va;
 
       std::vector<physics::JointPtr> joints_;
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_diff_drive.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_diff_drive.h
@@ -82,7 +82,6 @@ namespace gazebo {
       GazeboRosDiffDrive();
       ~GazeboRosDiffDrive();
       void Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf);
-      void Reset();
 
     protected:
       virtual void UpdateChild();

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_tricycle_drive.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_tricycle_drive.h
@@ -55,6 +55,7 @@
 #include <nav_msgs/Odometry.h>
 #include <nav_msgs/OccupancyGrid.h>
 #include <sensor_msgs/JointState.h>
+#include <std_msgs/UInt64.h>
 
 // Custom Callback Queue
 #include <ros/callback_queue.h>
@@ -94,13 +95,15 @@ protected:
     virtual void FiniChild();
 
 private:
-    GazeboRosPtr gazebo_ros_;
-    physics::ModelPtr parent;
     void publishOdometry(double step_time);
+    void publishAgentState ();  /// publishes the agent state current and target command as well as distance moved
     void publishWheelTF(); /// publishes the wheel tf's
     void publishWheelJointState();
+    void updateOdometryEncoder();
     void motorController(double target_speed, double target_angle, double dt);
 
+	GazeboRosPtr gazebo_ros_;
+    physics::ModelPtr parent;
     event::ConnectionPtr update_connection_;
 
     physics::JointPtr joint_steering_;
@@ -120,11 +123,7 @@ private:
     OdomSource odom_source_;
     double wheel_torque_;
 
-    std::string robot_namespace_;
-    std::string command_topic_;
-    std::string odometry_topic_;
-    std::string odometry_frame_;
-    std::string robot_base_frame_;
+    
 
     // ROS STUFF
     ros::Publisher odometry_publisher_;
@@ -133,10 +132,29 @@ private:
     sensor_msgs::JointState joint_state_;
     ros::Publisher joint_state_publisher_;
     nav_msgs::Odometry odom_;
+    std::string tf_prefix_;
+    ros::Publisher trip_recorder_publisher_;
+    ros::Publisher command_current_publisher_;
+    ros::Publisher command_target_publisher_;
+    double trip_recorder_scale_;
+    double trip_recorder_sub_meter_;
+    uint64_t  trip_recorder_;
+    geometry_msgs::Twist command_current_;
+    geometry_msgs::Twist command_target_;
 
     boost::mutex lock;
 
-
+	std::string robot_namespace_;
+    std::string command_topic_;
+    std::string odometry_topic_;
+    std::string trip_recorder_topic_;
+    std::string command_current_topic_;
+    std::string command_target_topic_;
+    std::string odometry_frame_;
+    std::string odometry_frame_resolved_;
+    std::string robot_base_frame_;
+    std::string robot_base_frame_resolved_;
+    bool publish_tf_;
     // Custom Callback Queue
     ros::CallbackQueue queue_;
     boost::thread callback_queue_thread_;

--- a/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
@@ -244,7 +244,7 @@ void GazeboRosDiffDrive::UpdateChild() {
 		double wheel_l = joints_[LEFT] ->GetVelocity ( 0 ) * ( wheel_diameter_ / 2.0 );
 		double wheel_r = joints_[RIGHT]->GetVelocity ( 0 ) * ( wheel_diameter_ / 2.0 );
         double current_vr = (wheel_l + wheel_r)/2.0 ;
-        double current_va = (wheel_l - wheel_r)/wheel_diameter_ ;
+        double current_va = (wheel_l - wheel_r)/wheel_separation_ ;
 		double req_vr = vr;
         double req_va = va;	
 	

--- a/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
@@ -244,7 +244,7 @@ void GazeboRosDiffDrive::UpdateChild() {
 		double wheel_l = joints_[LEFT] ->GetVelocity ( 0 ) * ( wheel_diameter_ / 2.0 );
 		double wheel_r = joints_[RIGHT]->GetVelocity ( 0 ) * ( wheel_diameter_ / 2.0 );
         double current_vr = (wheel_l + wheel_r)/2.0 ;
-        double current_va = (wheel_l - wheel_r)/wheel_diameter_ ;
+        double current_va = (wheel_l - wheel_r)/wheel_separation_ ;
 		double req_vr = vr;
         double req_va = va;	
 	
@@ -271,6 +271,9 @@ void GazeboRosDiffDrive::UpdateChild() {
 
             joints_[LEFT]->SetVelocity  ( 0,(instr_vr + instr_va * wheel_separation_ / 2.0) / ( wheel_diameter_ / 2.0 ));
             joints_[RIGHT]->SetVelocity ( 0,(instr_vr - instr_va * wheel_separation_ / 2.0) / ( wheel_diameter_ / 2.0 ));
+            
+            //joints_[LEFT]->SetVelocity  ( 0,(vr + va * wheel_separation_ / 2.0) / ( wheel_diameter_ / 2.0 ));
+            //joints_[RIGHT]->SetVelocity ( 0,(vr - va * wheel_separation_ / 2.0) / ( wheel_diameter_ / 2.0 ));
         }
         last_update_time_+= common::Time ( update_period_ );
     }

--- a/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
@@ -60,12 +60,12 @@
 namespace gazebo {
 
 enum {
-    RIGHT,
-    LEFT,
+    RIGHT = 0,
+    LEFT = 1,
 };
 enum {
-  V,
-  W,
+  FORWARD = 0,
+  ANGULAR = 1,
 };
 
 GazeboRosDiffDrive::GazeboRosDiffDrive() {}
@@ -95,8 +95,8 @@ void GazeboRosDiffDrive::Load ( physics::ModelPtr _parent, sdf::ElementPtr _sdf 
     gazebo_ros_->getParameter<double> ( trip_recorder_scale_, "tripRecorderScale", 1000. );
     gazebo_ros_->getParameter<double> ( wheel_separation_, "wheelSeparation", 0.34 );
     gazebo_ros_->getParameter<double> ( wheel_diameter_, "wheelDiameter", 0.15 );
-    gazebo_ros_->getParameter<double> ( accel[V], "Acceleration_v", 0.0 );
-    gazebo_ros_->getParameter<double> ( accel[W], "Acceleration_w", 0.0 );
+    gazebo_ros_->getParameter<double> ( accel[FORWARD], "Acceleration_v", 0.0 );
+    gazebo_ros_->getParameter<double> ( accel[ANGULAR], "Acceleration_w", 0.0 );
     gazebo_ros_->getParameter<double> ( wheel_torque, "wheelTorque", 5.0 );
     gazebo_ros_->getParameter<double> ( update_rate_, "updateRate", 100.0 );
 
@@ -249,7 +249,7 @@ void GazeboRosDiffDrive::UpdateChild() {
         double req_va = va;	
 	
 	
-        if (/*( accel[V] == 0 && accel[W] == 0)||*/
+        if (/*( accel[FORWARD] == 0 && accel[ANGULAR] == 0)||*/
                 (( fabs ( req_vr - current_vr ) < 0.01 ) &&
                  ( fabs ( req_va - current_va ) < 0.01 )) ) {
             //if max_accel == 0, or target speed is reached
@@ -257,14 +257,14 @@ void GazeboRosDiffDrive::UpdateChild() {
             joints_[RIGHT]->SetVelocity ( 0, (req_vr - req_va * wheel_separation_ / 2.0)  / ( wheel_diameter_ / 2.0 ));
         } else {
             if ( req_vr>=current_vr )
-                instr_vr += fmin ( req_vr - current_vr,  accel[V] * seconds_since_last_update );
+                instr_vr += fmin ( req_vr - current_vr,  accel[FORWARD] * seconds_since_last_update );
             else
-                instr_vr += fmax ( req_vr - current_vr, -accel[V] * seconds_since_last_update );
+                instr_vr += fmax ( req_vr - current_vr, -accel[FORWARD] * seconds_since_last_update );
 
             if ( req_va>=current_va )
-                instr_va += fmin ( req_va - current_va,  accel[W] * seconds_since_last_update );
+                instr_va += fmin ( req_va - current_va,  accel[ANGULAR] * seconds_since_last_update );
             else
-                instr_va += fmax ( req_va - current_va, -accel[W] * seconds_since_last_update );
+                instr_va += fmax ( req_va - current_va, -accel[ANGULAR] * seconds_since_last_update );
 
              //ROS_INFO("actual wheel speed = %lf, issued wheel speed= %lf", current_vr, req_vr);
              //ROS_INFO("actual wheel speed = %lf, issued wheel speed= %lf", current_va, req_va);

--- a/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
@@ -63,6 +63,10 @@ enum {
     RIGHT,
     LEFT,
 };
+enum {
+  V,
+  W,
+};
 
 GazeboRosDiffDrive::GazeboRosDiffDrive() {}
 
@@ -91,7 +95,8 @@ void GazeboRosDiffDrive::Load ( physics::ModelPtr _parent, sdf::ElementPtr _sdf 
     gazebo_ros_->getParameter<double> ( trip_recorder_scale_, "tripRecorderScale", 1000. );
     gazebo_ros_->getParameter<double> ( wheel_separation_, "wheelSeparation", 0.34 );
     gazebo_ros_->getParameter<double> ( wheel_diameter_, "wheelDiameter", 0.15 );
-    gazebo_ros_->getParameter<double> ( wheel_accel, "wheelAcceleration", 0.0 );
+    gazebo_ros_->getParameter<double> ( accel[V], "Acceleration_v", 0.0 );
+    gazebo_ros_->getParameter<double> ( accel[W], "Acceleration_w", 0.0 );
     gazebo_ros_->getParameter<double> ( wheel_torque, "wheelTorque", 5.0 );
     gazebo_ros_->getParameter<double> ( update_rate_, "updateRate", 100.0 );
 
@@ -236,34 +241,36 @@ void GazeboRosDiffDrive::UpdateChild() {
 
         // Update robot in case new velocities have been requested
         getWheelVelocities();
-
-        double current_speed[2];
-
-        current_speed[LEFT] = joints_[LEFT]->GetVelocity ( 0 )   * ( wheel_diameter_ / 2.0 );
-        current_speed[RIGHT] = joints_[RIGHT]->GetVelocity ( 0 ) * ( wheel_diameter_ / 2.0 );
-
-        if ( wheel_accel == 0 ||
-                ( fabs ( wheel_speed_[LEFT] - current_speed[LEFT] ) < 0.01 ) ||
-                ( fabs ( wheel_speed_[RIGHT] - current_speed[RIGHT] ) < 0.01 ) ) {
+		double wheel_l = joints_[LEFT] ->GetVelocity ( 0 ) * ( wheel_diameter_ / 2.0 );
+		double wheel_r = joints_[RIGHT]->GetVelocity ( 0 ) * ( wheel_diameter_ / 2.0 );
+        double current_vr = (wheel_l + wheel_r)/2.0 ;
+        double current_va = (wheel_l - wheel_r)/wheel_diameter_ ;
+		double req_vr = vr;
+        double req_va = va;	
+	
+	
+        if (/*( accel[V] == 0 && accel[W] == 0)||*/
+                (( fabs ( req_vr - current_vr ) < 0.01 ) &&
+                 ( fabs ( req_va - current_va ) < 0.01 )) ) {
             //if max_accel == 0, or target speed is reached
-            joints_[LEFT]->SetVelocity ( 0, wheel_speed_[LEFT]/ ( wheel_diameter_ / 2.0 ) );
-            joints_[RIGHT]->SetVelocity ( 0, wheel_speed_[RIGHT]/ ( wheel_diameter_ / 2.0 ) );
+            joints_[LEFT]->SetVelocity  ( 0, (req_vr + req_va * wheel_separation_ / 2.0)  / ( wheel_diameter_ / 2.0 ));
+            joints_[RIGHT]->SetVelocity ( 0, (req_vr - req_va * wheel_separation_ / 2.0)  / ( wheel_diameter_ / 2.0 ));
         } else {
-            if ( wheel_speed_[LEFT]>=current_speed[LEFT] )
-                wheel_speed_instr_[LEFT]+=fmin ( wheel_speed_[LEFT]-current_speed[LEFT],  wheel_accel * seconds_since_last_update );
+            if ( req_vr>=current_vr )
+                instr_vr += fmin ( req_vr - current_vr,  accel[V] * seconds_since_last_update );
             else
-                wheel_speed_instr_[LEFT]+=fmax ( wheel_speed_[LEFT]-current_speed[LEFT], -wheel_accel * seconds_since_last_update );
+                instr_vr += fmax ( req_vr - current_vr, -accel[V] * seconds_since_last_update );
 
-            if ( wheel_speed_[RIGHT]>current_speed[RIGHT] )
-                wheel_speed_instr_[RIGHT]+=fmin ( wheel_speed_[RIGHT]-current_speed[RIGHT], wheel_accel * seconds_since_last_update );
+            if ( req_va>=current_va )
+                instr_va += fmin ( req_va - current_va,  accel[W] * seconds_since_last_update );
             else
-                wheel_speed_instr_[RIGHT]+=fmax ( wheel_speed_[RIGHT]-current_speed[RIGHT], -wheel_accel * seconds_since_last_update );
+                instr_va += fmax ( req_va - current_va, -accel[W] * seconds_since_last_update );
 
-            // ROS_INFO("actual wheel speed = %lf, issued wheel speed= %lf", current_speed[LEFT], wheel_speed_[LEFT]);
-            // ROS_INFO("actual wheel speed = %lf, issued wheel speed= %lf", current_speed[RIGHT],wheel_speed_[RIGHT]);
+             //ROS_INFO("actual wheel speed = %lf, issued wheel speed= %lf", current_vr, req_vr);
+             //ROS_INFO("actual wheel speed = %lf, issued wheel speed= %lf", current_va, req_va);
 
-            joints_[LEFT]->SetVelocity ( 0,wheel_speed_instr_[LEFT] / ( wheel_diameter_ / 2.0 ) );
-            joints_[RIGHT]->SetVelocity ( 0,wheel_speed_instr_[RIGHT] / ( wheel_diameter_ / 2.0 ) );
+            joints_[LEFT]->SetVelocity  ( 0,(instr_vr + instr_va * wheel_separation_ / 2.0) / ( wheel_diameter_ / 2.0 ));
+            joints_[RIGHT]->SetVelocity ( 0,(instr_vr - instr_va * wheel_separation_ / 2.0) / ( wheel_diameter_ / 2.0 ));
         }
         last_update_time_+= common::Time ( update_period_ );
     }
@@ -281,8 +288,8 @@ void GazeboRosDiffDrive::FiniChild() {
 void GazeboRosDiffDrive::getWheelVelocities() {
     boost::mutex::scoped_lock scoped_lock ( lock );
 
-    double vr = command_target_.linear.x;
-    double va = command_target_.angular.z;
+    vr = command_target_.linear.x;
+    va = command_target_.angular.z;
 
     wheel_speed_[LEFT] = vr + va * wheel_separation_ / 2.0;
     wheel_speed_[RIGHT] = vr - va * wheel_separation_ / 2.0;
@@ -310,7 +317,7 @@ void GazeboRosDiffDrive::updateOdometryEncoder() {
 
     double b = wheel_separation_;
 
-    // Book: Sigwart 2011 Autonompus Mobile Robots page:337
+    // Book: Sigwart 2011 Autonomous Mobile Robots page:337
     double sl = vl * ( wheel_diameter_ / 2.0 ) * seconds_since_last_update;
     double sr = vr * ( wheel_diameter_ / 2.0 ) * seconds_since_last_update;
     double theta = ( sl - sr ) /b;

--- a/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
@@ -366,8 +366,6 @@ void GazeboRosDiffDrive::publishAgentState ( ) {
 
     if ( command_current_publisher_.getNumSubscribers() > 0 ) {
         command_current_publisher_.publish ( command_current_ );
-        std::cout << command_current_.linear.x << std::endl;
-        ROS_INFO ( "%s: command_current v %4.2f, w %4.2f !", gazebo_ros_->info(), command_current_.linear.x, command_current_.angular.z );
     }
     if ( command_target_publisher_.getNumSubscribers() > 0 ) {
         command_target_publisher_.publish ( command_target_ );

--- a/gazebo_plugins/test/multi_robot_scenario/xacro/p3dx/pioneer3dx_plugins.xacro
+++ b/gazebo_plugins/test/multi_robot_scenario/xacro/p3dx/pioneer3dx_plugins.xacro
@@ -26,11 +26,15 @@
             <wheelDiameter>0.18</wheelDiameter>
             <wheelTorque>20</wheelTorque>
             <wheelAcceleration>1.8</wheelAcceleration>
-            <commandTopic>cmd_vel</commandTopic>
             <odometryTopic>odom</odometryTopic>
             <odometryFrame>odom</odometryFrame>
             <odometrySource>world</odometrySource>
             <robotBaseFrame>base_link</robotBaseFrame>
+            <tripRecorderTopic>trip_recorder</tripRecorderTopic>
+            <tripRecorderScale>1000</tripRecorderScale>  <!-- scales to meters  -->
+            <commandTopic>cmd_vel</commandTopic>
+            <commandCurrentTopic>cmd_vel_current</commandCurrentTopic>
+	    <commandTargetTopic>cmd_vel_target</commandTargetTopic>
             <updateRate>10.0</updateRate>
         </plugin>
     </gazebo>

--- a/gazebo_plugins/test/multi_robot_scenario/xacro/p3dx/pioneer3dx_plugins.xacro
+++ b/gazebo_plugins/test/multi_robot_scenario/xacro/p3dx/pioneer3dx_plugins.xacro
@@ -27,9 +27,9 @@
             <wheelTorque>20</wheelTorque>
             <wheelAcceleration>1.8</wheelAcceleration>
             <odometryTopic>odom</odometryTopic>
-            <odometryFrame>odom</odometryFrame>
-            <odometrySource>world</odometrySource>
+            <odometryFrame>odom</odometryFrame> 
             <robotBaseFrame>base_link</robotBaseFrame>
+            <odometrySource>world</odometrySource> <!-- world or encoder, on world it will deliver ground truth -->
             <tripRecorderTopic>trip_recorder</tripRecorderTopic>
             <tripRecorderScale>1000</tripRecorderScale>  <!-- scales to meters  -->
             <commandTopic>cmd_vel</commandTopic>

--- a/gazebo_plugins/test/multi_robot_scenario/xacro/p3dx/pioneer3dx_plugins.xacro
+++ b/gazebo_plugins/test/multi_robot_scenario/xacro/p3dx/pioneer3dx_plugins.xacro
@@ -26,7 +26,7 @@
             <wheelDiameter>0.18</wheelDiameter>
             <wheelTorque>20</wheelTorque>
             <Acceleration_v>0.4</Acceleration_v>
-	        <Acceleration_w>0.4</Acceleration_w>
+	    <Acceleration_w>0.4</Acceleration_w>
             <odometryTopic>odom</odometryTopic>
             <odometryFrame>odom</odometryFrame> 
             <robotBaseFrame>base_link</robotBaseFrame>

--- a/gazebo_plugins/test/multi_robot_scenario/xacro/p3dx/pioneer3dx_plugins.xacro
+++ b/gazebo_plugins/test/multi_robot_scenario/xacro/p3dx/pioneer3dx_plugins.xacro
@@ -25,7 +25,8 @@
             <wheelSeparation>0.3</wheelSeparation>
             <wheelDiameter>0.18</wheelDiameter>
             <wheelTorque>20</wheelTorque>
-            <wheelAcceleration>1.8</wheelAcceleration>
+            <Acceleration_v>0.4</Acceleration_v>
+	    <Acceleration_w>0.4</Acceleration_w>
             <commandTopic>cmd_vel</commandTopic>
             <odometryTopic>odom</odometryTopic>
             <odometryFrame>odom</odometryFrame>

--- a/gazebo_plugins/test/multi_robot_scenario/xacro/p3dx/pioneer3dx_plugins.xacro
+++ b/gazebo_plugins/test/multi_robot_scenario/xacro/p3dx/pioneer3dx_plugins.xacro
@@ -25,7 +25,8 @@
             <wheelSeparation>0.3</wheelSeparation>
             <wheelDiameter>0.18</wheelDiameter>
             <wheelTorque>20</wheelTorque>
-            <wheelAcceleration>1.8</wheelAcceleration>
+            <Acceleration_v>0.4</Acceleration_v>
+	        <Acceleration_w>0.4</Acceleration_w>
             <odometryTopic>odom</odometryTopic>
             <odometryFrame>odom</odometryFrame> 
             <robotBaseFrame>base_link</robotBaseFrame>

--- a/gazebo_plugins/test/multi_robot_scenario/xacro/p3dx/pioneer3dx_plugins.xacro
+++ b/gazebo_plugins/test/multi_robot_scenario/xacro/p3dx/pioneer3dx_plugins.xacro
@@ -28,7 +28,7 @@
             <Acceleration_v>0.4</Acceleration_v>
 	    <Acceleration_w>0.4</Acceleration_w>
             <odometryTopic>odom</odometryTopic>
-            <odometryFrame>odom</odometryFrame> 
+            <odometryFrame>odom</odometryFrame>
             <robotBaseFrame>base_link</robotBaseFrame>
             <odometrySource>world</odometrySource> <!-- world or encoder, on world it will deliver ground truth -->
             <tripRecorderTopic>trip_recorder</tripRecorderTopic>

--- a/gazebo_plugins/test/tricycle_drive/xacro/tricycle/wheel_actuated.xacro
+++ b/gazebo_plugins/test/tricycle_drive/xacro/tricycle/wheel_actuated.xacro
@@ -29,6 +29,38 @@
   </gazebo>
   
   <!-- wheel joint -->
+  <joint name="${side}_wheel_joint" type="fixed">
+    <axis xyz="0 1 0"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <parent link="${side}_steering_joint"/>
+    <child link="${side}_wheel"/>
+  </joint>
+  <link name="${side}_wheel">
+    <inertial>
+      <mass value="0.5"/>
+      <origin xyz="0 0 0"/>
+      <inertia ixx="0.012411765597" ixy="0" ixz="0" iyy="0.015218160428" iyz="0" izz="0.011763977943"/>
+    </inertial>
+    <visual name="base_visual">
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry name="pioneer_geom">
+        <mesh filename="${meshes}/${side}_wheel.stl"/>
+      </geometry>
+      <material name="WheelBlack">
+        <color rgba="0.117 0.117 0.117 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="${-3.1415927/2} 0 0"/>
+      <geometry>
+        <!--<mesh filename="${meshes}/${side}_wheel.stl"/>-->
+        <cylinder radius="${radius}" length="0.01"/>
+      </geometry>
+    </collision>
+  </link>
+  <gazebo reference="${side}_wheel">
+    <material value="Gazebo/Black"/>
+  </gazebo>
   <xacro:wheel name="${name}"  parent="${name}_steering"  xyz="0 0 0" rpy="0 0 0" radius="${radius}" length="${length}" meshes="${meshes}"/>
   
   </xacro:macro>

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -776,6 +776,24 @@ bool GazeboRosApiPlugin::getModelState(gazebo_msgs::GetModelState::Request &req,
   }
   else
   {
+    /**
+     * @brief creates a header for the result
+     * @author Markus Bader markus.bader@tuwien.ac.at
+     * @date 21th Nov 2014
+     **/
+    {
+      std::map<std::string, unsigned int>::iterator it = access_count_get_model_state_.find(req.model_name);
+      if(it == access_count_get_model_state_.end()) {
+	access_count_get_model_state_.insert( std::pair<std::string, unsigned int>(req.model_name, 1) );
+	res.header.seq = 1;
+	
+      } else {
+	it->second++;
+	res.header.seq = it->second;
+      }
+      res.header.stamp = ros::Time::now();
+      res.header.frame_id = req.relative_entity_name; /// @brief this is a redundant information
+    }
     // get model pose
     gazebo::math::Pose       model_pose = model->GetWorldPose();
     gazebo::math::Vector3    model_pos = model_pose.pos;

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -31,9 +31,7 @@ GazeboRosApiPlugin::GazeboRosApiPlugin() :
   physics_reconfigure_initialized_(false),
   world_created_(false),
   stop_(false),
-  plugin_loaded_(false),
-  pub_link_states_connection_count_(0),
-  pub_model_states_connection_count_(0)
+  plugin_loaded_(false)
 {
   robot_namespace_.clear();
 }
@@ -84,17 +82,11 @@ GazeboRosApiPlugin::~GazeboRosApiPlugin()
   // Delete Force and Wrench Jobs
   lock_.lock();
   for (std::vector<GazeboRosApiPlugin::ForceJointJob*>::iterator iter=force_joint_jobs_.begin();iter!=force_joint_jobs_.end();)
-  {
     delete (*iter);
-    iter = force_joint_jobs_.erase(iter);
-  }
   force_joint_jobs_.clear();
   ROS_DEBUG_STREAM_NAMED("api_plugin","ForceJointJobs deleted");
   for (std::vector<GazeboRosApiPlugin::WrenchBodyJob*>::iterator iter=wrench_body_jobs_.begin();iter!=wrench_body_jobs_.end();)
-  {
     delete (*iter);
-    iter = wrench_body_jobs_.erase(iter);
-  }
   wrench_body_jobs_.clear();
   lock_.unlock();
   ROS_DEBUG_STREAM_NAMED("api_plugin","WrenchBodyJobs deleted");
@@ -527,6 +519,9 @@ bool GazeboRosApiPlugin::spawnURDFModel(gazebo_msgs::SpawnModel::Request &req,
   // get name space for the corresponding model plugins
   robot_namespace_ = req.robot_namespace;
 
+  // incoming robot name
+  std::string model_name = req.model_name;
+
   // incoming robot model string
   std::string model_xml = req.model_xml;
 
@@ -765,7 +760,6 @@ bool GazeboRosApiPlugin::deleteModel(gazebo_msgs::DeleteModel::Request &req,
 bool GazeboRosApiPlugin::getModelState(gazebo_msgs::GetModelState::Request &req,
                                        gazebo_msgs::GetModelState::Response &res)
 {
-  static std::map<std::string, unsigned int> access_count;
   gazebo::physics::ModelPtr model = world_->GetModel(req.model_name);
   gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.relative_entity_name));
   if (!model)
@@ -777,23 +771,6 @@ bool GazeboRosApiPlugin::getModelState(gazebo_msgs::GetModelState::Request &req,
   }
   else
   {
-    /**
-     * @brief creates a header for the result
-     * @author Markus Bader markus.bader@tuwien.ac.at
-     * @date 6th Oct 2014
-     **/
-    {
-      std::map<std::string, unsigned int>::iterator it = access_count.find(req.model_name);
-      if(it == access_count.end()) {
-	access_count.insert( std::pair<std::string, unsigned int>(req.model_name, 1) );
-	res.header.seq = 1;
-      } else {
-	it->second++;
-	res.header.seq = it->second;
-      }
-      res.header.stamp = ros::Time::now();
-      res.header.frame_id = req.relative_entity_name; ///@ToDo this is a redundant information
-    }
     // get model pose
     gazebo::math::Pose       model_pose = model->GetWorldPose();
     gazebo::math::Vector3    model_pos = model_pose.pos;
@@ -1755,7 +1732,7 @@ void GazeboRosApiPlugin::wrenchBodySchedulerSlot()
       iter = wrench_body_jobs_.erase(iter);
     }
     else
-      ++iter;
+      iter++;
   }
   lock_.unlock();
 }
@@ -1785,7 +1762,7 @@ void GazeboRosApiPlugin::forceJointSchedulerSlot()
       iter = force_joint_jobs_.erase(iter);
     }
     else
-      ++iter;
+      iter++;
   }
   lock_.unlock();
 }

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -780,6 +780,7 @@ bool GazeboRosApiPlugin::getModelState(gazebo_msgs::GetModelState::Request &req,
     /**
      * @brief creates a header for the result
      * @author Markus Bader markus.bader@tuwien.ac.at
+     * @date 6th Oct 2014
      **/
     {
       std::map<std::string, unsigned int>::iterator it = access_count.find(req.model_name);

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -780,10 +780,10 @@ bool GazeboRosApiPlugin::getModelState(gazebo_msgs::GetModelState::Request &req,
     std::map<std::string, unsigned int>::iterator it = access_count_get_model_state_.find(req.model_name);
     if(it == access_count_get_model_state_.end())
     {
-      access_count_get_model_state_.insert(std::pair<std::string, unsigned int>(req.model_name, 1) );
+      access_count_get_model_state_.insert(std::pair<std::string, unsigned int>(req.model_name, 1));
       res.header.seq = 1;
-    } 
-    else 
+    }
+    else
     {
       it->second++;
       res.header.seq = it->second;

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -31,7 +31,9 @@ GazeboRosApiPlugin::GazeboRosApiPlugin() :
   physics_reconfigure_initialized_(false),
   world_created_(false),
   stop_(false),
-  plugin_loaded_(false)
+  plugin_loaded_(false),
+  pub_link_states_connection_count_(0),
+  pub_model_states_connection_count_(0)
 {
   robot_namespace_.clear();
 }
@@ -82,11 +84,17 @@ GazeboRosApiPlugin::~GazeboRosApiPlugin()
   // Delete Force and Wrench Jobs
   lock_.lock();
   for (std::vector<GazeboRosApiPlugin::ForceJointJob*>::iterator iter=force_joint_jobs_.begin();iter!=force_joint_jobs_.end();)
+  {
     delete (*iter);
+    iter = force_joint_jobs_.erase(iter);
+  }
   force_joint_jobs_.clear();
   ROS_DEBUG_STREAM_NAMED("api_plugin","ForceJointJobs deleted");
   for (std::vector<GazeboRosApiPlugin::WrenchBodyJob*>::iterator iter=wrench_body_jobs_.begin();iter!=wrench_body_jobs_.end();)
+  {
     delete (*iter);
+    iter = wrench_body_jobs_.erase(iter);
+  }
   wrench_body_jobs_.clear();
   lock_.unlock();
   ROS_DEBUG_STREAM_NAMED("api_plugin","WrenchBodyJobs deleted");
@@ -519,9 +527,6 @@ bool GazeboRosApiPlugin::spawnURDFModel(gazebo_msgs::SpawnModel::Request &req,
   // get name space for the corresponding model plugins
   robot_namespace_ = req.robot_namespace;
 
-  // incoming robot name
-  std::string model_name = req.model_name;
-
   // incoming robot model string
   std::string model_xml = req.model_xml;
 
@@ -771,6 +776,24 @@ bool GazeboRosApiPlugin::getModelState(gazebo_msgs::GetModelState::Request &req,
   }
   else
   {
+    /**
+     * @brief creates a header for the result
+     * @author Markus Bader markus.bader@tuwien.ac.at
+     * @date 21th Nov 2014
+     **/
+    {
+      std::map<std::string, unsigned int>::iterator it = access_count_get_model_state_.find(req.model_name);
+      if(it == access_count_get_model_state_.end()) {
+	access_count_get_model_state_.insert( std::pair<std::string, unsigned int>(req.model_name, 1) );
+	res.header.seq = 1;
+	
+      } else {
+	it->second++;
+	res.header.seq = it->second;
+      }
+      res.header.stamp = ros::Time::now();
+      res.header.frame_id = req.relative_entity_name; /// @brief this is a redundant information
+    }
     // get model pose
     gazebo::math::Pose       model_pose = model->GetWorldPose();
     gazebo::math::Vector3    model_pos = model_pose.pos;
@@ -1732,7 +1755,7 @@ void GazeboRosApiPlugin::wrenchBodySchedulerSlot()
       iter = wrench_body_jobs_.erase(iter);
     }
     else
-      iter++;
+      ++iter;
   }
   lock_.unlock();
 }
@@ -1762,7 +1785,7 @@ void GazeboRosApiPlugin::forceJointSchedulerSlot()
       iter = force_joint_jobs_.erase(iter);
     }
     else
-      iter++;
+      ++iter;
   }
   lock_.unlock();
 }

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -776,24 +776,21 @@ bool GazeboRosApiPlugin::getModelState(gazebo_msgs::GetModelState::Request &req,
   }
   else
   {
-    /**
-     * @brief creates a header for the result
-     * @author Markus Bader markus.bader@tuwien.ac.at
-     * @date 21th Nov 2014
-     **/
+    // creates a header for the result
+    std::map<std::string, unsigned int>::iterator it = access_count_get_model_state_.find(req.model_name);
+    if(it == access_count_get_model_state_.end())
     {
-      std::map<std::string, unsigned int>::iterator it = access_count_get_model_state_.find(req.model_name);
-      if(it == access_count_get_model_state_.end()) {
-	access_count_get_model_state_.insert( std::pair<std::string, unsigned int>(req.model_name, 1) );
-	res.header.seq = 1;
-	
-      } else {
-	it->second++;
-	res.header.seq = it->second;
-      }
-      res.header.stamp = ros::Time::now();
-      res.header.frame_id = req.relative_entity_name; /// @brief this is a redundant information
+      access_count_get_model_state_.insert(std::pair<std::string, unsigned int>(req.model_name, 1) );
+      res.header.seq = 1;
+    } 
+    else 
+    {
+      it->second++;
+      res.header.seq = it->second;
     }
+    res.header.stamp = ros::Time::now();
+    res.header.frame_id = req.relative_entity_name; /// @brief this is a redundant information
+    
     // get model pose
     gazebo::math::Pose       model_pose = model->GetWorldPose();
     gazebo::math::Vector3    model_pos = model_pose.pos;

--- a/gazebo_ros/src/gazebo_ros_api_plugin.h
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.h
@@ -388,6 +388,9 @@ private:
 
   std::vector<GazeboRosApiPlugin::WrenchBodyJob*> wrench_body_jobs_;
   std::vector<GazeboRosApiPlugin::ForceJointJob*> force_joint_jobs_;
+  
+  /// \brief index counters to count the accesses on models via GetModelState
+  std::map<std::string, unsigned int> access_count_get_model_state_; 
 
 };
 }


### PR DESCRIPTION
Hi

I added a general header to the GetModelState.srv and some lines to the gazebo_ros_api_plugin.cpp which to get a actural time stamp to a model request.
I did this to fix the model state to the simlated time which is needed in many cases
I think my work would also be downward compatibel.

Greetings
Markus

PS.: I would suggest to do the same thing for the ModelStates.msg or ModelState.msg
