### PR TITLE
Added emergency stop support.

### DIFF
--- a/gazebo_ros_control/include/gazebo_ros_control/gazebo_ros_control_plugin.h
+++ b/gazebo_ros_control/include/gazebo_ros_control/gazebo_ros_control_plugin.h
@@ -119,6 +119,8 @@ protected:
   ros::Time last_update_sim_time_ros_;
   ros::Time last_write_sim_time_ros_;
 
+  bool e_stop_active_;  // True if the emergency stop is active.
+
 };
 
 

--- a/gazebo_ros_control/include/gazebo_ros_control/gazebo_ros_control_plugin.h
+++ b/gazebo_ros_control/include/gazebo_ros_control/gazebo_ros_control_plugin.h
@@ -46,6 +46,7 @@
 // ROS
 #include <ros/ros.h>
 #include <pluginlib/class_loader.h>
+#include <std_msgs/Bool.h>
 
 // Gazebo
 #include <gazebo/gazebo.hh>
@@ -82,6 +83,7 @@ public:
   bool parseTransmissionsFromURDF(const std::string& urdf_string);
 
 protected:
+  void eStopCB(const std_msgs::BoolConstPtr& e_stop_active);
 
   // Node Handles
   ros::NodeHandle model_nh_; // namespaces to robot name
@@ -119,7 +121,9 @@ protected:
   ros::Time last_update_sim_time_ros_;
   ros::Time last_write_sim_time_ros_;
 
-  bool e_stop_active_;  // True if the emergency stop is active.
+  // e_stop_active_ is true if the emergency stop is active.
+  bool e_stop_active_, last_e_stop_active_;
+  ros::Subscriber e_stop_sub_;  // Emergency stop subscriber
 
 };
 

--- a/gazebo_ros_control/include/gazebo_ros_control/robot_hw_sim.h
+++ b/gazebo_ros_control/include/gazebo_ros_control/robot_hw_sim.h
@@ -36,7 +36,7 @@
 
 /// \brief Plugin template for hardware interfaces for ros_control and Gazebo
 
-/// \author Jonathon Brohen
+/// \author Jonathan Bohren
 /// \author Dave Coleman
 
 #ifndef __ROS_CONTROL_GAZEBO_ROBOT_HW_SIM_H
