### PR TITLE
Add RTF republisher

### DIFF
--- a/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
+++ b/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
@@ -100,6 +100,9 @@
 
 #include <boost/algorithm/string.hpp>
 
+// For real-time factor calculations
+#include <boost/circular_buffer.hpp>
+
 namespace gazebo
 {
 
@@ -246,7 +249,7 @@ private:
   void publishSimTime();
 
   /// \brief Republish the Gazebo real-time factor
-  void publishRealTimeFactor(ConstWorldStatisticsPtr &_msg);
+  void publishRealTimeFactor();
 
   /// \brief
   void publishLinkStates();
@@ -321,7 +324,6 @@ private:
   gazebo::transport::PublisherPtr light_modify_pub_;
   gazebo::transport::PublisherPtr request_pub_;
   gazebo::transport::SubscriberPtr response_sub_;
-  gazebo::transport::SubscriberPtr rtf_sub_;    // Real-time factor republisher
 
   boost::shared_ptr<ros::NodeHandle> nh_;
   ros::CallbackQueue gazebo_queue_;
@@ -330,6 +332,7 @@ private:
   gazebo::physics::WorldPtr world_;
   gazebo::event::ConnectionPtr wrench_update_event_;
   gazebo::event::ConnectionPtr force_update_event_;
+  gazebo::event::ConnectionPtr rtf_update_event_;
   gazebo::event::ConnectionPtr time_update_event_;
   gazebo::event::ConnectionPtr pub_link_states_event_;
   gazebo::event::ConnectionPtr pub_model_states_event_;
@@ -386,10 +389,10 @@ private:
   gazebo::common::Time last_pub_clock_time_;
 
   /// \brief Sim time buffer for real-time factor calculation
-  std::list<common::Time> simTimes;
+  boost::circular_buffer<common::Time> sim_times_;
 
   /// \brief Real time buffer for real-time factor calculation
-  std::list<common::Time> realTimes;
+  boost::circular_buffer<common::Time> real_times_;
 
   /// \brief A mutex to lock access to fields that are used in ROS message callbacks
   boost::mutex lock_;

--- a/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
+++ b/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
@@ -245,6 +245,9 @@ private:
   void publishSimTime(const boost::shared_ptr<gazebo::msgs::WorldStatistics const> &msg);
   void publishSimTime();
 
+  /// \brief Republish the Gazebo real-time factor
+  void publishRealTimeFactor(ConstWorldStatisticsPtr &_msg);
+
   /// \brief
   void publishLinkStates();
 
@@ -318,6 +321,7 @@ private:
   gazebo::transport::PublisherPtr light_modify_pub_;
   gazebo::transport::PublisherPtr request_pub_;
   gazebo::transport::SubscriberPtr response_sub_;
+  gazebo::transport::SubscriberPtr rtf_sub_;    // Real-time factor republisher
 
   boost::shared_ptr<ros::NodeHandle> nh_;
   ros::CallbackQueue gazebo_queue_;
@@ -362,6 +366,7 @@ private:
   ros::Subscriber    set_model_state_topic_;
   ros::Publisher     pub_link_states_;
   ros::Publisher     pub_model_states_;
+  ros::Publisher     pub_real_time_factor_;
   int                pub_link_states_connection_count_;
   int                pub_model_states_connection_count_;
 
@@ -379,6 +384,12 @@ private:
   ros::Publisher     pub_clock_;
   int pub_clock_frequency_;
   gazebo::common::Time last_pub_clock_time_;
+
+  /// \brief Sim time buffer for real-time factor calculation
+  std::list<common::Time> simTimes;
+
+  /// \brief Real time buffer for real-time factor calculation
+  std::list<common::Time> realTimes;
 
   /// \brief A mutex to lock access to fields that are used in ROS message callbacks
   boost::mutex lock_;

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -2124,8 +2124,13 @@ void GazeboRosApiPlugin::publishRealTimeFactor()
   // https://bitbucket.org/osrf/gazebo/src/a24b331f8ebfd712a226ba73b7f43d2d4c14fe15/tools/gz.cc?at=gazebo7&fileviewer=file-view-default#gz.cc-854
   // The goal is to make the real-time factor available in ROS bags, for use as an easy "system performance" metric
   // with post-run analysis.
+#if GAZEBO_MAJOR_VERSION >= 8
+  sim_times_.push_back(world_->SimTime());
+  real_times_.push_back(world_->RealTime());
+#else
   sim_times_.push_back(world_->GetSimTime());
   real_times_.push_back(world_->GetRealTime());
+#endif
 
   auto ss_lambda = [&](common::Time& a, common::Time& b){
     return a + (b - sim_times_.front());


### PR DESCRIPTION
Added subscriber/callback to gz topic and ROS topic publisher to republish the current real-time factor.

Note that this is a re-implementation of the Gazebo method found [here](https://bitbucket.org/osrf/gazebo/src/a24b331f8ebfd712a226ba73b7f43d2d4c14fe15/tools/gz.cc?at=gazebo7&fileviewer=file-view-default#gz.cc-854).  The goal is to make the real-time factor available in ROS bags, for use as an easy "system performance" metric with post-run analysis.