### PR TITLE
Fix distortion coefficients order (kinetic-devel)

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -510,11 +510,14 @@ void GazeboRosCameraUtils::Init()
   camera_info_msg.distortion_model = "plumb_bob";
   camera_info_msg.D.resize(5);
 #endif
+  // D = {k1, k2, t1, t2, k3}, as specified in:
+  // - sensor_msgs/CameraInfo: http://docs.ros.org/api/sensor_msgs/html/msg/CameraInfo.html
+  // - OpenCV: http://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html
   camera_info_msg.D[0] = this->distortion_k1_;
   camera_info_msg.D[1] = this->distortion_k2_;
-  camera_info_msg.D[2] = this->distortion_k3_;
-  camera_info_msg.D[3] = this->distortion_t1_;
-  camera_info_msg.D[4] = this->distortion_t2_;
+  camera_info_msg.D[2] = this->distortion_t1_;
+  camera_info_msg.D[3] = this->distortion_t2_;
+  camera_info_msg.D[4] = this->distortion_k3_;
   // original camera_ matrix
   camera_info_msg.K[0] = this->focal_length_;
   camera_info_msg.K[1] = 0.0;


### PR DESCRIPTION
{ port of pull request #503 }
It should be D = {k1, k2, p1, p2, k3}, according to:
- sensor_msgs/CameraInfo:
  http://docs.ros.org/api/sensor_msgs/html/msg/CameraInfo.html
- OpenCV:
  http://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html