### PR TITLE
Add note about where to write simulation code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,15 @@
 
 We welcome contributions to this repo and encourage you to fork the project, thanks!
 
+## Implementations of simulations
+
+It is higly recommended to place the code that performs simulation inside
+[upstream gazebo code](https://bitbucket.org/osrf/gazebo/). The Gazebo project
+provides documentation about [how to create and code
+plugins](http://gazebosim.org/tutorials?cat=write_plugin) Ideally
+gazebo_ros_pkgs should implement the ROS wrapper over an existing gazebo
+plugin.
+
 ## Issues and Pull Requests
 
 There are several maintainers of different packages in this repository. If you


### PR DESCRIPTION
Add text explaining that real simulation code should go into gazebo upstream code.

@scpeters @nkoenig 
