### PR TITLE
gazebo_ros: delay shutdown of gzserver to allow for proper cleanup with some plugins

### DIFF
--- a/gazebo_ros/scripts/gazebo
+++ b/gazebo_ros/scripts/gazebo
@@ -7,7 +7,6 @@ SCRIPT_DIR=$(dirname ${SCRIPT_DIR})
 final="$@"
 
 EXT=so
-SIGNAL=SIGINT
 if [ $(uname) = "Darwin" ]; then
     EXT=dylib
     SIGNAL=INT
@@ -39,8 +38,16 @@ fi
 final=$(relocate_remappings "${final}")
 
 # Combine the commands
-GAZEBO_MASTER_URI="$desired_master_uri" gzserver $final & 
+GAZEBO_MASTER_URI="$desired_master_uri" setsid gzserver $final &
+pid=$!
 GAZEBO_MASTER_URI="$desired_master_uri" gzclient $client_final
 
 # Kill the server
-kill -s $SIGNAL $!
+echo -n Killing gzserver in 3...
+sleep 1
+echo -n 2...
+sleep 1
+echo -n 1...
+sleep 1
+echo Now!
+kill $pid

--- a/gazebo_ros/scripts/gzserver
+++ b/gazebo_ros/scripts/gzserver
@@ -34,4 +34,19 @@ fi
 
 final=$(relocate_remappings "${final}")
 
-GAZEBO_MASTER_URI="$desired_master_uri" gzserver $final
+GAZEBO_MASTER_URI="$desired_master_uri" setsid gzserver $final &
+pid=$!
+
+terminate_handler() {
+  echo -n Killing gzserver in 3...
+  sleep 1
+  echo -n 2...
+  sleep 1
+  echo -n 1...
+  sleep 1
+  echo Now!
+  kill $pid
+  trap - INT TERM
+}
+trap terminate_handler INT TERM
+wait


### PR DESCRIPTION
Not sure if it is worth to merge this small patch upstream or whether there is a better solution, but it solved an annoying issue for me if gzserver and gzclient are launched from the same roslaunch file, e.g. with `roslaunch gazebo_ros empty_world.launch`.

If the roslaunch process also spawns ros_control controllers, like it is the case for many deployments using `gazebo_ros_control`, a dead-lock occurs during shutdown because the spawner nodes tries to stop and unload controllers but Gazebo does not respond because the controller_manager is not executed anymore. So the termination blocks for 10 seconds until roslaunch escalates to SIGKILL.

There is no problem if Gazebo is launched separately from the controller spawner nodes, because either the controller_manager already disappeared or the spawner can cleanly unload its controllers before Gazebo terminates.

Example launch file: https://github.com/tu-darmstadt-ros-pkg/hector_quadrotor/blob/kinetic-devel/hector_quadrotor_gazebo/launch/quadrotor_empty_world.launch