### PR TITLE
Minor: Added a missing variable initialization inside Differential Drive

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
@@ -127,6 +127,10 @@ void GazeboRosDiffDrive::Load ( physics::ModelPtr _parent, sdf::ElementPtr _sdf 
     wheel_speed_[RIGHT] = 0;
     wheel_speed_[LEFT] = 0;
 
+    // Initialize velocity support stuff
+    wheel_speed_instr_[RIGHT] = 0;
+    wheel_speed_instr_[LEFT] = 0;
+
     x_ = 0;
     rot_ = 0;
     alive_ = true;


### PR DESCRIPTION
A variable inside the differential drive plugin was not initialized to zero in the constructor, this caused random speeds when spawning more than one differential drive plugin into gazebo (e.g. more than one iRobot Create).
In order to reply the error, add multiple robots that use a differential drive, and send them a cmd_vel with x>0.
Searching the code for the variable wheel_speed_instr_ will show that it was used and modified but never set (lines 275 and below), so even with a single robot the error could happen.
