### PR TITLE
Print name of joint with wrong interface

### DIFF
--- a/gazebo_ros_control/src/default_robot_hw_sim.cpp
+++ b/gazebo_ros_control/src/default_robot_hw_sim.cpp
@@ -177,7 +177,7 @@ bool DefaultRobotHWSim::initSim(
     else
     {
       ROS_FATAL_STREAM_NAMED("default_robot_hw_sim","No matching hardware interface found for '"
-        << hardware_interface );
+        << hardware_interface << "' while loading interfaces for " << joint_names_[j] );
       return false;
     }
 


### PR DESCRIPTION
This can be super helpful when dealing with a broken urdf.