### PR TITLE
openni_kinect: set correct row_step in pointcloudmsg

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
+++ b/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
@@ -382,6 +382,7 @@ bool GazeboRosOpenniKinect::FillPointCloudHelper(
   // reconvert to original height and width after the flat reshape
   point_cloud_msg.height = rows_arg;
   point_cloud_msg.width = cols_arg;
+  point_cloud_msg.row_step = cols_arg * point_cloud_msg.point_step;
 
   return true;
 }


### PR DESCRIPTION
I was wondering why our robot_self_filter kept segfaulting...
Until I figured out this gazebo plugin sends invalid PointCloud2 messages.
