### PR TITLE
[gazebo_ros_control] fix initialization issue in position controller

### DIFF
--- a/gazebo_ros_control/src/default_robot_hw_sim.cpp
+++ b/gazebo_ros_control/src/default_robot_hw_sim.cpp
@@ -83,6 +83,7 @@ bool DefaultRobotHWSim::initSim(
   joint_effort_command_.resize(n_dof_);
   joint_position_command_.resize(n_dof_);
   joint_velocity_command_.resize(n_dof_);
+  last_joint_position_command_.resize(n_dof_);
 
   // Initialize values
   for(unsigned int j=0; j < n_dof_; j++)
@@ -137,7 +138,8 @@ bool DefaultRobotHWSim::initSim(
     joint_effort_command_[j] = 0.0;
     joint_position_command_[j] = 0.0;
     joint_velocity_command_[j] = 0.0;
-
+    last_joint_position_command_[j]=0.0;
+    
     const std::string& hardware_interface = joint_interfaces.front();
 
     // Debug


### PR DESCRIPTION
The new e_stop feature seems to be missing an initialization of last_joint_position_command_ array. Which leads to the fact that the array, which will later set the position in the simulation (joint_position_command_), will be a zero length array, cause it is overwritten with the last_joint_position_ command in line 278. That leads to unpredicted behavior for the joint -> mostly in the joint acting like a helicopter rotor for me. My suggested changes seem to fix this for me.