### PR TITLE
Workaround to support gazebo and ROS arguments in the command line (jade-devel)

### DIFF
--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -51,6 +51,7 @@ catkin_package(
   std_msgs
   gazebo_msgs
 
+
   DEPENDS
     TinyXML
 )
@@ -96,9 +97,17 @@ install(TARGETS gazebo_ros_api_plugin gazebo_ros_paths_plugin
   )
 
 # Install Gazebo Scripts
-install(PROGRAMS scripts/gazebo scripts/debug scripts/gzclient scripts/gzserver scripts/gdbrun scripts/perf scripts/spawn_model
-  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-  )
+install(PROGRAMS scripts/gazebo
+                 scripts/debug
+		 scripts/gzclient
+		 scripts/gzserver
+		 scripts/gdbrun
+		 scripts/perf
+		 scripts/spawn_model
+		 scripts/libcommon.sh
+        DESTINATION
+                 ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 # Install Gazebo launch files
 install(DIRECTORY launch/

--- a/gazebo_ros/scripts/gazebo
+++ b/gazebo_ros/scripts/gazebo
@@ -1,4 +1,9 @@
 #!/bin/sh
+[ -L ${0} ] && SCRIPT_DIR=$(readlink ${0}) || SCRIPT_DIR=${0}
+SCRIPT_DIR=$(dirname ${SCRIPT_DIR})
+
+. ${SCRIPT_DIR}/libcommon.sh
+
 final="$@"
 
 EXT=so
@@ -30,6 +35,8 @@ desired_master_uri="$GAZEBO_MASTER_URI"
 if [ "$desired_master_uri" = "" ]; then
 	desired_master_uri="$GAZEBO_MASTER_URI"
 fi
+
+final=$(relocate_remappings "${final}")
 
 # Combine the commands
 GAZEBO_MASTER_URI="$desired_master_uri" gzserver $final & 

--- a/gazebo_ros/scripts/gzclient
+++ b/gazebo_ros/scripts/gzclient
@@ -1,4 +1,9 @@
 #!/bin/sh
+[ -L ${0} ] && SCRIPT_DIR=$(readlink ${0}) || SCRIPT_DIR=${0}
+SCRIPT_DIR=$(dirname ${SCRIPT_DIR})
+
+. ${SCRIPT_DIR}/libcommon.sh
+
 final="$@"
 
 EXT=so
@@ -20,6 +25,8 @@ desired_master_uri="$GAZEBO_MASTER_URI"
 if [ "$desired_master_uri" = "" ]; then
 	desired_master_uri="$GAZEBO_MASTER_URI"
 fi
+
+final=$(relocate_remappings "${final}")
 
 # Combine the commands
 GAZEBO_MASTER_URI="$desired_master_uri" gzclient $final

--- a/gazebo_ros/scripts/gzserver
+++ b/gazebo_ros/scripts/gzserver
@@ -1,4 +1,9 @@
 #!/bin/sh
+[ -L ${0} ] && SCRIPT_DIR=$(readlink ${0}) || SCRIPT_DIR=${0}
+SCRIPT_DIR=$(dirname ${SCRIPT_DIR})
+
+. ${SCRIPT_DIR}/libcommon.sh
+
 final="$@"
 
 EXT=so
@@ -26,5 +31,7 @@ desired_master_uri="$GAZEBO_MASTER_URI"
 if [ "$desired_master_uri" = "" ]; then
 	desired_master_uri="$GAZEBO_MASTER_URI"
 fi
+
+final=$(relocate_remappings "${final}")
 
 GAZEBO_MASTER_URI="$desired_master_uri" gzserver $final

--- a/gazebo_ros/scripts/libcommon.sh
+++ b/gazebo_ros/scripts/libcommon.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
 
-# the function relocate all the remappings in the command at the end of the string
-# this allows some punky uses of rosrun, for more information see:
+# the function relocates all the ROS remappings in the command at the end of the
+# string this allows some punky uses of rosrun, for more information see:
 # https://github.com/ros-simulation/gazebo_ros_pkgs/issues/387
 relocate_remappings()
 {
   command_line=${1}
   
   for w in $command_line; do
-    if $(echo $w | grep ':='> /dev/null); then
+    if $(echo $w | grep -q ':='); then
       ros_remaps="$ros_remaps $w"
     else
       gazebo_args="$gazebo_args $w"

--- a/gazebo_ros/scripts/libcommon.sh
+++ b/gazebo_ros/scripts/libcommon.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# the function relocate all the remappings in the command at the end of the string
+# this allows some punky uses of rosrun, for more information see:
+# https://github.com/ros-simulation/gazebo_ros_pkgs/issues/387
+relocate_remappings()
+{
+  command_line=${1}
+  
+  for w in $command_line; do
+    if $(echo $w | grep ':='> /dev/null); then
+      ros_remaps="$ros_remaps $w"
+    else
+      gazebo_args="$gazebo_args $w"
+    fi
+  done
+
+  echo $gazebo_args$ros_remaps | cut -c 1-
+}


### PR DESCRIPTION
{ port of pull request #516 }
Reorder command line arguments to place ROS remappings at the end so gazebo passed them to be handle by gazebo ROS plugins. While this is not the recommended way of using rosrun, it could be useful for
some use cases.

Should fix #387