### PR TITLE
Added emergency stop support

### DIFF
--- a/gazebo_ros_control/include/gazebo_ros_control/default_robot_hw_sim.h
+++ b/gazebo_ros_control/include/gazebo_ros_control/default_robot_hw_sim.h
@@ -34,7 +34,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Dave Coleman, Johnathan Bohren
+/* Author: Dave Coleman, Jonathan Bohren
    Desc:   Hardware Interface for any simulated robot in Gazebo
 */
 
@@ -86,6 +86,8 @@ public:
 
   virtual void writeSim(ros::Time time, ros::Duration period);
 
+  virtual void eStopActive(const bool active);
+
 protected:
   // Methods used to control a joint.
   enum ControlMethod {EFFORT, POSITION, POSITION_PID, VELOCITY, VELOCITY_PID};
@@ -127,9 +129,13 @@ protected:
   std::vector<double> joint_effort_;
   std::vector<double> joint_effort_command_;
   std::vector<double> joint_position_command_;
+  std::vector<double> last_joint_position_command_;
   std::vector<double> joint_velocity_command_;
 
   std::vector<gazebo::physics::JointPtr> sim_joints_;
+
+  // e_stop_active_ is true if the emergency stop is active.
+  bool e_stop_active_, last_e_stop_active_;
 };
 
 typedef boost::shared_ptr<DefaultRobotHWSim> DefaultRobotHWSimPtr;

--- a/gazebo_ros_control/include/gazebo_ros_control/gazebo_ros_control_plugin.h
+++ b/gazebo_ros_control/include/gazebo_ros_control/gazebo_ros_control_plugin.h
@@ -46,6 +46,7 @@
 // ROS
 #include <ros/ros.h>
 #include <pluginlib/class_loader.h>
+#include <std_msgs/Bool.h>
 
 // Gazebo
 #include <gazebo/gazebo.hh>
@@ -82,6 +83,7 @@ public:
   bool parseTransmissionsFromURDF(const std::string& urdf_string);
 
 protected:
+  void eStopCB(const std_msgs::BoolConstPtr& e_stop_active);
 
   // Node Handles
   ros::NodeHandle model_nh_; // namespaces to robot name
@@ -118,6 +120,10 @@ protected:
   ros::Duration control_period_;
   ros::Time last_update_sim_time_ros_;
   ros::Time last_write_sim_time_ros_;
+
+  // e_stop_active_ is true if the emergency stop is active.
+  bool e_stop_active_, last_e_stop_active_;
+  ros::Subscriber e_stop_sub_;  // Emergency stop subscriber
 
 };
 

--- a/gazebo_ros_control/include/gazebo_ros_control/robot_hw_sim.h
+++ b/gazebo_ros_control/include/gazebo_ros_control/robot_hw_sim.h
@@ -34,10 +34,10 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* 
-   Author: Jonathon Brohen, Dave Coleman
-   Desc:   Plugin template for hardware interfaces for ros_control and Gazebo
-*/
+/// \brief Plugin template for hardware interfaces for ros_control and Gazebo
+
+/// \author Jonathan Bohren
+/// \author Dave Coleman
 
 #ifndef __ROS_CONTROL_GAZEBO_ROBOT_HW_SIM_H
 #define __ROS_CONTROL_GAZEBO_ROBOT_HW_SIM_H
@@ -62,13 +62,26 @@ namespace gazebo_ros_control {
     {}
   };
 
-  // Gazebo plugin version of RobotHW
+  /// \brief Gazebo plugin version of RobotHW
+  ///
+  /// An object of class RobotHWSim represents a robot's simulated hardware.
   class RobotHWSim : public hardware_interface::RobotHW 
   {
   public:
 
     virtual ~RobotHWSim() { }
 
+    /// \brief Initialize the simulated robot hardware
+    ///
+    /// Initialize the simulated robot hardware.
+    ///
+    /// \param robot_namespace  Robot namespace.
+    /// \param model_nh  Model node handle.
+    /// \param parent_model  Parent model.
+    /// \param urdf_model  URDF model.
+    /// \param transmissions  Transmissions.
+    ///
+    /// \return  \c true if the simulated robot hardware is initialized successfully, \c false if not.
     virtual bool initSim(
         const std::string& robot_namespace,
         ros::NodeHandle model_nh, 
@@ -76,9 +89,28 @@ namespace gazebo_ros_control {
         const urdf::Model *const urdf_model,
         std::vector<transmission_interface::TransmissionInfo> transmissions) = 0;
 
+    /// \brief Read state data from the simulated robot hardware
+    ///
+    /// Read state data, such as joint positions and velocities, from the simulated robot hardware.
+    ///
+    /// \param time  Simulation time.
+    /// \param period  Time since the last simulation step.
     virtual void readSim(ros::Time time, ros::Duration period) = 0;
 
+    /// \brief Write commands to the simulated robot hardware
+    ///
+    /// Write commands, such as joint position and velocity commands, to the simulated robot hardware.
+    ///
+    /// \param time  Simulation time.
+    /// \param period  Time since the last simulation step.
     virtual void writeSim(ros::Time time, ros::Duration period) = 0;
+
+    /// \brief Set the emergency stop state
+    ///
+    /// Set the simulated robot's emergency stop state. The default implementation of this function does nothing.
+    ///
+    /// \param active  \c true if the emergency stop is active, \c false if not.
+    virtual void eStopActive(const bool active) {}
 
   };
 


### PR DESCRIPTION
I have added emergency stop support to the gazebo_ros_control and DefaultRobotHWSim plugins. gazebo_ros_control now resets the controllers when the emergency stop has been deactivated after being activated. The eStopTopic SDF element defines the E-stop topic. Messages received from the topic control the E-stop. When the E-stop is activated, the following occurs:
- If a joint's position is being controlled, DefaultRobotHWSim maintains the position the joint had when the E-stop was activated.
- If a joint's velocity is being controlled, the velocity is set to zero.
- If a joint's effort is being controlled, the effort is set to zero.
