### PR TITLE
Parameter to disable ROS network interaction from/to Gazebo (indigo-devel)

### DIFF
--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -90,6 +90,9 @@ set_target_properties(gazebo_ros_paths_plugin PROPERTIES COMPILE_FLAGS "${cxx_fl
 set_target_properties(gazebo_ros_paths_plugin PROPERTIES LINK_FLAGS "${ld_flags}")
 target_link_libraries(gazebo_ros_paths_plugin ${GAZEBO_LIBRARIES} ${SDFormat_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
+## Tests
+add_subdirectory(test)
+
 # Install Gazebo System Plugins
 install(TARGETS gazebo_ros_api_plugin gazebo_ros_paths_plugin
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
+++ b/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
@@ -108,13 +108,13 @@ public:
 
   /// \brief Destructor
   ~GazeboRosApiPlugin();
-  
+
   /// \bried Detect if sig-int shutdown signal is recieved
   void shutdownSignal();
 
   /// \brief Gazebo-inherited load function
-  /// 
-  /// Called before Gazebo is loaded. Must not block. 
+  ///
+  /// Called before Gazebo is loaded. Must not block.
   /// Capitalized per Gazebo cpp style guidelines
   /// \param _argc Number of command line arguments.
   /// \param _argv Array of command line arguments.
@@ -139,13 +139,12 @@ public:
   void onModelStatesDisconnect();
 
   /// \brief Function for inserting a URDF into Gazebo from ROS Service Call
-  bool spawnURDFModel(gazebo_msgs::SpawnModel::Request &req,gazebo_msgs::SpawnModel::Response &res);
-
-  /// \brief Function for inserting a URDF into Gazebo from ROS Service Call. Deprecated in ROS Hydro - replace with spawnURDFModel()
-  ROS_DEPRECATED bool spawnGazeboModel(gazebo_msgs::SpawnModel::Request &req,gazebo_msgs::SpawnModel::Response &res);
+  bool spawnURDFModel(gazebo_msgs::SpawnModel::Request &req,
+                      gazebo_msgs::SpawnModel::Response &res);
 
   /// \brief Both SDFs and converted URDFs get sent to this function for further manipulation from a ROS Service call
-  bool spawnSDFModel(gazebo_msgs::SpawnModel::Request &req,gazebo_msgs::SpawnModel::Response &res);
+  bool spawnSDFModel(gazebo_msgs::SpawnModel::Request &req,
+                     gazebo_msgs::SpawnModel::Response &res);
 
   /// \brief delete model given name
   bool deleteModel(gazebo_msgs::DeleteModel::Request &req,gazebo_msgs::DeleteModel::Response &res);
@@ -243,21 +242,21 @@ private:
   void stripXmlDeclaration(std::string &model_xml);
 
   /// \brief Update the model name and pose of the SDF file before sending to Gazebo
-  void updateSDFAttributes(TiXmlDocument &gazebo_model_xml, std::string model_name, 
+  void updateSDFAttributes(TiXmlDocument &gazebo_model_xml, std::string model_name,
                            gazebo::math::Vector3 initial_xyz, gazebo::math::Quaternion initial_q);
 
   /// \brief Update the model pose of the URDF file before sending to Gazebo
-  void updateURDFModelPose(TiXmlDocument &gazebo_model_xml, 
+  void updateURDFModelPose(TiXmlDocument &gazebo_model_xml,
                            gazebo::math::Vector3 initial_xyz, gazebo::math::Quaternion initial_q);
 
   /// \brief Update the model name of the URDF file before sending to Gazebo
   void updateURDFName(TiXmlDocument &gazebo_model_xml, std::string model_name);
 
   /// \brief
-  void walkChildAddRobotNamespace(TiXmlNode* robot_xml);
+  void walkChildAddRobotNamespace(TiXmlNode* model_xml);
 
   /// \brief
-  bool spawnAndConform(TiXmlDocument &gazebo_model_xml, std::string model_name, 
+  bool spawnAndConform(TiXmlDocument &gazebo_model_xml, std::string model_name,
                        gazebo_msgs::SpawnModel::Response &res);
 
   /// \brief helper function for applyBodyWrench
@@ -294,7 +293,7 @@ private:
   bool plugin_loaded_;
 
   // detect if sigint event occurs
-  bool stop_; 
+  bool stop_;
   gazebo::event::ConnectionPtr sigint_event_;
 
   std::string robot_namespace_;
@@ -317,7 +316,6 @@ private:
   gazebo::event::ConnectionPtr pub_model_states_event_;
   gazebo::event::ConnectionPtr load_gazebo_ros_api_plugin_event_;
 
-  ros::ServiceServer spawn_gazebo_model_service_; // DEPRECATED IN HYDRO
   ros::ServiceServer spawn_sdf_model_service_;
   ros::ServiceServer spawn_urdf_model_service_;
   ros::ServiceServer delete_model_service_;
@@ -389,6 +387,8 @@ private:
   std::vector<GazeboRosApiPlugin::WrenchBodyJob*> wrench_body_jobs_;
   std::vector<GazeboRosApiPlugin::ForceJointJob*> force_joint_jobs_;
 
+  /// \brief enable the communication of gazebo information using ROS service/topics
+  bool enable_ros_network_;
 };
 }
 #endif

--- a/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
+++ b/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
@@ -108,13 +108,13 @@ public:
 
   /// \brief Destructor
   ~GazeboRosApiPlugin();
-
+  
   /// \bried Detect if sig-int shutdown signal is recieved
   void shutdownSignal();
 
   /// \brief Gazebo-inherited load function
-  ///
-  /// Called before Gazebo is loaded. Must not block.
+  /// 
+  /// Called before Gazebo is loaded. Must not block. 
   /// Capitalized per Gazebo cpp style guidelines
   /// \param _argc Number of command line arguments.
   /// \param _argv Array of command line arguments.
@@ -139,12 +139,13 @@ public:
   void onModelStatesDisconnect();
 
   /// \brief Function for inserting a URDF into Gazebo from ROS Service Call
-  bool spawnURDFModel(gazebo_msgs::SpawnModel::Request &req,
-                      gazebo_msgs::SpawnModel::Response &res);
+  bool spawnURDFModel(gazebo_msgs::SpawnModel::Request &req,gazebo_msgs::SpawnModel::Response &res);
+
+  /// \brief Function for inserting a URDF into Gazebo from ROS Service Call. Deprecated in ROS Hydro - replace with spawnURDFModel()
+  ROS_DEPRECATED bool spawnGazeboModel(gazebo_msgs::SpawnModel::Request &req,gazebo_msgs::SpawnModel::Response &res);
 
   /// \brief Both SDFs and converted URDFs get sent to this function for further manipulation from a ROS Service call
-  bool spawnSDFModel(gazebo_msgs::SpawnModel::Request &req,
-                     gazebo_msgs::SpawnModel::Response &res);
+  bool spawnSDFModel(gazebo_msgs::SpawnModel::Request &req,gazebo_msgs::SpawnModel::Response &res);
 
   /// \brief delete model given name
   bool deleteModel(gazebo_msgs::DeleteModel::Request &req,gazebo_msgs::DeleteModel::Response &res);
@@ -242,21 +243,21 @@ private:
   void stripXmlDeclaration(std::string &model_xml);
 
   /// \brief Update the model name and pose of the SDF file before sending to Gazebo
-  void updateSDFAttributes(TiXmlDocument &gazebo_model_xml, std::string model_name,
+  void updateSDFAttributes(TiXmlDocument &gazebo_model_xml, std::string model_name, 
                            gazebo::math::Vector3 initial_xyz, gazebo::math::Quaternion initial_q);
 
   /// \brief Update the model pose of the URDF file before sending to Gazebo
-  void updateURDFModelPose(TiXmlDocument &gazebo_model_xml,
+  void updateURDFModelPose(TiXmlDocument &gazebo_model_xml, 
                            gazebo::math::Vector3 initial_xyz, gazebo::math::Quaternion initial_q);
 
   /// \brief Update the model name of the URDF file before sending to Gazebo
   void updateURDFName(TiXmlDocument &gazebo_model_xml, std::string model_name);
 
   /// \brief
-  void walkChildAddRobotNamespace(TiXmlNode* model_xml);
+  void walkChildAddRobotNamespace(TiXmlNode* robot_xml);
 
   /// \brief
-  bool spawnAndConform(TiXmlDocument &gazebo_model_xml, std::string model_name,
+  bool spawnAndConform(TiXmlDocument &gazebo_model_xml, std::string model_name, 
                        gazebo_msgs::SpawnModel::Response &res);
 
   /// \brief helper function for applyBodyWrench
@@ -293,7 +294,7 @@ private:
   bool plugin_loaded_;
 
   // detect if sigint event occurs
-  bool stop_;
+  bool stop_; 
   gazebo::event::ConnectionPtr sigint_event_;
 
   std::string robot_namespace_;
@@ -316,6 +317,7 @@ private:
   gazebo::event::ConnectionPtr pub_model_states_event_;
   gazebo::event::ConnectionPtr load_gazebo_ros_api_plugin_event_;
 
+  ros::ServiceServer spawn_gazebo_model_service_; // DEPRECATED IN HYDRO
   ros::ServiceServer spawn_sdf_model_service_;
   ros::ServiceServer spawn_urdf_model_service_;
   ros::ServiceServer delete_model_service_;

--- a/gazebo_ros/launch/empty_world.launch
+++ b/gazebo_ros/launch/empty_world.launch
@@ -10,6 +10,7 @@
   <arg name="physics" default="ode"/>
   <arg name="verbose" default="false"/>
   <arg name="world_name" default="worlds/empty.world"/> <!-- Note: the world_name is with respect to GAZEBO_RESOURCE_PATH environmental variable -->
+  <arg name="enable_ros_network" default="true" />
 
   <!-- set use_sim_time flag -->
   <group if="$(arg use_sim_time)">
@@ -27,6 +28,9 @@
   <arg     if="$(arg debug)" name="script_type" value="debug"/>
 
   <!-- start gazebo server-->
+  <group>
+    <param name="gazebo/enable_ros_network" value="$(arg enable_ros_network)" />
+  </group>  
   <node name="gazebo" pkg="gazebo_ros" type="$(arg script_type)" respawn="false" output="screen"
 	args="$(arg command_arg1) $(arg command_arg2) $(arg command_arg3) -e $(arg physics) $(arg extra_gazebo_args) $(arg world_name)" />
 	

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -34,7 +34,7 @@ GazeboRosApiPlugin::GazeboRosApiPlugin() :
   plugin_loaded_(false),
   pub_link_states_connection_count_(0),
   pub_model_states_connection_count_(0),
-  enable_ros_network_
+  enable_ros_network_()
 {
   robot_namespace_.clear();
 }

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -33,7 +33,8 @@ GazeboRosApiPlugin::GazeboRosApiPlugin() :
   stop_(false),
   plugin_loaded_(false),
   pub_link_states_connection_count_(0),
-  pub_model_states_connection_count_(0)
+  pub_model_states_connection_count_(0),
+  enable_ros_network_
 {
   robot_namespace_.clear();
 }
@@ -57,7 +58,8 @@ GazeboRosApiPlugin::~GazeboRosApiPlugin()
   gazebo::event::Events::DisconnectWorldCreated(load_gazebo_ros_api_plugin_event_);
   gazebo::event::Events::DisconnectWorldUpdateBegin(wrench_update_event_);
   gazebo::event::Events::DisconnectWorldUpdateBegin(force_update_event_);
-  gazebo::event::Events::DisconnectWorldUpdateBegin(time_update_event_);
+  if (enable_ros_network_)
+    gazebo::event::Events::DisconnectWorldUpdateBegin(time_update_event_);
   ROS_DEBUG_STREAM_NAMED("api_plugin","Slots disconnected");
 
   if (pub_link_states_connection_count_ > 0) // disconnect if there are subscribers on exit
@@ -151,6 +153,9 @@ void GazeboRosApiPlugin::Load(int argc, char** argv)
   // below needs the world to be created first
   load_gazebo_ros_api_plugin_event_ = gazebo::event::Events::ConnectWorldCreated(boost::bind(&GazeboRosApiPlugin::loadGazeboRosApiPlugin,this,_1));
 
+  nh_->getParam("enable_ros_network", enable_ros_network_);
+
+
   plugin_loaded_ = true;
   ROS_INFO("Finished loading Gazebo ROS API Plugin.");
 }
@@ -190,12 +195,15 @@ void GazeboRosApiPlugin::loadGazeboRosApiPlugin(std::string world_name)
   pub_model_states_connection_count_ = 0;
 
   /// \brief advertise all services
-  advertiseServices();
+  if (enable_ros_network_)
+    advertiseServices();
 
   // hooks for applying forces, publishing simtime on /clock
   wrench_update_event_ = gazebo::event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboRosApiPlugin::wrenchBodySchedulerSlot,this));
   force_update_event_  = gazebo::event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboRosApiPlugin::forceJointSchedulerSlot,this));
-  time_update_event_   = gazebo::event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboRosApiPlugin::publishSimTime,this));
+
+  if (enable_ros_network_)
+    time_update_event_   = gazebo::event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboRosApiPlugin::publishSimTime,this));
 }
 
 void GazeboRosApiPlugin::onResponse(ConstResponsePtr &response)
