### PR TITLE
[gazebo_plugins] Add vacuum gripper plugin

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -109,6 +109,7 @@ catkin_package(
   gazebo_ros_skid_steer_drive
   gazebo_ros_video
   gazebo_ros_planar_move
+  gazebo_ros_vacuum_gripper
   
   CATKIN_DEPENDS 
   message_generation 
@@ -265,6 +266,9 @@ target_link_libraries(gazebo_ros_ft_sensor ${GAZEBO_LIBRARIES} ${catkin_LIBRARIE
 add_library(gazebo_ros_range src/gazebo_ros_range.cpp)
 target_link_libraries(gazebo_ros_range ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES} RayPlugin)
 
+add_library(gazebo_ros_vacuum_gripper src/gazebo_ros_vacuum_gripper.cpp)
+target_link_libraries(gazebo_ros_vacuum_gripper ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
 ##
 ## Add your new plugin here
 ##
@@ -305,6 +309,7 @@ install(TARGETS
   gazebo_ros_skid_steer_drive
   gazebo_ros_video
   gazebo_ros_planar_move
+  gazebo_ros_vacuum_gripper
   pub_joint_trajectory_test  
   gazebo_ros_gpu_laser
   gazebo_ros_range

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_vacuum_gripper.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_vacuum_gripper.h
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2012-2014 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+/*
+   Desc: GazeboVacuumGripper plugin for manipulating objects in Gazebo
+ * Author: Kentaro Wada
+ * Date: 7 Dec 2015
+ */
+
+#ifndef GAZEBO_ROS_VACUUM_GRIPPER_HH
+#define GAZEBO_ROS_VACUUM_GRIPPER_HH
+
+#include <string>
+
+// Custom Callback Queue
+#include <ros/callback_queue.h>
+#include <ros/advertise_options.h>
+#include <ros/advertise_service_options.h>
+#include <std_srvs/Empty.h>
+
+#include <ros/ros.h>
+#include <boost/thread.hpp>
+#include <boost/thread/mutex.hpp>
+
+#include <gazebo/physics/physics.hh>
+#include <gazebo/transport/TransportTypes.hh>
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/common/Events.hh>
+
+
+namespace gazebo
+{
+/// @addtogroup gazebo_dynamic_plugins Gazebo ROS Dynamic Plugins
+/// @{
+/** \defgroup GazeboRosVacuumGripper Plugin XML Reference and Example
+
+  \brief Ros Vacuum Gripper Plugin.
+
+  This is a Plugin that collects data from a ROS topic and applies wrench to a body accordingly.
+
+  Example Usage:
+    - left_end_effector will be the power point
+    - revolute type joint is necessary (fixed joint disappears on gazebo and plugin can't find the joint and link)
+  \verbatim
+    <link name="left_end_effector">
+      <gravity>0</gravity>
+      <visual>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <geometry>
+          <box size="0.01 0.01 0.01"/>
+        </geometry>
+        <material name="transparent">
+          <color rgba="0 0 0 0"/>
+        </material>
+      </visual>
+      <inertial>
+        <origin rpy="0 0 0" xyz="0.000000 0.000000 0.000000"/>
+        <mass value="0.0001"/>
+        <inertia ixx="1e-08" ixy="0" ixz="0" iyy="1e-08" iyz="0" izz="1e-08"/>
+      </inertial>
+    </link>
+    <joint name="left_end_joint" type="revolute">
+      <parent link="left_wrist" />
+      <child link="left_end_effector" />
+      <origin rpy="0 0 0" xyz="0.08 0 .44" />
+      <limit effort="30" velocity="1.0" lower="0" upper="0" />
+    </joint>
+    <gazebo>
+      <plugin name="gazebo_ros_vacuum_gripper" filename="libgazebo_ros_vacuum_gripper.so">
+        <robotNamespace>/robot/left_vacuum_gripper</robotNamespace>
+        <bodyName>left_end_effector</bodyName>
+        <topicName>grasping</topicName>
+      </plugin>
+    </gazebo>
+  \endverbatim
+
+
+\{
+*/
+
+
+class GazeboRosVacuumGripper : public ModelPlugin
+{
+  /// \brief Constructor
+  public: GazeboRosVacuumGripper();
+
+  /// \brief Destructor
+  public: virtual ~GazeboRosVacuumGripper();
+
+  // Documentation inherited
+  protected: void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
+
+  // Documentation inherited
+  protected: virtual void UpdateChild();
+
+  /// \brief The custom callback queue thread function.
+  private: void QueueThread();
+
+  private: bool OnServiceCallback(std_srvs::Empty::Request &req,
+                                std_srvs::Empty::Response &res);
+  private: bool OffServiceCallback(std_srvs::Empty::Request &req,
+                                std_srvs::Empty::Response &res);
+
+  private: bool status_;
+
+  private: physics::ModelPtr parent_;
+
+  /// \brief A pointer to the gazebo world.
+  private: physics::WorldPtr world_;
+
+  /// \brief A pointer to the Link, where force is applied
+  private: physics::LinkPtr link_;
+
+  /// \brief A pointer to the ROS node.  A node will be instantiated if it does not exist.
+  private: ros::NodeHandle* rosnode_;
+
+  /// \brief A mutex to lock access to fields that are used in ROS message callbacks
+  private: boost::mutex lock_;
+  private: ros::Publisher pub_;
+  private: ros::ServiceServer srv1_;
+  private: ros::ServiceServer srv2_;
+
+  /// \brief ROS Wrench topic name inputs
+  private: std::string topic_name_;
+  private: std::string service_name_;
+  /// \brief The Link this plugin is attached to, and will exert forces on.
+  private: std::string link_name_;
+
+  /// \brief for setting ROS name space
+  private: std::string robot_namespace_;
+
+  // Custom Callback Queue
+  private: ros::CallbackQueue queue_;
+  /// \brief Thead object for the running callback Thread.
+  private: boost::thread callback_queue_thread_;
+
+  // Pointer to the update event connection
+  private: event::ConnectionPtr update_connection_;
+
+  /// \brief: keep track of number of connections
+  private: int connect_count_;
+  private: void Connect();
+  private: void Disconnect();
+};
+/** \} */
+/// @}
+}
+#endif

--- a/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2015 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+/*
+   Desc: GazeboVacuumGripper plugin for manipulating objects in Gazebo
+   Author: Kentaro Wada
+   Date: 7 Dec 2015
+ */
+
+#include <algorithm>
+#include <assert.h>
+
+#include <std_msgs/Bool.h>
+#include <gazebo_plugins/gazebo_ros_vacuum_gripper.h>
+
+
+namespace gazebo
+{
+GZ_REGISTER_MODEL_PLUGIN(GazeboRosVacuumGripper);
+
+////////////////////////////////////////////////////////////////////////////////
+// Constructor
+GazeboRosVacuumGripper::GazeboRosVacuumGripper()
+{
+  connect_count_ = 0;
+  status_ = false;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Destructor
+GazeboRosVacuumGripper::~GazeboRosVacuumGripper()
+{
+  event::Events::DisconnectWorldUpdateBegin(update_connection_);
+
+  // Custom Callback Queue
+  queue_.clear();
+  queue_.disable();
+  rosnode_->shutdown();
+  callback_queue_thread_.join();
+
+  delete rosnode_;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Load the controller
+void GazeboRosVacuumGripper::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
+{
+  ROS_INFO("Loading gazebo_ros_vacuum_gripper");
+
+  // Set attached model;
+  parent_ = _model;
+
+  // Get the world name.
+  world_ = _model->GetWorld();
+
+  // load parameters
+  robot_namespace_ = "";
+  if (_sdf->HasElement("robotNamespace"))
+    robot_namespace_ = _sdf->GetElement("robotNamespace")->Get<std::string>() + "/";
+
+  if (!_sdf->HasElement("bodyName"))
+  {
+    ROS_FATAL("vacuum_gripper plugin missing <bodyName>, cannot proceed");
+    return;
+  }
+  else
+    link_name_ = _sdf->GetElement("bodyName")->Get<std::string>();
+
+  link_ = _model->GetLink(link_name_);
+  if (!link_)
+  {
+    std::string found;
+    physics::Link_V links = _model->GetLinks();
+    for (size_t i = 0; i < links.size(); i++) {
+      found += std::string(" ") + links[i]->GetName();
+    }
+    ROS_FATAL("gazebo_ros_vacuum_gripper plugin error: link named: %s does not exist", link_name_.c_str());
+    ROS_FATAL("gazebo_ros_vacuum_gripper plugin error: You should check it exists and is not connected with fixed joint");
+    ROS_FATAL("gazebo_ros_vacuum_gripper plugin error: Found links are: %s", found.c_str());
+    return;
+  }
+
+  if (!_sdf->HasElement("topicName"))
+  {
+    ROS_FATAL("vacuum_gripper plugin missing <serviceName>, cannot proceed");
+    return;
+  }
+  else
+    topic_name_ = _sdf->GetElement("topicName")->Get<std::string>();
+
+  // Make sure the ROS node for Gazebo has already been initialized
+  if (!ros::isInitialized())
+  {
+    ROS_FATAL_STREAM("A ROS node for Gazebo has not been initialized, unable to load plugin. "
+      << "Load the Gazebo system plugin 'libgazebo_ros_api_plugin.so' in the gazebo_ros package)");
+    return;
+  }
+
+  rosnode_ = new ros::NodeHandle(robot_namespace_);
+
+  // Custom Callback Queue
+  ros::AdvertiseOptions ao = ros::AdvertiseOptions::create<std_msgs::Bool>(
+    topic_name_, 1,
+    boost::bind(&GazeboRosVacuumGripper::Connect, this),
+    boost::bind(&GazeboRosVacuumGripper::Disconnect, this),
+    ros::VoidPtr(), &queue_);
+  pub_ = rosnode_->advertise(ao);
+
+  // Custom Callback Queue
+  ros::AdvertiseServiceOptions aso1 =
+    ros::AdvertiseServiceOptions::create<std_srvs::Empty>(
+    "on", boost::bind(&GazeboRosVacuumGripper::OnServiceCallback,
+    this, _1, _2), ros::VoidPtr(), &queue_);
+  srv1_ = rosnode_->advertiseService(aso1);
+  ros::AdvertiseServiceOptions aso2 =
+    ros::AdvertiseServiceOptions::create<std_srvs::Empty>(
+    "off", boost::bind(&GazeboRosVacuumGripper::OffServiceCallback,
+    this, _1, _2), ros::VoidPtr(), &queue_);
+  srv2_ = rosnode_->advertiseService(aso2);
+
+  // Custom Callback Queue
+  callback_queue_thread_ = boost::thread( boost::bind( &GazeboRosVacuumGripper::QueueThread,this ) );
+
+  // New Mechanism for Updating every World Cycle
+  // Listen to the update event. This event is broadcast every
+  // simulation iteration.
+  update_connection_ = event::Events::ConnectWorldUpdateBegin(
+      boost::bind(&GazeboRosVacuumGripper::UpdateChild, this));
+
+  ROS_INFO("Loaded gazebo_ros_vacuum_gripper");
+}
+
+bool GazeboRosVacuumGripper::OnServiceCallback(std_srvs::Empty::Request &req,
+                                     std_srvs::Empty::Response &res)
+{
+  if (status_) {
+    ROS_WARN("gazebo_ros_vacuum_gripper: already status is 'on'");
+  } else {
+    status_ = true;
+    ROS_INFO("gazebo_ros_vacuum_gripper: status: off -> on");
+  }
+  return true;
+}
+bool GazeboRosVacuumGripper::OffServiceCallback(std_srvs::Empty::Request &req,
+                                     std_srvs::Empty::Response &res)
+{
+  if (status_) {
+    status_ = false;
+    ROS_INFO("gazebo_ros_vacuum_gripper: status: on -> off");
+  } else {
+    ROS_WARN("gazebo_ros_vacuum_gripper: already status is 'off'");
+  }
+  return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Update the controller
+void GazeboRosVacuumGripper::UpdateChild()
+{
+  std_msgs::Bool grasping_msg;
+  grasping_msg.data = false;
+  if (!status_) {
+    pub_.publish(grasping_msg);
+    return;
+  }
+  // apply force
+  lock_.lock();
+  math::Pose parent_pose = link_->GetWorldPose();
+  physics::Model_V models = world_->GetModels();
+  for (size_t i = 0; i < models.size(); i++) {
+    if (models[i]->GetName() == link_->GetName() ||
+        models[i]->GetName() == parent_->GetName())
+    {
+      continue;
+    }
+    physics::Link_V links = models[i]->GetLinks();
+    for (size_t j = 0; j < links.size(); j++) {
+      math::Pose link_pose = links[j]->GetWorldPose();
+      math::Pose diff = parent_pose - link_pose;
+      double norm = diff.pos.GetLength();
+      if (norm < 0.05) {
+        links[j]->SetLinearAccel(link_->GetWorldLinearAccel());
+        links[j]->SetAngularAccel(link_->GetWorldAngularAccel());
+        links[j]->SetLinearVel(link_->GetWorldLinearVel());
+        links[j]->SetAngularVel(link_->GetWorldAngularVel());
+        double norm_force = 1 / norm;
+        if (norm < 0.01) {
+          // apply friction like force
+          // TODO(unknown): should apply friction actually
+          link_pose.Set(parent_pose.pos, link_pose.rot);
+          links[j]->SetWorldPose(link_pose);
+        }
+        if (norm_force > 20) {
+          norm_force = 20;  // max_force
+        }
+        math::Vector3 force = norm_force * diff.pos.Normalize();
+        links[j]->AddForce(force);
+        grasping_msg.data = true;
+      }
+    }
+  }
+  pub_.publish(grasping_msg);
+  lock_.unlock();
+}
+
+// Custom Callback Queue
+////////////////////////////////////////////////////////////////////////////////
+// custom callback queue thread
+void GazeboRosVacuumGripper::QueueThread()
+{
+  static const double timeout = 0.01;
+
+  while (rosnode_->ok())
+  {
+    queue_.callAvailable(ros::WallDuration(timeout));
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Someone subscribes to me
+void GazeboRosVacuumGripper::Connect()
+{
+  this->connect_count_++;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Someone subscribes to me
+void GazeboRosVacuumGripper::Disconnect()
+{
+  this->connect_count_--;
+}
+
+}  // namespace gazebo


### PR DESCRIPTION
this plugin is not perfect:
- apply forces to link's coords not collision
- do not apply friction actually

rrbot_sample: 
- code: https://github.com/wkentaro/gazebo_ros_demos/commit/93ab6f1b3bd02687436a9ef483bb6904917d4e67
- demo_movie: https://drive.google.com/file/d/0B9P1L--7Wd2vd0YzTkkwRFh3SG8/view?usp=sharing

baxter_sample:
- code: https://github.com/start-jsk/jsk_apc/blob/76db5dd1aab662f55a71e7e3157789ca1c018e21/jsk_2015_05_baxter_apc/robots/baxter.gazebo#L39-L69
- demo_movies
  - https://drive.google.com/file/d/0B9P1L--7Wd2va1JSQ1U4WkkzMnM/view?usp=sharing
  - https://www.youtube.com/watch?v=uV6XctamwEA
