### PR TITLE
[gazebo_ros] Quote arguments to echo in libcommon.sh (lunar-devel)

### DIFF
--- a/gazebo_ros/scripts/libcommon.sh
+++ b/gazebo_ros/scripts/libcommon.sh
@@ -8,12 +8,12 @@ relocate_remappings()
   command_line=${1}
 
   for w in $command_line; do
-    if $(echo $w | grep -q ':='); then
+    if $(echo "$w" | grep -q ':='); then
       ros_remaps="$ros_remaps $w"
     else
       gazebo_args="$gazebo_args $w"
     fi
   done
 
-  echo $gazebo_args$ros_remaps | cut -c 1-
+  echo "$gazebo_args$ros_remaps" | cut -c 1-
 }


### PR DESCRIPTION
{ port of pull request #590 }
If /bin/sh is provided by bash, echo will consume arguments such as `-e`. On such a system, running `rosrun gazebo_ros gzserver -e ode empty_world.world` will execute `gzserver` with the `-e` missing (meaning the world file is ignored).