### PR TITLE
fill in child_frame_id of odom topic (kinetic-devel)

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -223,6 +223,7 @@ void GazeboRosP3D::UpdateChild()
         this->pose_msg_.header.stamp.sec = cur_time.sec;
         this->pose_msg_.header.stamp.nsec = cur_time.nsec;
 
+        this->pose_msg_.child_frame_id = this->link_name_;
 
         math::Pose pose, frame_pose;
         math::Vector3 frame_vpos;


### PR DESCRIPTION
{ port of pull request #492 }
does anyone knows why p3d publishes /odom with empty 'child_frame_id' ?