### PR TITLE
Add rostest to accompany range plugin world

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
   - cd ~/ros/ws_$REPOSITORY_NAME
   - catkin build -j4 --verbose --summary
   # Run tests
-  - catkin run_tests
+  - catkin run_tests -j1 # have to run only 1 test at a time to ensure no gazebo instances collide
   # catkin run_tests always returns 0, use catkin_test_results to check for errors
   # https://github.com/catkin/catkin_tools/issues/245
   - catkin_test_results

--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -342,5 +342,6 @@ if (CATKIN_ENABLE_TESTING)
   add_rostest_gtest(set_model_state-test
                     test/set_model_state_test/set_model_state_test.test 
                     test/set_model_state_test/set_model_state_test.cpp)
+  add_rostest(test/range/range_plugin.test)
   target_link_libraries(set_model_state-test ${catkin_LIBRARIES})
 endif()

--- a/gazebo_plugins/package.xml
+++ b/gazebo_plugins/package.xml
@@ -69,4 +69,8 @@
   <run_depend>camera_info_manager</run_depend>
   <run_depend>std_msgs</run_depend>
 
+  <!-- When moved to format 2, this can be turned test_depend -->
+  <build_depend>rostest</build_depend>
+  <run_depend>rostest</run_depend>
+
 </package>

--- a/gazebo_plugins/scripts/test_range.py
+++ b/gazebo_plugins/scripts/test_range.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+import rospy
+from sensor_msgs.msg import Range
+
+import unittest
+
+class TestRangePlugin(unittest.TestCase):
+
+  def test_max_range(self):
+    msg = rospy.wait_for_message('/sonar2', Range)
+    self.assertAlmostEqual(msg.range, msg.max_range)
+
+  def test_inside_range(self):
+    msg = rospy.wait_for_message('/sonar', Range)
+    self.assertTrue(msg.range < 0.25 and msg.range > 0.22)
+
+if __name__ == '__main__':
+  import rostest
+  PKG_NAME = 'gazebo_plugins'
+  TEST_NAME = PKG_NAME + 'range_test'
+  rospy.init_node(TEST_NAME)
+  rostest.rosrun(PKG_NAME, TEST_NAME, TestRangePlugin)

--- a/gazebo_plugins/test/range/range_plugin.test
+++ b/gazebo_plugins/test/range/range_plugin.test
@@ -1,6 +1,8 @@
 <?xml version="1.0" ?>
 <launch>
 
+  <env name="GAZEBO_PLUGIN_PATH" value="$(find gazebo_plugins)/../../../devel/lib"/>
+
   <include file="$(find gazebo_ros)/launch/range_world.launch">
     <arg name="gui" value="false"/>
   </include>

--- a/gazebo_plugins/test/range/range_plugin.test
+++ b/gazebo_plugins/test/range/range_plugin.test
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<launch>
+
+  <include file="$(find gazebo_ros)/launch/range_world.launch">
+    <arg name="gui" value="false"/>
+  </include>
+
+  <test pkg="gazebo_plugins" type="test_range.py" test-name="test_range_plugin"/>
+
+</launch>

--- a/gazebo_ros/launch/range_world.launch
+++ b/gazebo_ros/launch/range_world.launch
@@ -6,7 +6,6 @@
   <arg name="use_sim_time" default="true"/>
   <arg name="extra_gazebo_args" default=""/>
   <arg name="gui" default="true"/>
-  <arg name="headless" default="false"/>
   <arg name="debug" default="false"/>
   <arg name="physics" default="ode"/>
   <arg name="verbose" default="true"/>


### PR DESCRIPTION
I wrote this yesterday on the airplane. I am able to run the test individually, but when I ran `catkin_make run_tests` it failed on the set model test. It seems that the tests are launched all at once, so it attempts to spawn several gazebo instances which conflict with each other.

Take a look and let me know what do you think. The organization of files could be better, maybe there is time for a general reorganization so similar tests can be made for the other plugins as well.
