### PR TITLE
[gazebo_plugins] Fix: add gazebo_ros_range to catkin package libraries

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -114,6 +114,7 @@ catkin_package(
   gazebo_ros_skid_steer_drive
   gazebo_ros_video
   gazebo_ros_planar_move
+  gazebo_ros_range
   gazebo_ros_vacuum_gripper
   
   CATKIN_DEPENDS 


### PR DESCRIPTION
gazebo_ros_range is missing in the catkin_package libraries list. So linking against the library from other packages fails as it is not exported.