### PR TITLE
gazebo_packages/gazebo_ros_joint_pose_trajectory.cpp BUG that caused simulated trajectories to run fast

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
@@ -201,6 +201,8 @@ void GazeboRosJointPoseTrajectory::SetTrajectory(
   for (unsigned int i = 0; i < points_size; ++i)
   {
     this->points_[i].positions.resize(chain_size);
+    this->points_[i].time_from_start = trajectory->points[i].time_from_start;
+
     for (unsigned int j = 0; j < chain_size; ++j)
     {
       this->points_[i].positions[j] = trajectory->points[i].positions[j];

--- a/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
@@ -202,7 +202,6 @@ void GazeboRosJointPoseTrajectory::SetTrajectory(
   {
     this->points_[i].positions.resize(chain_size);
     this->points_[i].time_from_start = trajectory->points[i].time_from_start;
-
     for (unsigned int j = 0; j < chain_size; ++j)
     {
       this->points_[i].positions[j] = trajectory->points[i].positions[j];


### PR DESCRIPTION
In the Gazebo plugin to run a ros JointTrajectory, the points in the class.points_ member never had their time_from_start set. This caused all the time_from_starts to be set to 0. This in turn caused all the trajectory points to be played instantly one after the other in Gazebo.
