### PR TITLE
Fix unset variable in gazebo_ros_joint_pose_trajectory

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
@@ -201,6 +201,8 @@ void GazeboRosJointPoseTrajectory::SetTrajectory(
   for (unsigned int i = 0; i < points_size; ++i)
   {
     this->points_[i].positions.resize(chain_size);
+    this->points_[i].time_from_start = trajectory->points[i].time_from_start;
+
     for (unsigned int j = 0; j < chain_size; ++j)
     {
       this->points_[i].positions[j] = trajectory->points[i].positions[j];

--- a/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
@@ -202,7 +202,6 @@ void GazeboRosJointPoseTrajectory::SetTrajectory(
   {
     this->points_[i].positions.resize(chain_size);
     this->points_[i].time_from_start = trajectory->points[i].time_from_start;
-
     for (unsigned int j = 0; j < chain_size; ++j)
     {
       this->points_[i].positions[j] = trajectory->points[i].positions[j];

--- a/gazebo_plugins/src/gazebo_ros_joint_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_trajectory.cpp
@@ -203,6 +203,7 @@ void GazeboRosJointTrajectory::SetTrajectory(
   for (unsigned int i = 0; i < points_size; ++i)
   {
     this->points_[i].positions.resize(chain_size);
+    this->points_[i].time_from_start = trajectory->points[i].time_from_start;
     for (unsigned int j = 0; j < chain_size; ++j)
     {
       this->points_[i].positions[j] = trajectory->points[i].positions[j];


### PR DESCRIPTION
This is a duplicate of #405 that is back-ported to `indigo-devel`. The problem is that the `SetTrajectory(const trajectory_msgs::JointTrajectory)` function didn't copy the `time_from_start` field into the `points_` member variable.
