### PR TITLE
[gazebo_ros] fixes #361

### DIFF
--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -577,7 +577,7 @@ bool GazeboRosApiPlugin::spawnURDFModel(gazebo_msgs::SpawnModel::Request &req,
       ROS_DEBUG_ONCE("Package name [%s] has path [%s]", package_name.c_str(), package_path.c_str());
 
       model_xml.replace(pos1,(pos2-pos1),package_path);
-      pos1 = model_xml.find(package_prefix,0);
+      pos1 = model_xml.find(package_prefix, pos1);
     }
   }
   // ROS_DEBUG("Model XML\n\n%s\n\n ",model_xml.c_str());


### PR DESCRIPTION
Implemented a dictionary of resolved package path in the URDF spawner to speed up the process.
Also not starting all over finding new occurrences of package:// as suggested by @rhaschke

Not starting all over did not improve significantly the time, but the dictionary improved spawning from 15.5 sec down to 2.7 sec on our file and reduced loading time of the bare shadow hand (without 200 tactile elements) by more than 7 seconds.
