### PR TITLE
[gazebo_ros_control] add missing dependencies

### DIFF
--- a/gazebo_ros_control/CMakeLists.txt
+++ b/gazebo_ros_control/CMakeLists.txt
@@ -4,6 +4,7 @@ project(gazebo_ros_control)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS
   roscpp
+  std_msgs
   control_toolbox
   controller_manager
   hardware_interface 
@@ -20,10 +21,15 @@ find_package(gazebo REQUIRED)
 catkin_package(
   CATKIN_DEPENDS
     roscpp
+    std_msgs
     controller_manager
+    control_toolbox
     pluginlib
+    hardware_interface
     transmission_interface
+    joint_limits_interface
     urdf
+    angles
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME} default_robot_hw_sim
   DEPENDS gazebo

--- a/gazebo_ros_control/package.xml
+++ b/gazebo_ros_control/package.xml
@@ -18,22 +18,27 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>roscpp</build_depend> 
+  <build_depend>std_msgs</build_depend>
   <build_depend>gazebo</build_depend>
   <build_depend>control_toolbox</build_depend> 
   <build_depend>controller_manager</build_depend> 
   <build_depend>pluginlib</build_depend> 
+  <build_depend>hardware_interface</build_depend>
   <build_depend>transmission_interface</build_depend> 
   <build_depend>joint_limits_interface</build_depend>
   <build_depend>urdf</build_depend>
   <build_depend>angles</build_depend>
   
   <run_depend>roscpp</run_depend>
+  <run_depend>std_msgs</run_depend>
   <run_depend>gazebo</run_depend>
   <run_depend>gazebo_ros</run_depend> 
   <run_depend>control_toolbox</run_depend> 
   <run_depend>controller_manager</run_depend> 
   <run_depend>pluginlib</run_depend> 
+  <run_depend>hardware_interface</run_depend>
   <run_depend>transmission_interface</run_depend> 
+  <run_depend>joint_limits_interface</run_depend>
   <run_depend>urdf</run_depend>
   <run_depend>angles</run_depend>
 


### PR DESCRIPTION
When reviewing the dependency of our own [gazebo_ros_control plugin](https://github.com/ipa320/cob_gazebo_plugins) (providing hardware_interface switching functionality), we were facing build farm complaints about headers not being found (full [protocol](http://jenkins.ros.org/job/devel-indigo-cob_gazebo_plugins/ARCH_PARAM=amd64,UBUNTU_PARAM=trusty,label=devel/6/console))

> Scanning dependencies of target hwi_switch_robot_hw_sim
> [ 50%] Building CXX object cob_gazebo_plugins/cob_gazebo_ros_control/CMakeFiles/hwi_switch_robot_hw_sim.dir/src/hwi_switch_robot_hw_sim.cpp.o
> In file included from /tmp/test_repositories/src_repository/cob_gazebo_plugins/cob_gazebo_ros_control/include/cob_gazebo_ros_control/hwi_switch_robot_hw_sim.h:47:0,
>                  from /tmp/test_repositories/src_repository/cob_gazebo_plugins/cob_gazebo_ros_control/src/hwi_switch_robot_hw_sim.cpp:44:
> /opt/ros/indigo/include/gazebo_ros_control/default_robot_hw_sim.h:48:49: fatal error: joint_limits_interface/joint_limits.h: No such file or directory
>  #include <joint_limits_interface/joint_limits.h>
>                                                  ^
> compilation terminated.

For now, I fixed it, by adding a dependency to `joint_limits_interface` to our own package (see https://github.com/ipa320/cob_gazebo_plugins/pull/9).
However, this dependency is introduced by `#include <joint_limits_interface/joint_limits.h>` in `gazebo_ros_control/default_robot_hw_sim.h` (see [here](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/indigo-devel/gazebo_ros_control/include/gazebo_ros_control/default_robot_hw_sim.h#L48-L51)). And `joint_limits_interface` is nowhere else included in our own package.
From my (newly gained) understanding about transitive dependencies in `catkin_package` and `CATKIN_DEPENDS`, it seems that there are some dependencies missing in `gazebo_ros_control`.

This PR fixes it.
