### PR TITLE
[gazebo_plugins] bugfix: duplicated tf prefix resolution (kinetic-devel)

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -277,14 +277,6 @@ void GazeboRosCameraUtils::LoadThread()
   this->camera_info_manager_.reset(new camera_info_manager::CameraInfoManager(
           *this->rosnode_, this->camera_name_));
 
-  // resolve tf prefix
-  std::string key;
-  if(this->rosnode_->searchParam("tf_prefix", key)){
-    std::string prefix;
-    this->rosnode_->getParam(key, prefix);
-    this->frame_name_ = tf::resolve(prefix, this->frame_name_);
-  }
-
   this->itnode_ = new image_transport::ImageTransport(*this->rosnode_);
   
   // resolve tf prefix


### PR DESCRIPTION
Appears this cherry-pick never made it into `kinetic-devel`. Supersedes #464, relates to #460 and #463. Resolves #526. The gist of this commit is that the tf-prefix only needs to be resolved once in the camera plugin.

(cherry picked from commit d760220bfb28e639f28fa933edf315699127dcd0)