### PR TITLE
Add an argument to enable required flag on gazebo gui

### DIFF
--- a/gazebo_ros/launch/empty_world.launch
+++ b/gazebo_ros/launch/empty_world.launch
@@ -13,6 +13,7 @@
   <arg name="respawn_gazebo" default="false"/>
   <arg name="use_clock_frequency" default="false"/>
   <arg name="pub_clock_frequency" default="100"/>
+  <arg name="required_gui" default="false"/>
 
   <!-- set use_sim_time flag -->
   <group if="$(arg use_sim_time)">
@@ -38,7 +39,7 @@
 	
   <!-- start gazebo client -->
   <group if="$(arg gui)">
-    <node name="gazebo_gui" pkg="gazebo_ros" type="gzclient" respawn="false" output="screen"/>
+    <node name="gazebo_gui" pkg="gazebo_ros" type="gzclient" respawn="false" output="screen" required="$(arg required_gui)"/>
   </group>
 
 </launch>

--- a/gazebo_ros/launch/empty_world.launch
+++ b/gazebo_ros/launch/empty_world.launch
@@ -13,7 +13,7 @@
   <arg name="respawn_gazebo" default="false"/>
   <arg name="use_clock_frequency" default="false"/>
   <arg name="pub_clock_frequency" default="100"/>
-  <arg name="required_gui" default="false"/>
+  <arg name="required" default="false"/>
 
   <!-- set use_sim_time flag -->
   <group if="$(arg use_sim_time)">
@@ -39,7 +39,7 @@
 	
   <!-- start gazebo client -->
   <group if="$(arg gui)">
-    <node name="gazebo_gui" pkg="gazebo_ros" type="gzclient" respawn="false" output="screen" required="$(arg required_gui)"/>
+    <node name="gazebo_gui" pkg="gazebo_ros" type="gzclient" respawn="false" output="screen" required="$(arg required)"/>
   </group>
 
 </launch>


### PR DESCRIPTION
This change will enable the ability to close all the nodes launched with gazebo when you close the gazebo gui window.
This is  a more convenient way to close the simulation, in comparison to ctrl+c in the right terminal.
