### PR TITLE
Implemented APIs to simulate torque control.

### DIFF
--- a/gazebo_msgs/CMakeLists.txt
+++ b/gazebo_msgs/CMakeLists.txt
@@ -25,6 +25,10 @@ add_message_files(
   )
 
 add_service_files(DIRECTORY srv FILES
+  AddForceSensor.srv
+  AddJoint.srv
+  AddLink.srv
+  AddTorqueSensor.srv
   ApplyBodyWrench.srv
   DeleteModel.srv
   GetLinkState.srv

--- a/gazebo_msgs/CMakeLists.txt
+++ b/gazebo_msgs/CMakeLists.txt
@@ -15,6 +15,7 @@ add_message_files(
   FILES
   ContactsState.msg
   ContactState.msg
+  JointStates.msg
   LinkState.msg
   LinkStates.msg
   ModelState.msg
@@ -27,7 +28,6 @@ add_message_files(
 add_service_files(DIRECTORY srv FILES
   AddForceSensor.srv
   AddJoint.srv
-  AddLink.srv
   AddTorqueSensor.srv
   ApplyBodyWrench.srv
   DeleteModel.srv
@@ -36,6 +36,7 @@ add_service_files(DIRECTORY srv FILES
   SetJointProperties.srv
   SetModelConfiguration.srv
   SpawnModel.srv
+  StartTimer.srv
   ApplyJointEffort.srv
   GetJointProperties.srv
   GetModelProperties.srv

--- a/gazebo_msgs/msg/JointStates.msg
+++ b/gazebo_msgs/msg/JointStates.msg
@@ -1,0 +1,4 @@
+# broadcast all joint states in world frame
+string[] name                   # joint names
+float64[] q                     # generalized coordinates
+float64[] dq                    # velocity of q

--- a/gazebo_msgs/msg/LinkStates.msg
+++ b/gazebo_msgs/msg/LinkStates.msg
@@ -2,3 +2,4 @@
 string[] name                 # link names
 geometry_msgs/Pose[] pose     # desired pose in world frame
 geometry_msgs/Twist[] twist   # desired twist in world frame
+string[] reference_frame

--- a/gazebo_msgs/srv/AddForceSensor.srv
+++ b/gazebo_msgs/srv/AddForceSensor.srv
@@ -1,0 +1,3 @@
+string joint_name
+string sensor_name
+---

--- a/gazebo_msgs/srv/AddJoint.srv
+++ b/gazebo_msgs/srv/AddJoint.srv
@@ -1,0 +1,3 @@
+string name
+float64 effort_time
+---

--- a/gazebo_msgs/srv/AddLink.srv
+++ b/gazebo_msgs/srv/AddLink.srv
@@ -1,0 +1,3 @@
+string name
+string reference_frame
+---

--- a/gazebo_msgs/srv/AddLink.srv
+++ b/gazebo_msgs/srv/AddLink.srv
@@ -1,3 +1,0 @@
-string name
-string reference_frame
----

--- a/gazebo_msgs/srv/AddTorqueSensor.srv
+++ b/gazebo_msgs/srv/AddTorqueSensor.srv
@@ -1,0 +1,3 @@
+string joint_name
+string sensor_name
+---

--- a/gazebo_msgs/srv/StartTimer.srv
+++ b/gazebo_msgs/srv/StartTimer.srv
@@ -1,0 +1,5 @@
+float64 duration_write_joint_states
+float64 duration_update_link_states
+float64 duration_read_joint_efforts
+float64 duration_write_forces
+---

--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -35,6 +35,8 @@ catkin_python_setup()
 generate_dynamic_reconfigure_options(cfg/Physics.cfg)
 
 catkin_package(
+  INCLUDE_DIRS
+  include
   LIBRARIES
   gazebo_ros_api_plugin
   gazebo_ros_paths_plugin

--- a/gazebo_ros/include/gazebo_ros/shared_memory.h
+++ b/gazebo_ros/include/gazebo_ros/shared_memory.h
@@ -1,0 +1,127 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, Daichi Yoshikawa
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Daichi Yoshikawa nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Daichi Yoshikawa
+ *
+ *********************************************************************/
+
+#ifndef __GAZEBO_ROS_SHARED_MEMORY_HH__
+#define __GAZEBO_ROS_SHARED_MEMORY_HH__
+
+#include <string>
+#include <memory>
+#include <boost/interprocess/managed_shared_memory.hpp>
+#include <boost/interprocess/sync/named_mutex.hpp>
+#include <boost/interprocess/sync/scoped_lock.hpp>
+#include <boost/interprocess/containers/vector.hpp>
+#include <boost/interprocess/allocators/allocator.hpp>
+
+using namespace boost::interprocess;
+
+namespace gazebo
+{
+
+template<typename T>
+class SharedMemory
+{
+public:
+  explicit SharedMemory(const std::string& name, bool remove = false)
+    : name_(name)
+  {
+    size_ = sizeof(T);
+
+    if(remove)
+    {
+      shared_memory_object::remove(name.c_str());
+    }
+
+    try
+    {
+      shm_ = std::make_shared<shared_memory_object>(open_or_create, name_.c_str(), read_write);
+      shm_->truncate(size_);
+    }
+    catch(interprocess_exception&)
+    {
+      shared_memory_object::remove(name.c_str());
+      shm_ = std::make_shared<shared_memory_object>(open_or_create, name_.c_str(), read_write);
+      shm_->truncate(size_);
+    }
+
+    region_ = std::make_shared<mapped_region>(*shm_, read_write);
+    std::string mutex_name = name + "_mutex";
+    mutex_ = std::make_shared<named_mutex>(open_or_create, mutex_name.c_str());
+    data_ = static_cast<T*>(region_->get_address());
+  }
+
+  void write(const T& val)
+  {
+    scoped_lock<named_mutex> lock(*mutex_);
+    *data_ = val;
+  }
+
+  void read(T& val)
+  {
+    scoped_lock<named_mutex> lock(*mutex_);
+    val = *data_;
+  }
+
+  const std::string& getName() const
+  {
+    return name_;
+  }
+
+  uint32_t getSize()
+  {
+    return size_;
+  }
+
+private:
+  using SharedMemoryObjectPtr = std::shared_ptr<shared_memory_object>;
+  using MappedRegionPtr = std::shared_ptr<mapped_region>;
+  using NamedMutexPtr = std::shared_ptr<named_mutex>;
+
+  std::string name_;
+  uint32_t size_;
+  SharedMemoryObjectPtr shm_;
+  MappedRegionPtr region_;
+  NamedMutexPtr mutex_;
+  T* data_;
+};
+
+template<typename T>
+using SharedMemoryPtr = std::shared_ptr<SharedMemory<T>>;
+
+} // namespace ahl_utils
+
+#endif // __GAZEBO_ROS_SHARED_MEMORY_HH__


### PR DESCRIPTION
I wanted a straight way to do simulation of torque control for mobile manipulator.
In order to do so, I added APIs as the follow.

With the APIs, user can do torque simulation as the follow.
1. By using ROS service "AddJoint", register joints which you'd like to use for torque control.
2. Setup shared memory to share desired torques with gazebo simulator.
3. Send desired torques to gazebo simulator via the above shared memory
4. Gazebo simulator checks shared memory in very short interval(Default: 1ms)
5. If the desired torques are for joints registered in advance, simulator applies the torques to each joint and simulates the behavior.

To realize the above, I did the follows.
- Implemented SharedMemory class in gazebo namespace, which is used to deliver desired torques to gazebo simulator. 
- Added ROS services like AddJoint, to inform gazebo_ros joint which is used for torque control
- Added reception of desired torque to gazebo_ros_api_plugin.cpp
- Added part applying desired torque to proper joint.

Here's an [example](https://github.com/daichi-yoshikawa/ahl_wbc) of torque control simulation using the above APIs.
In [this package](https://github.com/daichi-yoshikawa/ahl_common/tree/master/ahl_gazebo_interface), the APIs are used.

Thank you.