@@ -76,7 +76,6 @@ namespace gazebo_ros_control {
     /// Initialize the simulated robot hardware.
     ///
     /// \param robot_namespace  Robot namespace.
-    /// \param sdf  SDF data.
     /// \param model_nh  Model node handle.
     /// \param parent_model  Parent model.
     /// \param urdf_model  URDF model.
@@ -85,7 +84,6 @@ namespace gazebo_ros_control {
     /// \return  \c true if the simulated robot hardware is initialized successfully, \c false if not.
     virtual bool initSim(
         const std::string& robot_namespace,
-        const sdf::ElementPtr sdf,
         ros::NodeHandle model_nh, 
         gazebo::physics::ModelPtr parent_model,
         const urdf::Model *const urdf_model,
@@ -107,13 +105,12 @@ namespace gazebo_ros_control {
     /// \param period  Time since the last simulation step.
     virtual void writeSim(ros::Time time, ros::Duration period) = 0;
 
-    /// \brief Return the emergency stop state
+    /// \brief Set the emergency stop state
     ///
-    /// Return the simulated robot's emergency stop state. The default implementation of this function returns
-    /// \c false.
+    /// Set the simulated robot's emergency stop state. The default implementation of this function does nothing.
     ///
-    /// \return  \c true if the emergency stop is active, \c false if not.
-    virtual bool eStopActive() {return false;}
+    /// \param active  \c true if the emergency stop is active, \c false if not.
+    virtual void eStopActive(const bool active) {}
 
   };
 

--- a/gazebo_ros_control/include/gazebo_ros_control/robot_hw_sim.h
+++ b/gazebo_ros_control/include/gazebo_ros_control/robot_hw_sim.h
@@ -34,10 +34,10 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* 
-   Author: Jonathon Brohen, Dave Coleman
-   Desc:   Plugin template for hardware interfaces for ros_control and Gazebo
-*/
+/// \brief Plugin template for hardware interfaces for ros_control and Gazebo
+
+/// \author Jonathon Brohen
+/// \author Dave Coleman
 
 #ifndef __ROS_CONTROL_GAZEBO_ROBOT_HW_SIM_H
 #define __ROS_CONTROL_GAZEBO_ROBOT_HW_SIM_H
@@ -62,23 +62,58 @@ namespace gazebo_ros_control {
     {}
   };
 
-  // Gazebo plugin version of RobotHW
+  /// \brief Gazebo plugin version of RobotHW
+  ///
+  /// An object of class RobotHWSim represents a robot's simulated hardware.
   class RobotHWSim : public hardware_interface::RobotHW 
   {
   public:
 
     virtual ~RobotHWSim() { }
 
+    /// \brief Initialize the simulated robot hardware
+    ///
+    /// Initialize the simulated robot hardware.
+    ///
+    /// \param robot_namespace  Robot namespace.
+    /// \param sdf  SDF data.
+    /// \param model_nh  Model node handle.
+    /// \param parent_model  Parent model.
+    /// \param urdf_model  URDF model.
+    /// \param transmissions  Transmissions.
+    ///
+    /// \return  \c true if the simulated robot hardware is initialized successfully, \c false if not.
     virtual bool initSim(
         const std::string& robot_namespace,
+        const sdf::ElementPtr sdf,
         ros::NodeHandle model_nh, 
         gazebo::physics::ModelPtr parent_model,
         const urdf::Model *const urdf_model,
         std::vector<transmission_interface::TransmissionInfo> transmissions) = 0;
 
+    /// \brief Read state data from the simulated robot hardware
+    ///
+    /// Read state data, such as joint positions and velocities, from the simulated robot hardware.
+    ///
+    /// \param time  Simulation time.
+    /// \param period  Time since the last simulation step.
     virtual void readSim(ros::Time time, ros::Duration period) = 0;
 
+    /// \brief Write commands to the simulated robot hardware
+    ///
+    /// Write commands, such as joint position and velocity commands, to the simulated robot hardware.
+    ///
+    /// \param time  Simulation time.
+    /// \param period  Time since the last simulation step.
     virtual void writeSim(ros::Time time, ros::Duration period) = 0;
+
+    /// \brief Return the emergency stop state
+    ///
+    /// Return the simulated robot's emergency stop state. The default implementation of this function returns
+    /// \c false.
+    ///
+    /// \return  \c true if the emergency stop is active, \c false if not.
+    virtual bool eStopActive() {return false;}
 
   };
 

--- a/gazebo_ros_control/src/default_robot_hw_sim.cpp
+++ b/gazebo_ros_control/src/default_robot_hw_sim.cpp
@@ -354,12 +354,12 @@ void DefaultRobotHWSim::eStopActive(const bool active)
 // retrieved from joint_limit_nh. If urdf_model is not NULL, limits are retrieved from it also.
 // Return the joint's type, lower position limit, upper position limit, and effort limit.
 void DefaultRobotHWSim::registerJointLimits(const std::string& joint_name,
-                           const hardware_interface::JointHandle& joint_handle,
-                           const ControlMethod ctrl_method,
-                           const ros::NodeHandle& joint_limit_nh,
-                           const urdf::Model *const urdf_model,
-                           int *const joint_type, double *const lower_limit,
-                           double *const upper_limit, double *const effort_limit)
+                         const hardware_interface::JointHandle& joint_handle,
+                         const ControlMethod ctrl_method,
+                         const ros::NodeHandle& joint_limit_nh,
+                         const urdf::Model *const urdf_model,
+                         int *const joint_type, double *const lower_limit,
+                         double *const upper_limit, double *const effort_limit)
 {
   *joint_type = urdf::Joint::UNKNOWN;
   *lower_limit = -std::numeric_limits<double>::max();

--- a/gazebo_ros_control/src/default_robot_hw_sim.cpp
+++ b/gazebo_ros_control/src/default_robot_hw_sim.cpp
@@ -90,7 +90,6 @@ public:
     const urdf::Model *const urdf_model,
     std::vector<transmission_interface::TransmissionInfo> transmissions)
   {
-    model_nh_ = model_nh;
     // getJointLimits() searches joint_limit_nh for joint limit parameters. The format of each
     // parameter's name is "joint_limits/<joint name>". An example is "joint_limits/axle_joint".
     const ros::NodeHandle joint_limit_nh(model_nh, robot_namespace);
@@ -504,7 +503,6 @@ private:
     }
   }
 
-  ros::NodeHandle model_nh_;
   unsigned int n_dof_;
 
   hardware_interface::JointStateInterface    js_interface_;

--- a/gazebo_ros_control/src/default_robot_hw_sim.cpp
+++ b/gazebo_ros_control/src/default_robot_hw_sim.cpp
@@ -350,13 +350,16 @@ void DefaultRobotHWSim::eStopActive(const bool active)
   e_stop_active_ = active;
 }
 
+// Register the limits of the joint specified by joint_name and joint_handle. The limits are
+// retrieved from joint_limit_nh. If urdf_model is not NULL, limits are retrieved from it also.
+// Return the joint's type, lower position limit, upper position limit, and effort limit.
 void DefaultRobotHWSim::registerJointLimits(const std::string& joint_name,
-                                            const hardware_interface::JointHandle& joint_handle,
-                                            const ControlMethod ctrl_method,
-                                            const ros::NodeHandle& joint_limit_nh,
-                                            const urdf::Model *const urdf_model,
-                                            int *const joint_type, double *const lower_limit,
-                                            double *const upper_limit, double *const effort_limit)
+                           const hardware_interface::JointHandle& joint_handle,
+                           const ControlMethod ctrl_method,
+                           const ros::NodeHandle& joint_limit_nh,
+                           const urdf::Model *const urdf_model,
+                           int *const joint_type, double *const lower_limit,
+                           double *const upper_limit, double *const effort_limit)
 {
   *joint_type = urdf::Joint::UNKNOWN;
   *lower_limit = -std::numeric_limits<double>::max();


### PR DESCRIPTION
I have added emergency stop support to the gazebo_ros_control and DefaultRobotHWSim plugins. gazebo_ros_control now resets the controllers when the robot's simulated hardware indicates that the emergency stop has been deactivated after being activated. DefaultRobotHWSim now subscribes to the Boolean topic specified by the eStopTopic SDF element. Messages received from the topic control the E-stop. When the E-stop is activated, the following occurs:
- If a joint's position is being controlled, DefaultRobotHWSim maintains the position the joint had when the E-stop was activated.
- If a joint's velocity is being controlled, the velocity is set to zero.
- If a joint's effort is being controlled, the effort is set to zero.