@@ -214,6 +222,12 @@ void GazeboRosApiPlugin::gazeboQueueThread()
 
 void GazeboRosApiPlugin::advertiseServices()
 {
+  if (! enable_ros_network_)
+  {
+    ROS_INFO_NAMED("api_plugin", "ROS gazebo topics/services are disabled");
+    return;
+  }
+
   // publish clock for simulated ros time
   pub_clock_ = nh_->advertise<rosgraph_msgs::Clock>("/clock",10);
 

--- a/gazebo_ros/test/CMakeLists.txt
+++ b/gazebo_ros/test/CMakeLists.txt
@@ -1,0 +1,22 @@
+set (rostests_python
+  ros_network/ros_network_default.test
+  ros_network/ros_network_disabled.test
+)
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+    foreach (rostest ${rostests_python})
+      # We don't set a timeout here because we trust rostest to enforce the
+      # timeout specified in each .test file.
+      add_rostest(${rostest} rostest ${CMAKE_CURRENT_SOURCE_DIR}/${rostest})
+      # Check for test result file and create one if needed.  rostest can fail to
+      # generate a file if it throws an exception.
+      add_test(check_${rostest} rosrun rosunit check_test_ran.py 
+               --rostest ${ROS_PACKAGE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${rostest})
+  endforeach()
+endif()
+
+install(PROGRAMS
+  ros_network/ros_api_checker
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/test
+)

--- a/gazebo_ros/test/ros_network/gazebo_network_api.yaml
+++ b/gazebo_ros/test/ros_network/gazebo_network_api.yaml
@@ -1,0 +1,152 @@
+strict: true
+
+##########################################################
+# Published topics
+topics:
+  # System
+  - topic: /clock
+    type: rosgraph_msgs/Clock
+    num_publishers: 1
+    num_subscribers: -1
+
+  - topic: /rosout
+    type: rosgraph_msgs/Log
+    num_publishers: -1
+    num_subscribers: 1
+
+  - topic: /rosout_agg
+    type: rosgraph_msgs/Log
+    num_publishers: 1
+    num_subscribers: -1
+
+  # Gazebo
+  - topic: /gazebo/set_model_state
+    type: gazebo_msgs/ModelState
+    num_publishers: 0
+    num_subscribers: -1
+
+  - topic: /gazebo/set_link_state
+    type: gazebo_msgs/LinkState
+    num_publishers: 0
+    num_subscribers: -1
+
+  - topic: /gazebo/link_states
+    type: gazebo_msgs/LinkStates
+    num_publishers: 1
+    num_subscribers: -1
+
+  - topic: /gazebo/model_states
+    type: gazebo_msgs/ModelStates
+    num_publishers: 1
+    num_subscribers: -1
+
+  - topic: /gazebo/parameter_descriptions
+    type: dynamic_reconfigure/ConfigDescription
+    num_publishers: 1
+    num_subscribers: -1
+
+  - topic: /gazebo/parameter_updates
+    type: dynamic_reconfigure/Config
+    num_publishers: 1
+    num_subscribers: -1
+
+##########################################################
+# Published services
+services:
+  # System
+  - service: /rosout/get_loggers
+    type: roscpp/GetLoggers
+
+  - service: /rosout/set_logger_level
+    type: roscpp/SetLoggerLevel
+
+  # Gazebo
+  - service: /gazebo/apply_joint_effort
+    type: gazebo_msgs/ApplyJointEffort
+
+  - service: /gazebo/get_physics_properties
+    type: gazebo_msgs/GetPhysicsProperties
+
+  - service: /gazebo/set_link_state
+    type: gazebo_msgs/SetLinkState
+
+  - service: /gazebo/set_joint_properties
+    type: gazebo_msgs/SetJointProperties
+
+  - service: /gazebo/reset_world
+    type: std_srvs/Empty
+
+  - service: /gazebo/set_model_configuration
+    type: gazebo_msgs/SetModelConfiguration
+
+  - service: /gazebo/get_world_properties
+    type: gazebo_msgs/GetWorldProperties
+
+  - service: /gazebo/delete_light
+    type: gazebo_msgs/DeleteLight
+
+  - service: /gazebo/set_parameters
+    type: dynamic_reconfigure/Reconfigure
+
+  - service: /gazebo/spawn_sdf_model
+    type: gazebo_msgs/SpawnModel
+
+  - service: /gazebo/unpause_physics
+    type: std_srvs/Empty
+
+  - service: /gazebo/pause_physics
+    type: std_srvs/Empty
+
+  - service: /gazebo/get_joint_properties
+    type: gazebo_msgs/GetJointProperties
+
+  - service: /gazebo/set_logger_level
+    type: roscpp/SetLoggerLevel
+
+  - service: /gazebo/get_light_properties
+    type: gazebo_msgs/GetLightProperties
+
+  - service: /gazebo/clear_body_wrenches
+    type: gazebo_msgs/BodyRequest
+
+  - service: /gazebo/clear_joint_forces
+    type: gazebo_msgs/JointRequest
+
+  - service: /gazebo/set_physics_properties
+    type: gazebo_msgs/SetPhysicsProperties
+
+  - service: /gazebo/get_model_state
+    type: gazebo_msgs/GetModelState
+
+  - service: /gazebo/reset_simulation
+    type: std_srvs/Empty
+
+  - service: /gazebo/delete_model
+    type: gazebo_msgs/DeleteModel
+
+  - service: /gazebo/spawn_urdf_model
+    type: gazebo_msgs/SpawnModel
+
+  - service: /gazebo/set_link_properties
+    type: gazebo_msgs/SetLinkProperties
+
+  - service: /gazebo/set_model_state
+    type: gazebo_msgs/SetModelState
+
+  - service: /gazebo/apply_body_wrench
+    type: gazebo_msgs/ApplyBodyWrench
+
+  - service: /gazebo/get_link_state
+    type: gazebo_msgs/GetLinkState
+
+  - service: /gazebo/get_loggers
+    type: roscpp/GetLoggers
+
+  - service: /gazebo/get_model_properties
+    type: gazebo_msgs/GetModelProperties
+
+  - service: /gazebo/set_light_properties
+    type: gazebo_msgs/SetLightProperties
+  
+  - service: /gazebo/get_link_properties
+    type: gazebo_msgs/GetLinkProperties

--- a/gazebo_ros/test/ros_network/no_gazebo_network_api.yaml
+++ b/gazebo_ros/test/ros_network/no_gazebo_network_api.yaml
@@ -1,0 +1,36 @@
+strict: true
+
+##########################################################
+# Published topics
+topics:
+  # System
+  - topic: /clock
+    type: rosgraph_msgs/Clock
+    num_publishers: 1
+    num_subscribers: -1
+
+  - topic: /rosout
+    type: rosgraph_msgs/Log
+    num_publishers: -1
+    num_subscribers: 1
+
+  - topic: /rosout_agg
+    type: rosgraph_msgs/Log
+    num_publishers: 1
+    num_subscribers: -1
+
+##########################################################
+# Published services
+services:
+  # System
+  - service: /rosout/get_loggers
+    type: roscpp/GetLoggers
+
+  - service: /rosout/set_logger_level
+    type: roscpp/SetLoggerLevel
+
+  - service: /gazebo/set_logger_level
+    type: roscpp/SetLoggerLevel
+
+  - service: /gazebo/get_loggers
+    type: roscpp/GetLoggers

--- a/gazebo_ros/test/ros_network/ros_api_checker
+++ b/gazebo_ros/test/ros_network/ros_api_checker
@@ -1,0 +1,196 @@
+#!/usr/bin/env python
+
+# The script was originally written by Brian Gerkey under
+# the works of the Virtual Robotics Challenge
+#
+# Copyright Open Source Robotics Foundation
+#
+
+from __future__ import print_function
+import unittest
+import rostest
+import subprocess
+import sys
+import time
+import re
+import rospy
+
+class Tester(unittest.TestCase):
+
+    def _test_extra_topics(self, topics):
+        cmd = ['rostopic', 'list']
+        po = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = po.communicate()
+        self.assertEqual(po.returncode, 0, 'rostopic failed (%s). stdout: %s stderr: %s'%(cmd, out, err))
+        topics_actual = set(out.split('\n')) - set([''])
+        topics_expected = set([x['topic'] for x in topics])
+        topics_extra = topics_actual - topics_expected
+        self.assertEqual(topics_extra, set([]))
+
+    def _test_extra_services(self, services):
+        cmd = ['rosservice', 'list']
+        po = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = po.communicate()
+        self.assertEqual(po.returncode, 0, 'rosservice failed (%s). stdout: %s stderr: %s'%(cmd, out, err))
+        services_actual = set(out.split('\n')) - set([''])
+        services_expected = set([x['service'] for x in services])
+        services_extra = services_actual - services_expected
+        self.assertEqual(services_extra, set([]))
+
+    def _test_topic(self, t):
+        self.assertIn('topic', t)
+        self.assertIn('type', t)
+        self.assertIn('num_publishers', t)
+        self.assertIn('num_subscribers', t)
+
+        cmd = ['rostopic', 'info', t['topic']]
+        po = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = po.communicate()
+        self.assertEqual(po.returncode, 0, 'rostopic failed (%s). stdout: %s stderr: %s'%(cmd, out, err))
+        self._parse_rostopic(t, out)
+
+    def _parse_rostopic(self, t, out):
+        # Should probably do this through a library API instead...
+
+        # Step 0: make sure we have enough output
+        outsplit = out.split('\n')
+        self.assertTrue(len(outsplit) >= 5)
+
+        type_re = re.compile('\w*Type: (.*)')
+        pub_start_re = re.compile('Publishers:.*')
+        sub_start_re = re.compile('Subscribers:.*')
+        pub_sub_re = re.compile(' *\* *([^ ]*).*')
+
+        # Step 1: check type
+        m = type_re.match(outsplit[0])
+        self.assertEqual(len(m.groups()), 1)
+        self.assertEqual(m.groups()[0], t['type'])
+
+        # Step 2: check num_publishers and num_subscribers
+        state = None
+        pubs = 0
+        subs = 0
+        for l in outsplit:
+            if pub_start_re.match(l):
+                state = 'in_pubs'
+            elif sub_start_re.match(l):
+                state = 'in_subs'
+            else:
+                m = pub_sub_re.match(l)
+                if m and len(m.groups()) == 1:
+                    if state == 'in_pubs':
+                        pubs += 1
+                    elif state == 'in_subs':
+                        subs += 1
+        if t['num_publishers'] >= 0:
+            self.assertEqual(pubs, t['num_publishers'])
+        if t['num_subscribers'] >= 0:
+            self.assertEqual(subs, t['num_subscribers'])
+
+    def _test_service(self, s):
+        self.assertIn('service', s)
+        self.assertIn('type', s)
+
+        cmd = ['rosservice', 'info', s['service']]
+        po = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = po.communicate()
+        self.assertEqual(po.returncode, 0, 'rosservice failed (%s). stdout: %s stderr: %s'%(cmd, out, err))
+        self._parse_rosservice(s, out)
+
+    def _parse_rosservice(self, s, out):
+        # Should probably do this through a library API instead...
+
+        # Step 0: make sure we have enough output
+        outsplit = out.split('\n')
+        self.assertTrue(len(outsplit) >= 4)
+
+        type_re = re.compile('Type: (.*)')
+
+        # Step 1: check type
+        m = type_re.match(outsplit[2])
+        self.assertEqual(len(m.groups()), 1)
+        self.assertEqual(m.groups()[0], s['type'])
+
+def load_config(files):
+    import yaml
+    topics = []
+    services = []
+    strict = False
+    for f in files:
+        # Ignore args passed in by rostest
+        if f[:2] == '--' or f[:2] == '__':
+            continue
+        # Let parsing exceptions leak out; we'll catch them by noticing the
+        # absence of a test result file.
+        y = yaml.load(open(f))
+        for t in y['topics']:
+            topics.append(t)
+        if 'services' in y:
+            for s in y['services']:
+                services.append(s)
+
+        # TODO: This logic will enforce strictness if any of the provided files
+        # sets strict to true, which isn't necessarily the right thing.
+        if 'strict' in y and y['strict']:
+            strict = True
+    return topics, services, strict
+
+def generate_topic_test(t):
+    def test_func(self):
+        self._test_topic(t)
+    return test_func
+
+def generate_service_test(t):
+    def test_func(self):
+        self._test_service(t)
+    return test_func
+
+def generate_test_extra_topics(topics):
+    def test_func(self):
+        self._test_extra_topics(topics)
+    return test_func
+
+def generate_test_extra_services(services):
+    def test_func(self):
+        self._test_extra_services(services)
+    return test_func
+
+def add_tests(topics, services, strict):
+    for t in topics:
+        test_func = generate_topic_test(t)
+        test_name = "test_topic_%s"%(t['topic'].replace('/','_'))
+        setattr(Tester, test_name, test_func)
+    for s in services:
+        test_func = generate_service_test(s)
+        test_name = "test_service_%s"%(s['service'].replace('/','_'))
+        setattr(Tester, test_name, test_func)
+    if strict:
+        test_func = generate_test_extra_topics(topics)
+        test_name = "test_extra_topics"
+        setattr(Tester, test_name, test_func)
+        test_func = generate_test_extra_services(services)
+        test_name = "test_extra_services"
+        setattr(Tester, test_name, test_func)
+
+if __name__ == '__main__':
+    rospy.init_node('rosapi_checker', anonymous=True)
+
+    # Dynamically generate test cases and stuff them into the Tester class
+    topics, services, strict = load_config(sys.argv[1:])
+    # The rostest node itself will advertise a couple of services
+    services.append({'service': '%s/get_loggers'%(rospy.get_name()),
+                     'type': 'roscpp/GetLoggers'})
+    services.append({'service': '%s/set_logger_level'%(rospy.get_name()),
+                     'type': 'roscpp/SetLoggerLevel'})
+    add_tests(topics, services, strict)
+
+    # Wait until /clock is being published; this can take an unpredictable
+    # amount of time when we're downloading models.
+    while rospy.Time.now().to_sec() == 0.0:
+        print('Waiting for Gazebo to start...')
+        time.sleep(1.0)
+    # Take an extra nap, to allow plugins to be loaded
+    time.sleep(5.0)
+    print('OK, starting test.')
+
+    rostest.run('gazebo_ros', 'api_check', Tester, sys.argv)

--- a/gazebo_ros/test/ros_network/ros_network_default.test
+++ b/gazebo_ros/test/ros_network/ros_network_default.test
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<launch>
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    <arg name="paused"   value="false"/>
+    <arg name="gui"      value="false"/>
+    <arg name="headless" value="false"/>
+    <arg name="debug"    value="false"/>
+    <arg name="enable_ros_network" value="true" />
+  </include>
+
+  <!-- the long timeout is just in case that gazebo needs to download models -->
+  <test pkg="gazebo_ros" type="ros_api_checker" test-name="ros_network_by_default"
+      args="$(find gazebo_ros)/test/ros_network/gazebo_network_api.yaml"
+      time-limit="100.0"/>
+</launch>

--- a/gazebo_ros/test/ros_network/ros_network_disabled.test
+++ b/gazebo_ros/test/ros_network/ros_network_disabled.test
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<launch>
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    <arg name="paused"   value="false"/>
+    <arg name="gui"      value="false"/>
+    <arg name="headless" value="false"/>
+    <arg name="debug"    value="false"/>
+    <arg name="enable_ros_network" value="false"/>
+  </include>
+
+  <!-- the long timeout is just in case that gazebo needs to download models -->
+  <test pkg="gazebo_ros" type="ros_api_checker" test-name="ros_network_by_default"
+      args="$(find gazebo_ros)/test/ros_network/no_gazebo_network_api.yaml"
+      time-limit="100.0"/>
+</launch>


### PR DESCRIPTION
{ port of pull request #585 }
The PR implements a ROS parameter named `enable_ros_network` that allows to disable all the gazebo topics (except /clock) and services that are created from the `gazebo_ros` package. This is useful in situation where the interaction from user with the gazebo simulator should be limited or blocked.

To keep backwards compatibility, by default, the behaviour is to enable all topics and services if the parameter is not present so current code should not experiment any difference at all.

I've added a couple of tests based on the `ros_api_checker` that the OSRF developed during the times of the Virtual Robotics Challenge. It checks all the ROS topics and services in runtime to check if they are exactly the same that is described in the .yaml files available in this PR.
