### PR TITLE
Revert catkin warning fix

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -140,8 +140,8 @@ catkin_package(
   camera_info_manager
   std_msgs
   DEPENDS
-    GAZEBO
-    SDFormat
+    gazebo
+    SDF
   )
 add_dependencies(${PROJECT_NAME}_gencfg ${catkin_EXPORTED_TARGETS})
 


### PR DESCRIPTION
See https://github.com/yujinrobot/kobuki_desktop/issues/50 . @davetcoleman the commit causes regressions in different points that would be better resolved by the inclusion of the gazebo_dev (pull request #473). I would prefer not to revert again the commit so let's role a new fast release to solve third party regressions and afterwards merge #473 into the kinetic-devel and lunar-devel branches.