### PR TITLE
gazebo_plugins: Adding ogre library dirs to cmakelists

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -65,6 +65,7 @@ include_directories(include
 
 link_directories(
   ${GAZEBO_LIBRARY_DIRS}
+  ${OGRE_LIBRARY_DIRS}
 )
 
 catkin_package(


### PR DESCRIPTION
fixes #269
