### PR TITLE
Add catkin package(s) to provide the default version of Gazebo (kinetic-devel)

### DIFF
--- a/gazebo_dev/CMakeLists.txt
+++ b/gazebo_dev/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(gazebo_dev)
+
+find_package(catkin REQUIRED)
+
+catkin_package(
+  CFG_EXTRAS gazebo_dev-extras.cmake
+)

--- a/gazebo_dev/cmake/gazebo_dev-extras.cmake
+++ b/gazebo_dev/cmake/gazebo_dev-extras.cmake
@@ -1,0 +1,13 @@
+# Depend on system install of Gazebo
+find_package(gazebo REQUIRED)
+
+message(STATUS "Gazebo version: ${GAZEBO_VERSION}")
+
+# The following lines will tell catkin to add the Gazebo directories and libraries to the
+# respective catkin_* cmake variables.
+set(gazebo_dev_INCLUDE_DIRS ${GAZEBO_INCLUDE_DIRS})
+set(gazebo_dev_LIBRARY_DIRS ${GAZEBO_LIBRARY_DIRS})
+set(gazebo_dev_LIBRARIES ${GAZEBO_LIBRARIES})
+
+# Append gazebo CXX_FLAGS to CMAKE_CXX_FLAGS (c++11)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")

--- a/gazebo_dev/package.xml
+++ b/gazebo_dev/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>gazebo_dev</name>
+  <version>0.0.0</version>
+  <description>
+    Provides a cmake config for the default version of Gazebo for the ROS distribution.
+  </description>
+
+  <maintainer email="hsu@osrfoundation.org">John Hsu</maintainer>
+  <maintainer email="davetcoleman@gmail.com">Dave Coleman</maintainer>
+
+  <license>Apache 2.0</license>
+
+  <url type="website">http://gazebosim.org/tutorials?cat=connect_ros</url>
+  <url type="bugtracker">https://github.com/ros-simulation/gazebo_ros_pkgs/issues</url>
+  <url type="repository">https://github.com/ros-simulation/gazebo_ros_pkgs</url>
+
+  <author>Johannes Meyer</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_export_depend>gazebo</build_export_depend>
+
+</package>

--- a/gazebo_msgs/package.xml
+++ b/gazebo_msgs/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>gazebo_msgs</name>
   <version>2.5.12</version>
   <description>
@@ -25,12 +25,12 @@
   <build_depend>std_srvs</build_depend>
   <build_depend>message_generation</build_depend>
 
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>trajectory_msgs</run_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>message_runtime</run_depend>
-  <run_depend>std_srvs</run_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>trajectory_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>std_srvs</exec_depend>
 </package>
 
 

