### PR TITLE
run_depend on libgazebo5-dev (#323)

### DIFF
--- a/gazebo_plugins/package.xml
+++ b/gazebo_plugins/package.xml
@@ -45,6 +45,10 @@
   <run_depend>gazebo_msgs</run_depend>
   <run_depend>gazebo_ros</run_depend>
   <run_depend>geometry_msgs</run_depend>
+  <!--
+    Need to use libgazebo5-dev since run script needs pkg-config
+    See: https://github.com/ros-simulation/gazebo_ros_pkgs/issues/323 for more info
+  -->
   <run_depend>libgazebo5-dev</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>trajectory_msgs</run_depend>

--- a/gazebo_plugins/package.xml
+++ b/gazebo_plugins/package.xml
@@ -42,10 +42,10 @@
   <build_depend>diagnostic_updater</build_depend>
   <build_depend>camera_info_manager</build_depend>
 
-  <run_depend>gazebo5</run_depend>
   <run_depend>gazebo_msgs</run_depend>
   <run_depend>gazebo_ros</run_depend>
   <run_depend>geometry_msgs</run_depend>
+  <run_depend>libgazebo5-dev</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>trajectory_msgs</run_depend>
   <run_depend>std_srvs</run_depend>

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -38,6 +38,10 @@
   <build_depend>tinyxml</build_depend>
 
   <run_depend>gazebo_msgs</run_depend>
+  <!--
+    Need to use libgazebo5-dev since run script needs pkg-config
+    See: https://github.com/ros-simulation/gazebo_ros_pkgs/issues/323 for more info
+  -->
   <run_depend>libgazebo5-dev</run_depend>
   <run_depend>roslib</run_depend>
   <run_depend>roscpp</run_depend>

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -37,8 +37,8 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>tinyxml</build_depend>
 
-  <run_depend>gazebo5</run_depend>
   <run_depend>gazebo_msgs</run_depend>
+  <run_depend>libgazebo5-dev</run_depend>
   <run_depend>roslib</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>tf</run_depend>

--- a/gazebo_ros_control/package.xml
+++ b/gazebo_ros_control/package.xml
@@ -28,8 +28,8 @@
   <build_depend>angles</build_depend>
 
   <run_depend>roscpp</run_depend>
-  <run_depend>gazebo5</run_depend>
   <run_depend>gazebo_ros</run_depend>
+  <run_depend>libgazebo5-dev</run_depend>
   <run_depend>control_toolbox</run_depend>
   <run_depend>controller_manager</run_depend>
   <run_depend>pluginlib</run_depend>

--- a/gazebo_ros_control/package.xml
+++ b/gazebo_ros_control/package.xml
@@ -29,6 +29,10 @@
 
   <run_depend>roscpp</run_depend>
   <run_depend>gazebo_ros</run_depend>
+  <!--
+    Need to use libgazebo5-dev since run script needs pkg-config
+    See: https://github.com/ros-simulation/gazebo_ros_pkgs/issues/323 for more info
+  -->
   <run_depend>libgazebo5-dev</run_depend>
   <run_depend>control_toolbox</run_depend>
   <run_depend>controller_manager</run_depend>


### PR DESCRIPTION
Declare the dependency.
It can be fixed later if we don't want it.
Fixes #323.
