### PR TITLE
add PointCloudCutoffMax

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_openni_kinect.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_openni_kinect.h
@@ -115,7 +115,10 @@ namespace gazebo
     private: sensor_msgs::PointCloud2 point_cloud_msg_;
     private: sensor_msgs::Image depth_image_msg_;
 
+    /// \brief Minimum range of the point cloud
     private: double point_cloud_cutoff_;
+    /// \brief Maximum range of the point cloud
+    private: double point_cloud_cutoff_max_;
 
     /// \brief ROS image topic name
     private: std::string point_cloud_topic_name_;


### PR DESCRIPTION
This adds a parameter "PointCloudCutoffMax" which allows one to set the clipping plane of the camera to a much longer distance (so that you still get RGB data), but only get depth data where it would be expected on the real device.

In addition, I moved the tan() calculations inside the if() statement so that we don't compute them and just throw them away in the case of depth being out of range.
