### PR TITLE
gazebo_ros: replace 'headless' arg with 'recording'

### DIFF
--- a/gazebo_ros/launch/elevator_world.launch
+++ b/gazebo_ros/launch/elevator_world.launch
@@ -5,6 +5,10 @@
   <arg name="use_sim_time" default="true"/>
   <arg name="extra_gazebo_args" default=""/>
   <arg name="gui" default="true"/>
+  <arg name="recording" default="false"/>
+  <!-- Note that 'headless' is currently non-functional.  See gazebo_ros_pkgs issue #491 (-r arg does not disable
+       rendering, but instead enables recording). The arg definition has been left here to prevent breaking downstream
+       launch files, but it does nothing. -->
   <arg name="headless" default="false"/>
   <arg name="debug" default="false"/>
   <arg name="physics" default="ode"/>
@@ -19,8 +23,8 @@
   <!-- set command arguments -->
   <arg unless="$(arg paused)" name="command_arg1" value=""/>
   <arg     if="$(arg paused)" name="command_arg1" value="-u"/>
-  <arg unless="$(arg headless)" name="command_arg2" value=""/>
-  <arg     if="$(arg headless)" name="command_arg2" value="-r"/>
+  <arg unless="$(arg recording)" name="command_arg2" value=""/>
+  <arg     if="$(arg recording)" name="command_arg2" value="-r"/>
   <arg unless="$(arg verbose)" name="command_arg3" value=""/>
   <arg     if="$(arg verbose)" name="command_arg3" value="--verbose"/>
   <arg unless="$(arg debug)" name="script_type" value="gzserver"/>

--- a/gazebo_ros/launch/empty_world.launch
+++ b/gazebo_ros/launch/empty_world.launch
@@ -5,6 +5,10 @@
   <arg name="use_sim_time" default="true"/>
   <arg name="extra_gazebo_args" default=""/>
   <arg name="gui" default="true"/>
+  <arg name="recording" default="false"/>
+  <!-- Note that 'headless' is currently non-functional.  See gazebo_ros_pkgs issue #491 (-r arg does not disable
+       rendering, but instead enables recording). The arg definition has been left here to prevent breaking downstream
+       launch files, but it does nothing. -->
   <arg name="headless" default="false"/>
   <arg name="debug" default="false"/>
   <arg name="physics" default="ode"/>
@@ -22,8 +26,8 @@
   <!-- set command arguments -->
   <arg unless="$(arg paused)" name="command_arg1" value=""/>
   <arg     if="$(arg paused)" name="command_arg1" value="-u"/>
-  <arg unless="$(arg headless)" name="command_arg2" value=""/>
-  <arg     if="$(arg headless)" name="command_arg2" value="-r"/>
+  <arg unless="$(arg recording)" name="command_arg2" value=""/>
+  <arg     if="$(arg recording)" name="command_arg2" value="-r"/>
   <arg unless="$(arg verbose)" name="command_arg3" value=""/>
   <arg     if="$(arg verbose)" name="command_arg3" value="--verbose"/>
   <arg unless="$(arg debug)" name="script_type" value="gzserver"/>

--- a/gazebo_ros/launch/mud_world.launch
+++ b/gazebo_ros/launch/mud_world.launch
@@ -6,7 +6,8 @@
     <arg name="paused" value="false"/>
     <arg name="use_sim_time" value="true"/>
     <arg name="gui" value="true"/>
-    <arg name="headless" value="false"/>
+    <arg name="headless" value="false"/> <!-- Inert - see gazebo_ros_pkgs issue #491 -->
+    <arg name="recording" value="false"/>
     <arg name="debug" value="false"/>
   </include>
 

--- a/gazebo_ros/launch/rubble_world.launch
+++ b/gazebo_ros/launch/rubble_world.launch
@@ -6,7 +6,8 @@
     <arg name="paused" value="false"/>
     <arg name="use_sim_time" value="true"/>
     <arg name="gui" value="true"/>
-    <arg name="headless" value="false"/>
+    <arg name="headless" value="false"/> <!-- Inert - see gazebo_ros_pkgs issue #491 -->
+    <arg name="recording" value="false"/>
     <arg name="debug" value="false"/>
   </include>
 

--- a/gazebo_ros/launch/shapes_world.launch
+++ b/gazebo_ros/launch/shapes_world.launch
@@ -6,7 +6,8 @@
     <arg name="paused" value="false"/>
     <arg name="use_sim_time" value="true"/>
     <arg name="gui" value="true"/>
-    <arg name="headless" value="false"/>
+    <arg name="headless" value="false"/> <!-- Inert - see gazebo_ros_pkgs issue #491 -->
+    <arg name="recording" value="false"/>
     <arg name="debug" value="false"/>
   </include>
 

--- a/gazebo_ros/launch/willowgarage_world.launch
+++ b/gazebo_ros/launch/willowgarage_world.launch
@@ -6,7 +6,8 @@
     <arg name="paused" value="false"/>
     <arg name="use_sim_time" value="true"/>
     <arg name="gui" value="true"/>
-    <arg name="headless" value="false"/>
+    <arg name="headless" value="false"/> <!-- Inert - see gazebo_ros_pkgs issue #491 -->
+    <arg name="recording" value="false"/>
     <arg name="debug" value="false"/>
   </include>
 


### PR DESCRIPTION
See #491 for full context - currently, the `headless` arg actually enables recording instead.

I have added comments regarding `headless` arg, and replaced it with a new `recording` arg as a switch for `-r`.  The `headless` arg is left in place (for now at least) to avoid breaking downstream projects which may use these launch files.

The issue also exists in kinetic and indigo branches, and these changes should probably be backported if accepted.
