### PR TITLE
gazebo_ros_camera_utils: add try/catch

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -312,11 +312,19 @@ void GazeboRosCameraUtils::LoadThread()
              this->image_topic_name_.c_str());
   }
 
-  this->image_pub_ = this->itnode_->advertise(
-    this->image_topic_name_, 2,
-    boost::bind(&GazeboRosCameraUtils::ImageConnect, this),
-    boost::bind(&GazeboRosCameraUtils::ImageDisconnect, this),
-    ros::VoidPtr(), true);
+  try
+  {
+    this->image_pub_ = this->itnode_->advertise(
+      this->image_topic_name_, 2,
+      boost::bind(&GazeboRosCameraUtils::ImageConnect, this),
+      boost::bind(&GazeboRosCameraUtils::ImageDisconnect, this),
+      ros::VoidPtr(), true);
+  }
+  catch(...)
+  {
+    ROS_WARN("Unable to load image_transport plugin for topic [%s]",
+             this->image_topic_name_.c_str());
+  }
 
   // camera info publish rate will be synchronized to image sensor
   // publish rates.


### PR DESCRIPTION
The image_transport advertise call for image_raw was throwing exceptions quite often. This catches those exceptions and gives a `ROS_WARN`.

Room for improvement:
- catch exceptions from other `advertise` calls
- should this be `ROS_ERROR`?

This may be improved by https://github.com/ros/class_loader/pull/40
