### PR TITLE
[gazebo_ros] Fix invalid signal name on OS X for script/gazebo

### DIFF
--- a/gazebo_ros/scripts/gazebo
+++ b/gazebo_ros/scripts/gazebo
@@ -2,8 +2,10 @@
 final="$@"
 
 EXT=so
+SIGNAL=SIGINT
 if [ $(uname) = "Darwin" ]; then
     EXT=dylib
+    SIGNAL=INT
 fi
 
 # add ros path plugin if it does not already exist in the passed in arguments
@@ -27,4 +29,4 @@ gzserver $final &
 gzclient $client_final
 
 # Kill the server
-kill -s SIGINT $!
+kill -s $SIGNAL $!


### PR DESCRIPTION
Fixes the following error on OS X

```
scripts/gazebo: line 30: kill: SIGINT: invalid signal specification
```

by feeding system-dependent argument to `kill` command. On OS X it is `kill -s INT` instead of `kill -s SIGINT`.
