### PR TITLE
[gazebo_plugins] Fix vacuum gripper plugin to work in stable

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_vacuum_gripper.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_vacuum_gripper.h
@@ -142,6 +142,11 @@ class GazeboRosVacuumGripper : public ModelPlugin
   /// \brief for setting ROS name space
   private: std::string robot_namespace_;
 
+  /// \brief vacuum mechanism parameters
+  private: double max_force_;
+  private: double max_distance_;
+  private: double min_distance_;
+
   // Custom Callback Queue
   private: ros::CallbackQueue queue_;
   /// \brief Thead object for the running callback Thread.

--- a/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
@@ -217,18 +217,19 @@ void GazeboRosVacuumGripper::UpdateChild()
         links[j]->SetAngularAccel(link_->GetWorldAngularAccel());
         links[j]->SetLinearVel(link_->GetWorldLinearVel());
         links[j]->SetAngularVel(link_->GetWorldAngularVel());
-        double norm_force = 1 / norm;
         if (norm <= min_distance_) {
           // apply friction like force
           // TODO(unknown): should apply friction actually
           link_pose.Set(parent_pose.pos, link_pose.rot);
           links[j]->SetWorldPose(link_pose);
+        } else {
+          double norm_force = 1 / norm;
+          if (norm_force > max_force_) {
+            norm_force = max_force_;
+          }
+          math::Vector3 force = norm_force * diff.pos.Normalize();
+          links[j]->AddForce(force);
         }
-        if (norm_force > max_force_) {
-          norm_force = max_force_;
-        }
-        math::Vector3 force = norm_force * diff.pos.Normalize();
-        links[j]->AddForce(force);
         grasping_msg.data = true;
       }
     }

--- a/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
@@ -214,9 +214,9 @@ void GazeboRosVacuumGripper::UpdateChild()
       double norm = diff.pos.GetLength();
       if (norm <= max_distance_) {
         links[j]->SetLinearAccel(link_->GetWorldLinearAccel());
-        links[j]->SetAngularAccel(link_->GetWorldAngularAccel());
+        links[j]->SetAngularAccel(math::Vector3(0, 0, 0));
         links[j]->SetLinearVel(link_->GetWorldLinearVel());
-        links[j]->SetAngularVel(link_->GetWorldAngularVel());
+        links[j]->SetAngularVel(math::Vector3(0, 0, 0));
         if (norm <= min_distance_) {
           // apply friction like force
           // TODO(unknown): should apply friction actually


### PR DESCRIPTION
In order to make the vacuum gripper plugin work in stable.
Without last commit, 4c13f24, the object will have too fast angular velocity unexpectedly.