--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -4,6 +4,7 @@ project(gazebo_plugins)
 option(ENABLE_DISPLAY_TESTS "Enable the building of tests that requires a display" OFF)
 
 find_package(catkin REQUIRED COMPONENTS 
+  gazebo_dev
   message_generation
   gazebo_msgs
   roscpp
@@ -40,10 +41,7 @@ else()
 endif()
 
 # Depend on system install of Gazebo and SDFormat
-find_package(GAZEBO REQUIRED)
-find_package(SDFormat REQUIRED)
 find_package(Boost REQUIRED COMPONENTS thread)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
 
 execute_process(COMMAND
   pkg-config --variable=plugindir OGRE
@@ -63,18 +61,16 @@ generate_dynamic_reconfigure_options(
 include_directories(include
   ${Boost_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
-  ${GAZEBO_INCLUDE_DIRS}
   ${OGRE_INCLUDE_DIRS}
   ${OGRE-Terrain_INCLUDE_DIRS}
   ${OGRE-Paging_INCLUDE_DIRS}
 )
 
 link_directories(
-  ${GAZEBO_LIBRARY_DIRS}
+  ${catkin_LIBRARY_DIRS}
   ${OGRE_LIBRARY_DIRS}
   ${OGRE-Terrain_LIBRARY_DIRS}
   ${OGRE-Paging_LIBRARY_DIRS}
-  ${catkin_LIBRARY_DIRS}
 )
 
 if (NOT GAZEBO_VERSION VERSION_LESS 6.0)
@@ -117,9 +113,9 @@ catkin_package(
   gazebo_ros_planar_move
   gazebo_ros_range
   gazebo_ros_vacuum_gripper
-
-  CATKIN_DEPENDS
-  message_generation
+  
+  CATKIN_DEPENDS 
+  message_runtime
   gazebo_msgs
   roscpp
   rospy
@@ -139,10 +135,7 @@ catkin_package(
   rosconsole
   camera_info_manager
   std_msgs
-  DEPENDS
-    gazebo
-    SDF
-  )
+)
 add_dependencies(${PROJECT_NAME}_gencfg ${catkin_EXPORTED_TARGETS})
 
 ## Executables
@@ -153,7 +146,7 @@ target_link_libraries(hokuyo_node
 )
 
 add_library(gazebo_ros_utils src/gazebo_ros_utils.cpp)
-target_link_libraries(gazebo_ros_utils ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(gazebo_ros_utils ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(vision_reconfigure src/vision_reconfigure.cpp)
 add_dependencies(vision_reconfigure ${PROJECT_NAME}_gencfg)
@@ -164,7 +157,7 @@ add_dependencies(camera_synchronizer ${PROJECT_NAME}_gencfg)
 target_link_libraries(camera_synchronizer vision_reconfigure ${catkin_LIBRARIES})
 
 add_executable(pub_joint_trajectory_test test/pub_joint_trajectory_test.cpp)
-target_link_libraries(pub_joint_trajectory_test ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(pub_joint_trajectory_test ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(pub_joint_trajectory_test ${catkin_EXPORTED_TARGETS}) # don't build until gazebo_msgs is done
 
 add_definitions(-fPIC) # what is this for?
@@ -172,115 +165,115 @@ add_definitions(-fPIC) # what is this for?
 ## Plugins
 add_library(gazebo_ros_camera_utils src/gazebo_ros_camera_utils.cpp)
 add_dependencies(gazebo_ros_camera_utils ${PROJECT_NAME}_gencfg)
-target_link_libraries(gazebo_ros_camera_utils ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(gazebo_ros_camera_utils ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(MultiCameraPlugin src/MultiCameraPlugin.cpp)
-target_link_libraries(MultiCameraPlugin ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(MultiCameraPlugin ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(gazebo_ros_camera src/gazebo_ros_camera.cpp)
 add_dependencies(gazebo_ros_camera ${PROJECT_NAME}_gencfg)
-target_link_libraries(gazebo_ros_camera gazebo_ros_camera_utils ${GAZEBO_LIBRARIES} CameraPlugin ${catkin_LIBRARIES})
+target_link_libraries(gazebo_ros_camera gazebo_ros_camera_utils CameraPlugin ${catkin_LIBRARIES})
 
 if (NOT GAZEBO_VERSION VERSION_LESS 6.0)
   add_library(gazebo_ros_elevator src/gazebo_ros_elevator.cpp)
   add_dependencies(gazebo_ros_elevator ${PROJECT_NAME}_gencfg)
-  target_link_libraries(gazebo_ros_elevator ${GAZEBO_LIBRARIES} ElevatorPlugin ${catkin_LIBRARIES})
+  target_link_libraries(gazebo_ros_elevator ElevatorPlugin ${catkin_LIBRARIES})
 endif()
 
 add_library(gazebo_ros_multicamera src/gazebo_ros_multicamera.cpp)
 add_dependencies(gazebo_ros_multicamera ${PROJECT_NAME}_gencfg)
-target_link_libraries(gazebo_ros_multicamera gazebo_ros_camera_utils ${GAZEBO_LIBRARIES} MultiCameraPlugin ${catkin_LIBRARIES})
+target_link_libraries(gazebo_ros_multicamera gazebo_ros_camera_utils MultiCameraPlugin ${catkin_LIBRARIES})
 
 add_library(gazebo_ros_depth_camera src/gazebo_ros_depth_camera.cpp)
 add_dependencies(gazebo_ros_depth_camera ${PROJECT_NAME}_gencfg)
-target_link_libraries(gazebo_ros_depth_camera gazebo_ros_camera_utils ${GAZEBO_LIBRARIES} DepthCameraPlugin ${catkin_LIBRARIES})
+target_link_libraries(gazebo_ros_depth_camera gazebo_ros_camera_utils DepthCameraPlugin ${catkin_LIBRARIES})
 
 add_library(gazebo_ros_openni_kinect src/gazebo_ros_openni_kinect.cpp)
 add_dependencies(gazebo_ros_openni_kinect ${PROJECT_NAME}_gencfg)
-target_link_libraries(gazebo_ros_openni_kinect gazebo_ros_camera_utils ${GAZEBO_LIBRARIES} DepthCameraPlugin ${catkin_LIBRARIES})
+target_link_libraries(gazebo_ros_openni_kinect gazebo_ros_camera_utils DepthCameraPlugin ${catkin_LIBRARIES})
 
 add_library(gazebo_ros_gpu_laser src/gazebo_ros_gpu_laser.cpp)
-target_link_libraries(gazebo_ros_gpu_laser ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES} GpuRayPlugin)
+target_link_libraries(gazebo_ros_gpu_laser ${catkin_LIBRARIES} GpuRayPlugin)
 
 if (NOT GAZEBO_VERSION VERSION_LESS 7.3)
   add_library(gazebo_ros_harness src/gazebo_ros_harness.cpp)
   add_dependencies(gazebo_ros_harness ${catkin_EXPORTED_TARGETS})
-  target_link_libraries(gazebo_ros_harness ${GAZEBO_LIBRARIES}
+  target_link_libraries(gazebo_ros_harness
     ${Boost_LIBRARIES} HarnessPlugin ${catkin_LIBRARIES})
 endif()
 
 add_library(gazebo_ros_laser src/gazebo_ros_laser.cpp)
-target_link_libraries(gazebo_ros_laser ${GAZEBO_LIBRARIES} RayPlugin ${catkin_LIBRARIES})
+target_link_libraries(gazebo_ros_laser RayPlugin ${catkin_LIBRARIES})
 
 add_library(gazebo_ros_block_laser src/gazebo_ros_block_laser.cpp)
-target_link_libraries(gazebo_ros_block_laser ${GAZEBO_LIBRARIES} RayPlugin ${catkin_LIBRARIES})
+target_link_libraries(gazebo_ros_block_laser RayPlugin ${catkin_LIBRARIES})
 
 add_library(gazebo_ros_p3d src/gazebo_ros_p3d.cpp)
-target_link_libraries(gazebo_ros_p3d ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(gazebo_ros_p3d ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(gazebo_ros_imu src/gazebo_ros_imu.cpp)
-target_link_libraries(gazebo_ros_imu ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(gazebo_ros_imu ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(gazebo_ros_f3d src/gazebo_ros_f3d.cpp)
-target_link_libraries(gazebo_ros_f3d ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(gazebo_ros_f3d ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(gazebo_ros_bumper src/gazebo_ros_bumper.cpp)
 add_dependencies(gazebo_ros_bumper ${catkin_EXPORTED_TARGETS})
-target_link_libraries(gazebo_ros_bumper ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES} ContactPlugin ${catkin_LIBRARIES})
+target_link_libraries(gazebo_ros_bumper ${Boost_LIBRARIES} ContactPlugin ${catkin_LIBRARIES})
 
 add_library(gazebo_ros_projector src/gazebo_ros_projector.cpp)
-target_link_libraries(gazebo_ros_projector ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES} ${catkin_LIBRARIES})
+target_link_libraries(gazebo_ros_projector ${Boost_LIBRARIES} ${catkin_LIBRARIES})
 
 add_library(gazebo_ros_prosilica src/gazebo_ros_prosilica.cpp)
 add_dependencies(gazebo_ros_prosilica ${PROJECT_NAME}_gencfg)
-target_link_libraries(gazebo_ros_prosilica gazebo_ros_camera_utils ${GAZEBO_LIBRARIES} CameraPlugin ${catkin_LIBRARIES})
+target_link_libraries(gazebo_ros_prosilica gazebo_ros_camera_utils CameraPlugin ${catkin_LIBRARIES})
 
 add_library(gazebo_ros_force src/gazebo_ros_force.cpp)
-target_link_libraries(gazebo_ros_force ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(gazebo_ros_force ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(gazebo_ros_joint_trajectory src/gazebo_ros_joint_trajectory.cpp)
 add_dependencies(gazebo_ros_joint_trajectory ${catkin_EXPORTED_TARGETS})
-target_link_libraries(gazebo_ros_joint_trajectory ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(gazebo_ros_joint_trajectory ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 
 add_library(gazebo_ros_joint_state_publisher src/gazebo_ros_joint_state_publisher.cpp)
 set_target_properties(gazebo_ros_joint_state_publisher PROPERTIES LINK_FLAGS "${ld_flags}")
 set_target_properties(gazebo_ros_joint_state_publisher PROPERTIES COMPILE_FLAGS "${cxx_flags}")
 add_dependencies(gazebo_ros_joint_state_publisher ${catkin_EXPORTED_TARGETS})
-target_link_libraries(gazebo_ros_joint_state_publisher ${GAZEBO_LIBRARIES} ${SDFormat_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(gazebo_ros_joint_state_publisher ${SDFormat_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(gazebo_ros_joint_pose_trajectory src/gazebo_ros_joint_pose_trajectory.cpp)
 add_dependencies(gazebo_ros_joint_pose_trajectory ${catkin_EXPORTED_TARGETS})
-target_link_libraries(gazebo_ros_joint_pose_trajectory ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(gazebo_ros_joint_pose_trajectory ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(gazebo_ros_diff_drive src/gazebo_ros_diff_drive.cpp)
-target_link_libraries(gazebo_ros_diff_drive gazebo_ros_utils ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(gazebo_ros_diff_drive gazebo_ros_utils ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(gazebo_ros_tricycle_drive src/gazebo_ros_tricycle_drive.cpp)
-target_link_libraries(gazebo_ros_tricycle_drive gazebo_ros_utils ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES} ${catkin_LIBRARIES})
+target_link_libraries(gazebo_ros_tricycle_drive gazebo_ros_utils ${Boost_LIBRARIES} ${catkin_LIBRARIES})
 
 add_library(gazebo_ros_skid_steer_drive src/gazebo_ros_skid_steer_drive.cpp)
-target_link_libraries(gazebo_ros_skid_steer_drive ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(gazebo_ros_skid_steer_drive ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(gazebo_ros_video src/gazebo_ros_video.cpp)
-target_link_libraries(gazebo_ros_video ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OGRE_LIBRARIES})
+target_link_libraries(gazebo_ros_video ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OGRE_LIBRARIES})
 
 add_library(gazebo_ros_planar_move src/gazebo_ros_planar_move.cpp)
-target_link_libraries(gazebo_ros_planar_move ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(gazebo_ros_planar_move ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(gazebo_ros_hand_of_god src/gazebo_ros_hand_of_god.cpp)
 set_target_properties(gazebo_ros_hand_of_god PROPERTIES LINK_FLAGS "${ld_flags}")
 set_target_properties(gazebo_ros_hand_of_god PROPERTIES COMPILE_FLAGS "${cxx_flags}")
-target_link_libraries(gazebo_ros_hand_of_god ${GAZEBO_LIBRARIES} ${SDFormat_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(gazebo_ros_hand_of_god ${SDFormat_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(gazebo_ros_ft_sensor src/gazebo_ros_ft_sensor.cpp)
-target_link_libraries(gazebo_ros_ft_sensor ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(gazebo_ros_ft_sensor ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(gazebo_ros_range src/gazebo_ros_range.cpp)
-target_link_libraries(gazebo_ros_range ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES} RayPlugin)
+target_link_libraries(gazebo_ros_range ${catkin_LIBRARIES} ${Boost_LIBRARIES} RayPlugin)
 
 add_library(gazebo_ros_vacuum_gripper src/gazebo_ros_vacuum_gripper.cpp)
-target_link_libraries(gazebo_ros_vacuum_gripper ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(gazebo_ros_vacuum_gripper ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 ##
 ## Add your new plugin here
@@ -288,7 +281,7 @@ target_link_libraries(gazebo_ros_vacuum_gripper ${GAZEBO_LIBRARIES} ${catkin_LIB
 
 ## Template
 add_library(gazebo_ros_template src/gazebo_ros_template.cpp)
-target_link_libraries(gazebo_ros_template ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(gazebo_ros_template ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 install(TARGETS
   hokuyo_node

--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -40,7 +40,6 @@ else()
   message(FATAL_ERROR "pkg-config is required; please install it")
 endif()
 
-# Depend on system install of Gazebo and SDFormat
 find_package(Boost REQUIRED COMPONENTS thread)
 
 execute_process(COMMAND
@@ -240,7 +239,7 @@ add_library(gazebo_ros_joint_state_publisher src/gazebo_ros_joint_state_publishe
 set_target_properties(gazebo_ros_joint_state_publisher PROPERTIES LINK_FLAGS "${ld_flags}")
 set_target_properties(gazebo_ros_joint_state_publisher PROPERTIES COMPILE_FLAGS "${cxx_flags}")
 add_dependencies(gazebo_ros_joint_state_publisher ${catkin_EXPORTED_TARGETS})
-target_link_libraries(gazebo_ros_joint_state_publisher ${SDFormat_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(gazebo_ros_joint_state_publisher ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(gazebo_ros_joint_pose_trajectory src/gazebo_ros_joint_pose_trajectory.cpp)
 add_dependencies(gazebo_ros_joint_pose_trajectory ${catkin_EXPORTED_TARGETS})
@@ -264,16 +263,13 @@ target_link_libraries(gazebo_ros_planar_move ${catkin_LIBRARIES} ${Boost_LIBRARI
 add_library(gazebo_ros_hand_of_god src/gazebo_ros_hand_of_god.cpp)
 set_target_properties(gazebo_ros_hand_of_god PROPERTIES LINK_FLAGS "${ld_flags}")
 set_target_properties(gazebo_ros_hand_of_god PROPERTIES COMPILE_FLAGS "${cxx_flags}")
-target_link_libraries(gazebo_ros_hand_of_god ${SDFormat_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(gazebo_ros_hand_of_god ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(gazebo_ros_ft_sensor src/gazebo_ros_ft_sensor.cpp)
 target_link_libraries(gazebo_ros_ft_sensor ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(gazebo_ros_range src/gazebo_ros_range.cpp)
 target_link_libraries(gazebo_ros_range ${catkin_LIBRARIES} ${Boost_LIBRARIES} RayPlugin)
-
-add_library(gazebo_ros_vacuum_gripper src/gazebo_ros_vacuum_gripper.cpp)
-target_link_libraries(gazebo_ros_vacuum_gripper ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 ##
 ## Add your new plugin here
@@ -315,6 +311,7 @@ install(TARGETS
   gazebo_ros_skid_steer_drive
   gazebo_ros_video
   gazebo_ros_planar_move
+  pub_joint_trajectory_test
   gazebo_ros_vacuum_gripper
   pub_joint_trajectory_test
   gazebo_ros_gpu_laser

--- a/gazebo_plugins/package.xml
+++ b/gazebo_plugins/package.xml
@@ -1,4 +1,5 @@
-<package>
+<?xml version="1.0"?>
+<package format="2">
   <name>gazebo_plugins</name>
   <version>2.5.12</version>
   <description>
@@ -17,62 +18,35 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>gazebo_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>libgazebo7-dev</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>trajectory_msgs</build_depend>
-  <build_depend>std_srvs</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>rospy</build_depend>
-  <build_depend>nodelet</build_depend>
-  <build_depend>angles</build_depend>
-  <build_depend>nav_msgs</build_depend>
-  <build_depend>urdf</build_depend>
-  <build_depend>tf</build_depend>
-  <build_depend>tf2_ros</build_depend>
-  <build_depend>dynamic_reconfigure</build_depend>
-  <build_depend>rosgraph_msgs</build_depend>
-  <build_depend>image_transport</build_depend>
-  <build_depend>rosconsole</build_depend>
+  <build_depend>gazebo_dev</build_depend>
+  <exec_depend>gazebo</exec_depend>
+
+  <depend>gazebo_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>trajectory_msgs</depend>
+  <depend>std_srvs</depend>
+  <depend>roscpp</depend>
+  <depend>rospy</depend>
+  <depend>nodelet</depend>
+  <depend>angles</depend>
+  <depend>nav_msgs</depend>
+  <depend>urdf</depend>
+  <depend>tf</depend>
+  <depend>tf2_ros</depend>
+  <depend>dynamic_reconfigure</depend>
+  <depend>driver_base</depend>
+  <depend>rosgraph_msgs</depend>
+  <depend>image_transport</depend>
+  <depend>rosconsole</depend>
   <build_depend>message_generation</build_depend>
-  <build_depend>cv_bridge</build_depend>
-  <build_depend>polled_camera</build_depend>
-  <build_depend>diagnostic_updater</build_depend>
-  <build_depend>camera_info_manager</build_depend>
-  <build_depend>std_msgs</build_depend>
+  <exec_depend>message_runtime</exec_depend>
+  <depend>cv_bridge</depend>
+  <depend>polled_camera</depend>
+  <depend>diagnostic_updater</depend>
+  <depend>camera_info_manager</depend>
+  <depend>std_msgs</depend>
 
-  <run_depend>gazebo_msgs</run_depend>
-  <run_depend>gazebo_ros</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <!--
-    Need to use libgazebo7-dev since run script needs pkg-config
-    See: https://github.com/ros-simulation/gazebo_ros_pkgs/issues/323 for more info
-  -->
-  <run_depend>libgazebo7-dev</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>trajectory_msgs</run_depend>
-  <run_depend>std_srvs</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>nodelet</run_depend>
-  <run_depend>angles</run_depend>
-  <run_depend>nav_msgs</run_depend>
-  <run_depend>urdf</run_depend>
-  <run_depend>tf</run_depend>
-  <run_depend>tf2_ros</run_depend>
-  <run_depend>dynamic_reconfigure</run_depend>
-  <run_depend>rosgraph_msgs</run_depend>
-  <run_depend>image_transport</run_depend>
-  <run_depend>rosconsole</run_depend>
-  <run_depend>message_generation</run_depend>
-  <run_depend>cv_bridge</run_depend>
-  <run_depend>polled_camera</run_depend>
-  <run_depend>camera_info_manager</run_depend>
-  <run_depend>std_msgs</run_depend>
-
-  <!-- When moved to format 2, this can be turned test_depend -->
-  <build_depend>rostest</build_depend>
-  <run_depend>rostest</run_depend>
+  <test_depend>rostest</test_depend>
 
 </package>

--- a/gazebo_plugins/package.xml
+++ b/gazebo_plugins/package.xml
@@ -35,7 +35,6 @@
   <depend>tf</depend>
   <depend>tf2_ros</depend>
   <depend>dynamic_reconfigure</depend>
-  <depend>driver_base</depend>
   <depend>rosgraph_msgs</depend>
   <depend>image_transport</depend>
   <depend>rosconsole</depend>

--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(gazebo_ros)
 
 find_package(catkin REQUIRED COMPONENTS
+  gazebo_dev
   cmake_modules
   roslib
   roscpp
@@ -10,7 +11,6 @@ find_package(catkin REQUIRED COMPONENTS
   tf
   rosgraph_msgs
   dynamic_reconfigure
-  message_generation
   std_msgs
   gazebo_msgs
 )
@@ -21,10 +21,6 @@ if (PKG_CONFIG_FOUND)
 else()
   message(FATAL_ERROR "pkg-config is required; please install it")
 endif()
-
-# Depend on system install of Gazebo
-find_package(gazebo REQUIRED)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
 
 find_package(Boost REQUIRED COMPONENTS thread)
 
@@ -47,7 +43,6 @@ catkin_package(
     tf
     rosgraph_msgs
     dynamic_reconfigure
-    message_generation
     std_msgs
     gazebo_msgs
 
@@ -59,10 +54,8 @@ include_directories(
   include
   ${Boost_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
-  ${GAZEBO_INCLUDE_DIRS}
   ${SDFormat_INCLUDE_DIRS}
-  ${TinyXML_INCLUDE_DIRS}
-)
+  ${TinyXML_INCLUDE_DIRS})
 
 link_directories(${catkin_LIBRARY_DIRS})
 
@@ -76,25 +69,23 @@ foreach (item ${GAZEBO_LDFLAGS})
   set(ld_flags "${ld_flags} ${item}")
 endforeach ()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
-
 ## Plugins
 add_library(gazebo_ros_api_plugin src/gazebo_ros_api_plugin.cpp)
 add_dependencies(gazebo_ros_api_plugin ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 set_target_properties(gazebo_ros_api_plugin PROPERTIES LINK_FLAGS "${ld_flags}")
 set_target_properties(gazebo_ros_api_plugin PROPERTIES COMPILE_FLAGS "${cxx_flags}")
-target_link_libraries(gazebo_ros_api_plugin ${GAZEBO_LIBRARIES} ${SDFormat_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${TinyXML_LIBRARIES})
+target_link_libraries(gazebo_ros_api_plugin ${SDFormat_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${TinyXML_LIBRARIES})
 
 add_library(gazebo_ros_paths_plugin src/gazebo_ros_paths_plugin.cpp)
 add_dependencies(gazebo_ros_paths_plugin ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 set_target_properties(gazebo_ros_paths_plugin PROPERTIES COMPILE_FLAGS "${cxx_flags}")
 set_target_properties(gazebo_ros_paths_plugin PROPERTIES LINK_FLAGS "${ld_flags}")
-target_link_libraries(gazebo_ros_paths_plugin ${GAZEBO_LIBRARIES} ${SDFormat_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(gazebo_ros_paths_plugin ${SDFormat_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 # Install Gazebo System Plugins
 install(TARGETS gazebo_ros_api_plugin gazebo_ros_paths_plugin
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-)
+  )
 
 # Install Gazebo Scripts
 install(PROGRAMS scripts/gazebo

--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -54,7 +54,6 @@ include_directories(
   include
   ${Boost_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
-  ${SDFormat_INCLUDE_DIRS}
   ${TinyXML_INCLUDE_DIRS})
 
 link_directories(${catkin_LIBRARY_DIRS})
@@ -74,13 +73,13 @@ add_library(gazebo_ros_api_plugin src/gazebo_ros_api_plugin.cpp)
 add_dependencies(gazebo_ros_api_plugin ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 set_target_properties(gazebo_ros_api_plugin PROPERTIES LINK_FLAGS "${ld_flags}")
 set_target_properties(gazebo_ros_api_plugin PROPERTIES COMPILE_FLAGS "${cxx_flags}")
-target_link_libraries(gazebo_ros_api_plugin ${SDFormat_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${TinyXML_LIBRARIES})
+target_link_libraries(gazebo_ros_api_plugin ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${TinyXML_LIBRARIES})
 
 add_library(gazebo_ros_paths_plugin src/gazebo_ros_paths_plugin.cpp)
 add_dependencies(gazebo_ros_paths_plugin ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 set_target_properties(gazebo_ros_paths_plugin PROPERTIES COMPILE_FLAGS "${cxx_flags}")
 set_target_properties(gazebo_ros_paths_plugin PROPERTIES LINK_FLAGS "${ld_flags}")
-target_link_libraries(gazebo_ros_paths_plugin ${SDFormat_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(gazebo_ros_paths_plugin ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 # Install Gazebo System Plugins
 install(TARGETS gazebo_ros_api_plugin gazebo_ros_paths_plugin

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>gazebo_ros</name>
-  <version>2.5.12</version>
+  <version>2.4.11</version>
   <description>
     Provides ROS plugins that offer message and service publishers for interfacing with <a href="http://gazebosim.org">Gazebo</a> through ROS.
     Formally simulator_gazebo/gazebo
@@ -22,38 +22,21 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>cmake_modules</build_depend>
-  <build_depend>gazebo_msgs</build_depend>
-  <build_depend>libgazebo7-dev</build_depend>
-  <build_depend>roslib</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>tf</build_depend>
-  <build_depend>std_srvs</build_depend>
-  <build_depend>rosgraph_msgs</build_depend>
-  <build_depend>dynamic_reconfigure</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>message_generation</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>tinyxml</build_depend>
-
-  <run_depend>gazebo_msgs</run_depend>
-  <!-- Needed to pull in the setup.sh file for the tests -->
-  <run_depend>gazebo</run_depend>
+  <build_depend>gazebo_dev</build_depend>
   <!--
-    Need to use libgazebo7-dev since run script needs pkg-config
+    Need to use gazebo_dev since run script needs pkg-config
     See: https://github.com/ros-simulation/gazebo_ros_pkgs/issues/323 for more info
   -->
-  <run_depend>libgazebo7-dev</run_depend>
-  <run_depend>roslib</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>tf</run_depend>
-  <run_depend>std_srvs</run_depend>
-  <run_depend>rosgraph_msgs</run_depend>
-  <run_depend>dynamic_reconfigure</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>message_generation</run_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>tinyxml</run_depend>
-
+  <exec_depend>gazebo_dev</exec_depend>
+  <depend>gazebo_msgs</depend>
+  <depend>roslib</depend>
+  <depend>roscpp</depend>
+  <depend>tf</depend>
+  <depend>std_srvs</depend>
+  <depend>rosgraph_msgs</depend>
+  <depend>dynamic_reconfigure</depend>
+  <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>tinyxml</depend>
 
 </package>

--- a/gazebo_ros_control/CMakeLists.txt
+++ b/gazebo_ros_control/CMakeLists.txt
@@ -3,6 +3,7 @@ project(gazebo_ros_control)
 
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS
+  gazebo_dev
   roscpp
   std_msgs
   control_toolbox
@@ -14,12 +15,6 @@ find_package(catkin REQUIRED COMPONENTS
   urdf
   angles
 )
-
-# Depend on system install of Gazebo
-find_package(GAZEBO REQUIRED)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
-
-find_package(Boost REQUIRED COMPONENTS thread)
 
 catkin_package(
   CATKIN_DEPENDS
@@ -33,33 +28,25 @@ catkin_package(
     joint_limits_interface
     urdf
     angles
-  DEPENDS
-    #GAZEBO  # Re-enable after issue resolved:
-    # https://bitbucket.org/osrf/gazebo/issues/2198/gazebo7-linking-error-with-cmake-catkin
-  INCLUDE_DIRS
-    include
-  LIBRARIES
-    ${PROJECT_NAME}
-    default_robot_hw_sim
+  INCLUDE_DIRS include
+  LIBRARIES ${PROJECT_NAME} default_robot_hw_sim
 )
 
 link_directories(
-  ${GAZEBO_LIBRARY_DIRS}
   ${catkin_LIBRARY_DIRS}
 )
 
 include_directories(include
   ${Boost_INCLUDE_DIR}
   ${catkin_INCLUDE_DIRS}
-  ${GAZEBO_INCLUDE_DIRS}
 )
 
 ## Libraries
 add_library(${PROJECT_NAME} src/gazebo_ros_control_plugin.cpp)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
 add_library(default_robot_hw_sim src/default_robot_hw_sim.cpp)
-target_link_libraries(default_robot_hw_sim ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
+target_link_libraries(default_robot_hw_sim ${catkin_LIBRARIES})
 
 ## Install
 install(TARGETS ${PROJECT_NAME} default_robot_hw_sim

--- a/gazebo_ros_control/package.xml
+++ b/gazebo_ros_control/package.xml
@@ -1,6 +1,7 @@
-<package>
+<?xml version="1.0"?>
+<package format="2">
   <name>gazebo_ros_control</name>
-  <version>2.5.12</version>
+  <version>2.4.11</version>
   <description>gazebo_ros_control</description>
 
   <maintainer email="jrivero@osrfoundation.org">Jose Luis Rivero</maintainer>
@@ -16,34 +17,19 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>roscpp</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>control_toolbox</build_depend>
-  <build_depend>controller_manager</build_depend>
-  <build_depend>libgazebo7-dev</build_depend>
-  <build_depend>pluginlib</build_depend>
-  <build_depend>hardware_interface</build_depend>
-  <build_depend>transmission_interface</build_depend>
-  <build_depend>joint_limits_interface</build_depend>
-  <build_depend>urdf</build_depend>
-  <build_depend>angles</build_depend>
-
-  <run_depend>roscpp</run_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>gazebo_ros</run_depend>
-  <!--
-    Need to use libgazebo7-dev since run script needs pkg-config
-    See: https://github.com/ros-simulation/gazebo_ros_pkgs/issues/323 for more info
-  -->
-  <run_depend>libgazebo7-dev</run_depend>
-  <run_depend>control_toolbox</run_depend>
-  <run_depend>controller_manager</run_depend>
-  <run_depend>pluginlib</run_depend>
-  <run_depend>hardware_interface</run_depend>
-  <run_depend>joint_limits_interface</run_depend>
-  <run_depend>transmission_interface</run_depend>
-  <run_depend>urdf</run_depend>
-  <run_depend>angles</run_depend>
+  <build_depend>gazebo_dev</build_depend>
+  <exec_depend>gazebo</exec_depend>
+  <exec_depend>gazebo_ros</exec_depend>
+  <depend>roscpp</depend>
+  <depend>std_msgs</depend>
+  <depend>control_toolbox</depend>
+  <depend>controller_manager</depend>
+  <depend>pluginlib</depend>
+  <depend>hardware_interface</depend>
+  <depend>transmission_interface</depend>
+  <depend>joint_limits_interface</depend>
+  <depend>urdf</depend>
+  <depend>angles</depend>
 
   <export>
     <gazebo_ros_control plugin="${prefix}/robot_hw_sim_plugins.xml"/>

--- a/gazebo_ros_pkgs/package.xml
+++ b/gazebo_ros_pkgs/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>gazebo_ros_pkgs</name> <!-- This is a meta package! -->
   <version>2.5.12</version>
   <description>Interface for using ROS with the <a href="http://gazebosim.org/">Gazebo</a> simulator.</description>
@@ -16,9 +16,10 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>gazebo_msgs</run_depend>
-  <run_depend>gazebo_plugins</run_depend>
-  <run_depend>gazebo_ros</run_depend>
+  <exec_depend>gazebo_dev</exec_depend>
+  <exec_depend>gazebo_msgs</exec_depend>
+  <exec_depend>gazebo_plugins</exec_depend>
+  <exec_depend>gazebo_ros</exec_depend>
 
   <export>
     <metapackage/>


### PR DESCRIPTION
{ port of pull request #473 }

As a follow-up of the discussion in https://github.com/tu-darmstadt-ros-pkg/hector_gazebo/pull/30 (@mikepurvis, @tfoote, @meyerj), I created a proof-of-concept catkin package `gazebo_dev`.

The new package contains no code and its main purpose is to depend on the respective ROS distro's default version of the Gazebo development library package. Other packages that want to link to the Gazebo libraries can in turn depend on `gazebo_dev`, removing the need to maintain separate branches for different ROS and Gazebo versions as long as the source code is compatible. The current practice of depending on `gazebo_ros` pulls in some unnecessary dependencies (see [original discussion](https://github.com/tu-darmstadt-ros-pkg/hector_gazebo/pull/30#issuecomment-227872716)).
Secondary, the package provides a cmake script exposed via catkin's [CFG_EXTRAS mechanism](http://docs.ros.org/indigo/api/catkin/html/dev_guide/generated_cmake_api.html#catkin-package) so that the `gazebo_dev` package can be used in the same way as any other catkin package without the need to find the Gazebo libraries or apply C++ flags explicitly. I modified the other packages in this repository to only depend on `gazebo_dev` and removed the obsolete cmake code. It should be noted that all packages that directly depend on `gazebo_dev` will compile in C++11 mode because of the addition of `GAZEBO_CXX_FLAGS` to `CMAKE_CXX_FLAGS`. That's why this dependency has not been exported via the `CATKIN_DEPENDS` key of `catkin_package()` in the `gazebo_plugins` package. Derived packages have to depend on `gazebo_dev` explicitly.

Possible extensions would be a check in [gazebo_dev-extras.cmake](https://github.com/ros-simulation/gazebo_ros_pkgs/compare/indigo-devel...meyerj:indigo-gazebo-dev?expand=1#diff-3deb71e85d4c63095f615914b7270470) whether the found Gazebo version is indeed the expected one or even to provide a way to override the required version by means of cmake variables.

The `gazebo_dev` package does not declare a run-time dependency for the same Gazebo version at the moment. I am not sure if this is required. A rosdep key `gazebo_default` could be established that points to the correct gazebo binary package, so that derived packages like gazebo_plugins can build_depend on `gazebo_dev` and exec_depend on `gazebo_default`. Or is there a need for a separate run-time only package with that name, which would provide the per-distro `gazebo_default` key? Like

```
gazebo <----------\
libgazebo5-dev <---+--(build_export_depend)-- gazebo_dev (ROS) <------\
libgazebo7-dev <--/                                                 (build_depend)
                                                                        +---------- gazebo_plugins (ROS)
gazebo <---\                                                        (exec_depend)
gazebo5 <---+----------(exec_depend)--------- gazebo_default (ROS) <--/
gazebo7 <--/
```

This patch also converts all package manifest to format 2 according to [REP 140](http://www.ros.org/reps/rep-0140.html) to be able to use the new `<build_export_depend>` tag. Furthermore it removes the unnecessary dependency `message_generation` from package `gazebo_ros`.

I also created a [branch indigo-gazebo-dev](https://github.com/meyerj/hector_gazebo/tree/indigo-gazebo-dev) in [hector_gazebo](http://wiki.ros.org/hector_gazebo) ([diff](https://github.com/tu-darmstadt-ros-pkg/hector_gazebo/compare/indigo-devel...meyerj:indigo-gazebo-dev)) which applies a patch to use the new `gazebo_dev` package and which compiles successfully in ROS indigo, jade and kinetic with the respective default Gazebo versions.
