### PR TITLE
Fixed getLinkState service's angular velocity return (kinetic-devel)

### DIFF
--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -1050,7 +1050,7 @@ bool GazeboRosApiPlugin::getLinkState(gazebo_msgs::GetLinkState::Request &req,
   res.link_state.twist.linear.z = body_vpos.z;
   res.link_state.twist.angular.x = body_veul.x;
   res.link_state.twist.angular.y = body_veul.y;
-  res.link_state.twist.angular.z = body_veul.x;
+  res.link_state.twist.angular.z = body_veul.z;
   res.link_state.reference_frame = req.reference_frame;
 
   res.success = true;


### PR DESCRIPTION
{ port of pull request #495 }
A typo had the getLinkState service returning angular Vx for both Vx and Vz. Also creating a pull request for the indigo-devel branch which has the same issue.