### PR TITLE
hog: making only the hand of god link zero-g. 

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_hand_of_god.cpp
+++ b/gazebo_plugins/src/gazebo_ros_hand_of_god.cpp
@@ -102,11 +102,10 @@ namespace gazebo
     // Store the model
     model_ = _parent;
 
-    // Disable gravity for the hog
-    model_->SetGravityMode(false);
-
     // Get the floating link
     floating_link_ = model_->GetLink(link_name_);
+    // Disable gravity for the hog
+    floating_link_->SetGravityMode(false);
     if(!floating_link_) {
       ROS_ERROR("Floating link not found!");
       const std::vector<physics::LinkPtr> &links = model_->GetLinks();


### PR DESCRIPTION
this lets you use the hand of god on a single link in a gravity-affected model
