### PR TITLE
Revert "Remove ROS remapping arguments from gazebo_ros launch scripts." (jade-devel)

### DIFF
--- a/gazebo_ros/scripts/debug
+++ b/gazebo_ros/scripts/debug
@@ -1,10 +1,6 @@
 #!/bin/sh
 final="$@"
 
-# remove ros remapping arguments like "__name:=node_name"; otherwise, they'd 
-# be interpreted as a world name by gzserver, and it'd crash while loading it
-final=`echo "$final" | sed 's/[^ ]*:=[^ ]* \?//g'`
-
 EXT=so
 if [ $(uname) == "Darwin" ]; then
     EXT=dylib

--- a/gazebo_ros/scripts/gazebo
+++ b/gazebo_ros/scripts/gazebo
@@ -1,10 +1,6 @@
 #!/bin/sh
 final="$@"
 
-# remove ros remapping arguments like "__name:=node_name"; otherwise, they'd 
-# be interpreted as a world name by gzserver, and it'd crash while loading it
-final=`echo "$final" | sed 's/[^ ]*:=[^ ]* \?//g'`
-
 EXT=so
 SIGNAL=SIGINT
 if [ $(uname) = "Darwin" ]; then

--- a/gazebo_ros/scripts/gzclient
+++ b/gazebo_ros/scripts/gzclient
@@ -1,10 +1,6 @@
 #!/bin/sh
 final="$@"
 
-# remove ros remapping arguments like "__name:=node_name"; otherwise, they'd 
-# be interpreted as a world name by gzserver, and it'd crash while loading it
-final=`echo "$final" | sed 's/[^ ]*:=[^ ]* \?//g'`
-
 EXT=so
 if [ $(uname) = "Darwin" ]; then
     EXT=dylib

--- a/gazebo_ros/scripts/gzserver
+++ b/gazebo_ros/scripts/gzserver
@@ -1,10 +1,6 @@
 #!/bin/sh
 final="$@"
 
-# remove ros remapping arguments like "__name:=node_name"; otherwise, they'd 
-# be interpreted as a world name by gzserver, and it'd crash while loading it
-final=`echo "$final" | sed 's/[^ ]*:=[^ ]* \?//g'`
-
 EXT=so
 if [ $(uname) = "Darwin" ]; then
     EXT=dylib

--- a/gazebo_ros/scripts/perf
+++ b/gazebo_ros/scripts/perf
@@ -1,10 +1,6 @@
 #!/bin/sh
 final="$@"
 
-# remove ros remapping arguments like "__name:=node_name"; otherwise, they'd 
-# be interpreted as a world name by gzserver, and it'd crash while loading it
-final=`echo "$final" | sed 's/[^ ]*:=[^ ]* \?//g'`
-
 EXT=so
 if [ $(uname) = "Darwin" ]; then
     EXT=dylib


### PR DESCRIPTION
{ port of pull request #514 }
This reverts commit a90e609a81702b13bee235b079081edf68ff6971.

That commit removed remappings. While it fixed a specific problem (calling gazebo with arguments in a certain order didn't work) it completely broke remapping. See https://github.com/ros-simulation/gazebo_ros_pkgs/issues/486