### PR TITLE
gazebo_plugins: Also accept "/world" for the frameName parameter in gazebo_ros_p3d plugin

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -156,9 +156,10 @@ void GazeboRosP3D::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf)
   this->apos_ = 0;
   this->aeul_ = 0;
 
-  // if frameName specified is "world", "/map" or "map" report
+  // if frameName specified is "/world", "world", "/map" or "map" report
   // back inertial values in the gazebo world
-  if (this->frame_name_ != "world" &&
+  if (this->frame_name_ != "/world" &&
+      this->frame_name_ != "world" &&
       this->frame_name_ != "/map" &&
       this->frame_name_ != "map")
   {


### PR DESCRIPTION
We are using the gazebo_ros_p3d plugin in a multi robot environment with [hector_quadrotor](https://github.com/tu-darmstadt-ros-pkg/hector_quadrotor), where every spawned robot should have its own ROS namespace and tf_prefix. The plugin is expected to publish each robot's ground truth pose on topic `/<namespace>/ground_truth/state`, with the frame_id in the header set to `/world`.

Without this patch this is impossible to achieve (or only with ugly workarounds), because either the `frameName` plugin parameter has to be set to `"/world"` and the plugin prints the

```
frameName: /world does not exist, will not publish pose
```

error message during initialization, or `frameName` is set to `"world"` (without the `/`) and the tf resolution in [gazebo_ros_p3d.cpp:143](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/42061adea4f55ed295256055503bff7d4293a02d/gazebo_plugins/src/gazebo_ros_p3d.cpp#L143) resolves this to `"<tf_prefix>/world"` for the header.

Launch file (snippet):

``` xml
<launch>
  <arg name="name" default="quadrotor"/>
  <arg name="model" default="$(find hector_quadrotor_description)/urdf/quadrotor.gazebo.xacro"/>
  <arg name="tf_prefix" default="$(optenv ROS_NAMESPACE)"/>

  <arg name="x" default="0.0"/>
  <arg name="y" default="0.0"/>
  <arg name="z" default="0.3"/>

  <arg name="world_frame" default="/world"/>
  <arg name="base_link_frame" default="$(arg tf_prefix)/base_link"/>

  <!-- send the robot XML to param server -->
  <param name="tf_prefix" type="string" value="$(arg tf_prefix)" />
  <param name="robot_description" command="$(find xacro)/xacro.py '$(arg model)' base_link_frame:=$(arg base_link_frame) world_frame:=$(arg world_frame)" />

  <!-- push robot_description to factory and spawn robot in gazebo -->
  <node name="spawn_robot" pkg="gazebo_ros" type="spawn_model"
        args="-param robot_description
           -urdf
           -x $(arg x)
           -y $(arg y)
           -z $(arg z)
           -model $(arg name)"
        respawn="false" output="screen"/>

  <!--  ... -->
</launch>
```

Robot model (snippet):

``` xml
<robot xmlns:xacro="http://ros.org/wiki/xacro">

  <arg name="world_frame" default="/world"/>
  <arg name="base_link_frame" default="base_link"/>

  <!--  ... -->

  <plugin name="quadrotor_groundtruth_sim" filename="libgazebo_ros_p3d.so">
    <updateRate>100.0</updateRate>
    <bodyName>base_link</bodyName>
    <topicName>ground_truth/state</topicName>
    <gaussianNoise>0.0</gaussianNoise>
    <frameName>$(arg world_frame)</frameName>
  </plugin>
</robot>
```
