### PR TITLE
gazebo_ros_control: respect joint limits while measuring joint angle

### DIFF
--- a/gazebo_ros_control/src/default_robot_hw_sim.cpp
+++ b/gazebo_ros_control/src/default_robot_hw_sim.cpp
@@ -246,6 +246,16 @@ void DefaultRobotHWSim::readSim(ros::Time time, ros::Duration period)
     {
       joint_position_[j] = sim_joints_[j]->GetAngle(0).Radian();
     }
+    else if(joint_types_[j] == urdf::Joint::REVOLUTE)
+    {
+      double delta;
+      angles::shortest_angular_distance_with_limits(joint_position_[j],
+        sim_joints_[j]->GetAngle(0).Radian(),
+        joint_lower_limits_[j], joint_upper_limits_[j],
+        delta
+      );
+      joint_position_[j] += delta;
+    }
     else
     {
       joint_position_[j] += angles::shortest_angular_distance(joint_position_[j],


### PR DESCRIPTION
Previously, the logic used to reconstruct joint angles from
Gazebo measurements could end up with joint angles outside the limits.
For example, this occurs when setting joint angles with the
`set_model_configuration` service call.
Example:

lower limit: -2.792
upper limit: +2.792
argument to `set_model_configuration` call: -2.222
calculated joint angle: 4.061

This confuses the PID controllers from `ros_controllers`.

Now, use `angles::shortest_angular_distance_with_limits()`
for revolute joints to calculate a delta which results in an angle
inside our limits.
