### PR TITLE
[gazebo_ros_diff_drive] force call SetMaxForce

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_diff_drive.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_diff_drive.h
@@ -81,6 +81,7 @@ namespace gazebo {
       GazeboRosDiffDrive();
       ~GazeboRosDiffDrive();
       void Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf);
+      void Reset();
 
     protected:
       virtual void UpdateChild();


### PR DESCRIPTION
Since this Joint::Reset in gazebo/physics/Joint.cc reset MaxForce to zero and ModelPlugin::Reset is called after Joint::Reset at gazebo2,

this will solve problem such as http://answers.ros.org/question/114931/differential-drive-ros-plugin-stops-responding-after-reset_simulation-or-reset_world/
and partially, https://github.com/ros-simulation/gazebo_ros_pkgs/issues/169
