### PR TITLE
Enabling continuous integration with Travis (jade)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,55 @@
+sudo: required
+dist: trusty
+language: generic
+compiler:
+  - gcc
+env:
+  global:
+    - CI_ROS_DISTRO=jade
+
+before_install:
+  - export CI_SOURCE_PATH=$(pwd)
+  - export REPOSITORY_NAME=${PWD##*/}
+  - echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
+  # Add ROS repositories
+  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > 
+                            /etc/apt/sources.list.d/ros-latest.list'
+  - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
+  - sudo apt-get update
+  # Install and initialize rosdep
+  - sudo apt-get install -qq -y python-dev                
+                                python-catkin-pkg         
+                                python-rosdep             
+                                python-wstool             
+                                ros-$CI_ROS_DISTRO-catkin 
+                                ros-$CI_ROS_DISTRO-ros    
+                                python-rosinstall         
+                                python-catkin-tools       
+                                python-catkin-pkg         
+                                python-rospkg             
+                                python-vcstools
+  - sudo `which rosdep` init
+  - rosdep update
+  # Use rosdep to install dependencies
+  - rosdep install --default-yes --from-paths ./ --rosdistro $CI_ROS_DISTRO
+
+install:
+  # Create workspace
+  - mkdir -p ~/ros/ws_$REPOSITORY_NAME
+  - cd ~/ros/ws_$REPOSITORY_NAME
+  - catkin config --init --mkdirs
+  - cd src
+  # Link the repo we are testing to the new workspace
+  - ln -s $CI_SOURCE_PATH .
+
+before_script:
+  - source /opt/ros/$CI_ROS_DISTRO/setup.bash
+  - rospack profile
+
+script:
+  - cd ~/ros/ws_$REPOSITORY_NAME
+  - catkin build -j4 --verbose --summary
+  - catkin run_tests -p1 -j4 --summary
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,11 @@ before_script:
 script:
   - cd ~/ros/ws_$REPOSITORY_NAME
   - catkin build -j4 --verbose --summary
-  - catkin run_tests -p1 -j4 --summary
+  # Run tests
+  - catkin run_tests
+  # catkin run_tests always returns 0, use catkin_test_results to check for errors
+  # https://github.com/catkin/catkin_tools/issues/245
+  - catkin_test_results
 
 notifications:
   email: false


### PR DESCRIPTION
First part of integration with Travis.

Tests are failing although the build is marked as successful. The patches for the testing suite will become in a new pull request. We probably need X support to run the testing suite but at least we can integrate in Travis some static/dynamic analysis tools and it check the compilation with the ros of gazebo and ROS ecosystem.

A new pull request should be directed to the `indigo-devel` branch and new support will be added to test different versions of gazebo.

The testing result of travis in my fork: https://travis-ci.org/j-rivero/gazebo_ros_pkgs/builds/111649828.

Mental note: enable travis integration after merging in the travis console for this repo.
