### PR TITLE
[gazebo_plugins] bugfix: duplicated tf prefix resolution in gazebo_ros_camera plugin (jade-devel)

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -277,14 +277,6 @@ void GazeboRosCameraUtils::LoadThread()
   this->camera_info_manager_.reset(new camera_info_manager::CameraInfoManager(
           *this->rosnode_, this->camera_name_));
 
-  // resolve tf prefix
-  std::string key;
-  if(this->rosnode_->searchParam("tf_prefix", key)){
-    std::string prefix;
-    this->rosnode_->getParam(key, prefix);
-    this->frame_name_ = tf::resolve(prefix, this->frame_name_);
-  }
-
   this->itnode_ = new image_transport::ImageTransport(*this->rosnode_);
   
   // resolve tf prefix


### PR DESCRIPTION
{ port of pull request #460 }
In line 280-287 in `gazebo_ros_camera_utils.cpp`, there are codes that resolve tf prefix which I think is duplicated code of line 290-296.
When the spawning node is launched at `group` tag (for example `group ns="robot1"`) in launch file, and `tf_prefix` ros param is set, (for example `tf_prefix` is also set as "robot1"), the frame of `camera_info`'s header is published as `/robot1/robot1/camera_rgb_frame` which is resolved tf twice, though true tf frame is `/robot1/camera_rgb_frame`)
