### PR TITLE
Include gazebo binary package as runtime dependency

### DIFF
--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -43,6 +43,7 @@
     See: https://github.com/ros-simulation/gazebo_ros_pkgs/issues/323 for more info
   -->
   <run_depend>libgazebo5-dev</run_depend>
+  <run_depend>gazebo5</run_depend>
   <run_depend>roslib</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>tf</run_depend>


### PR DESCRIPTION
This has the nice effect of fixing the testing suite in current jade-devel.
