### PR TITLE
Set GAZEBO_CXX_FLAGS to fix c++11 compilation errors

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -71,6 +71,7 @@ link_directories(
   ${OGRE-Terrain_LIBRARY_DIRS}
   ${OGRE-Paging_LIBRARY_DIRS}
 )
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
 
 catkin_package(
   INCLUDE_DIRS include

--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -66,6 +66,8 @@ foreach (item ${GAZEBO_LDFLAGS})
   set(ld_flags "${ld_flags} ${item}")
 endforeach ()
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
+
 ## Plugins
 add_library(gazebo_ros_api_plugin src/gazebo_ros_api_plugin.cpp)
 add_dependencies(gazebo_ros_api_plugin gazebo_msgs_gencpp ${PROJECT_NAME}_gencfg) # wait for gazebo_msgs to be built

--- a/gazebo_ros_control/CMakeLists.txt
+++ b/gazebo_ros_control/CMakeLists.txt
@@ -35,6 +35,7 @@ include_directories(include
   ${catkin_INCLUDE_DIRS}
   ${GAZEBO_INCLUDE_DIRS}
 )
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
 
 ## Libraries
 add_library(${PROJECT_NAME} src/gazebo_ros_control_plugin.cpp)


### PR DESCRIPTION
sdformat version 3 uses c++11 features in its header files. The necessary compiler flags are exported in `GAZEBO_CXX_FLAGS`, and these must be set in order to avoid compiler errors. This is most relevant for gazebo6.

See the following:
- [gazebo pull request 1573](https://bitbucket.org/osrf/gazebo/pull-request/1573/use-flags-in-example-code-cmakeliststxt/diff)
- [sdformat pull request 172](https://bitbucket.org/osrf/sdformat/pull-request/172/add-std-c-11-flag-to-sdf_configcmakein-and/diff)
