### PR TITLE
plugins: Fixing race condition that prevents stereo cameras from broadcasting

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -258,6 +258,10 @@ event::ConnectionPtr GazeboRosCameraUtils::OnLoad(const boost::function<void()>&
 // Load the controller
 void GazeboRosCameraUtils::LoadThread()
 {
+  // Synchronize loading for multicamera setup, without this, not all transport
+  // topics may be advertised. This might be due to a bug in image_transport
+  boost::mutex::scoped_lock lock(*this->image_connect_count_lock_);
+
   // Exit if no ROS
   if (!ros::isInitialized())
   {


### PR DESCRIPTION
Related to https://github.com/ros-simulation/gazebo_ros_pkgs/pull/17

It appears that if both of these image transport publishers are created at the same time, they won't be able to load the same transport plugins. This is probably due to a bug in `image_transport` itself.
