### PR TITLE
Make gazebo_ros_control compatible with ros_control with respect to <hardwareInterface> tag

### DIFF
--- a/gazebo_ros_control/src/default_robot_hw_sim.cpp
+++ b/gazebo_ros_control/src/default_robot_hw_sim.cpp
@@ -150,7 +150,7 @@ bool DefaultRobotHWSim::initSim(
 
     // Decide what kind of command interface this actuator/joint has
     hardware_interface::JointHandle joint_handle;
-    if(hardware_interface == "EffortJointInterface")
+    if(hardware_interface == "EffortJointInterface" || hardware_interface == "hardware_interface/EffortJointInterface")
     {
       // Create effort joint interface
       joint_control_methods_[j] = EFFORT;
@@ -158,7 +158,7 @@ bool DefaultRobotHWSim::initSim(
                                                      &joint_effort_command_[j]);
       ej_interface_.registerHandle(joint_handle);
     }
-    else if(hardware_interface == "PositionJointInterface")
+    else if(hardware_interface == "PositionJointInterface" || hardware_interface == "hardware_interface/PositionJointInterface")
     {
       // Create position joint interface
       joint_control_methods_[j] = POSITION;
@@ -166,7 +166,7 @@ bool DefaultRobotHWSim::initSim(
                                                      &joint_position_command_[j]);
       pj_interface_.registerHandle(joint_handle);
     }
-    else if(hardware_interface == "VelocityJointInterface")
+    else if(hardware_interface == "VelocityJointInterface" || hardware_interface == "hardware_interface/VelocityJointInterface")
     {
       // Create velocity joint interface
       joint_control_methods_[j] = VELOCITY;

--- a/gazebo_ros_control/src/default_robot_hw_sim.cpp
+++ b/gazebo_ros_control/src/default_robot_hw_sim.cpp
@@ -181,6 +181,10 @@ bool DefaultRobotHWSim::initSim(
       return false;
     }
 
+    if(hardware_interface == "EffortJointInterface" || hardware_interface == "PositionJointInterface" || hardware_interface == "VelocityJointInterface") {
+      ROS_WARN_STREAM("Please update old, now deprecated, hardware_interface syntax in joint '" << joint_names_[j] << "': " << hardware_interface);
+    }
+
     // Get the gazebo joint that corresponds to the robot joint.
     //ROS_DEBUG_STREAM_NAMED("default_robot_hw_sim", "Getting pointer to gazebo joint: "
     //  << joint_names_[j]);

--- a/gazebo_ros_control/src/default_robot_hw_sim.cpp
+++ b/gazebo_ros_control/src/default_robot_hw_sim.cpp
@@ -182,7 +182,7 @@ bool DefaultRobotHWSim::initSim(
     }
 
     if(hardware_interface == "EffortJointInterface" || hardware_interface == "PositionJointInterface" || hardware_interface == "VelocityJointInterface") {
-      ROS_WARN_STREAM("Deprecated syntax, please prepend 'hardware_interface::' to '" << hardware_interface << "' within the <hardwareInterface> tag in joint '" << joint_names_[j] << "'.");
+      ROS_WARN_STREAM("Deprecated syntax, please prepend 'hardware_interface/' to '" << hardware_interface << "' within the <hardwareInterface> tag in joint '" << joint_names_[j] << "'.");
     }
 
     // Get the gazebo joint that corresponds to the robot joint.

--- a/gazebo_ros_control/src/default_robot_hw_sim.cpp
+++ b/gazebo_ros_control/src/default_robot_hw_sim.cpp
@@ -182,7 +182,7 @@ bool DefaultRobotHWSim::initSim(
     }
 
     if(hardware_interface == "EffortJointInterface" || hardware_interface == "PositionJointInterface" || hardware_interface == "VelocityJointInterface") {
-      ROS_WARN_STREAM("Please update old, now deprecated, hardware_interface syntax in joint '" << joint_names_[j] << "': " << hardware_interface);
+      ROS_WARN_STREAM("Deprecated syntax, please prepend 'hardware_interface::' to '" << hardware_interface << "' within the <hardwareInterface> tag in joint '" << joint_names_[j] << "'.");
     }
 
     // Get the gazebo joint that corresponds to the robot joint.


### PR DESCRIPTION
ros_control expects `<hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>`, i.e. "hardware_interface/" prefix.

At the moment, it is not possible to have an URDF that is compatible with both ros_control (transmission_interface) and gazebo_ros_control plugin.

Using the gazebo variant (no hardware_interface/ prefix), ros_control is discontent:
`Failed to process the 'PositionJointInterface' hardware interface for transmission 'foo_transmission'.
According to the loaded plugin descriptions the class PositionJointInterface with base class type transmission_interface::RequisiteProvider does not exist. Declared types are  hardware_interface/EffortJointInterface hardware_interface/JointStateInterface hardware_interface/PositionJointInterface hardware_interface/VelocityJointInterface`
Using the ros_control variant, gazebo_ros_control is unsatisfied:
`No matching hardware interface found for 'hardware_interface/PositionJointInterface' while loading interfaces for foo_joint
Could not initialize robot simulation interface`