### PR TITLE
Fix destructor of GazeboRosVideo

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_video.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_video.h
@@ -81,8 +81,10 @@ namespace gazebo
       boost::mutex m_image_;
       bool new_image_available_;
 
+      /// \brief A pointer to the ROS node.  A node will be instantiated if it does not exist.
+      ros::NodeHandle* rosnode_;
+
       // ROS Stuff
-      boost::shared_ptr<ros::NodeHandle> rosnode_;
       ros::Subscriber camera_subscriber_;
       std::string robot_namespace_;
       std::string topic_name_;
@@ -96,4 +98,3 @@ namespace gazebo
 }
 
 #endif
-


### PR DESCRIPTION
Fixes https://github.com/ros-simulation/gazebo_ros_pkgs/issues/354 with the destructor warning:

```
terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::lock_error> >'
terminate called recursively
  what():  boost: mutex lock failed in pthread_mutex_lock: Invalid argument
Aborted (core dumped)
```

This fix was copied from the GazeboRosForce plugin.

I also cleaned up the file while I was at it.

*This PR is sponsored by [Vicarious](http://www.vicarious.com/)*