### PR TITLE
ros_api_plugin: Throttle clock message to 100Hz by default, make it parameterizable by a rosparam

### DIFF
--- a/gazebo_ros/src/gazebo_ros_api_plugin.h
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.h
@@ -294,8 +294,15 @@ private:
   bool plugin_loaded_;
 
   // detect if sigint event occurs
-  bool stop_; 
+  bool stop_;
   gazebo::event::ConnectionPtr sigint_event_;
+
+  // \brief last published ROS simulation time
+  rosgraph_msgs::Clock ros_time_;
+
+  // \brief target rate for publishing ROS simulation time (in Hz)
+  double ros_time_publish_rate_;
+
 
   std::string robot_namespace_;
 


### PR DESCRIPTION
By default, if running gazebo with a 1Khz update rate, the gazebo ROS API plugin will attempt to publish the simulation time to the `/clock` topic at that rate. This means that Gazebo opens one TCP socket for _each_ ROS node, and tries to publish `/clock` messages at 1KHz to each node. This leads to a serious resource waste across an entire ROS system.

This PR throttles that publication to 100Hz by default, and makes it configurable with the ROS parameter `/sim_time_rate`.

When publishing at 100Hz, this has the following effects (on an Intel Xeon E5-1650 workstation):
- Gazebo itself uses 50% less CPU time 
- All trivial or idle python processes consume 1% CPU time instead of a minimum of 10% CPU time

This bug is related to: http://answers.ros.org/question/29425/rospy-horrible-performance-with-sim_time/?answer=29456#post-id-29456
