### PR TITLE
Fix for relative frame errors

### DIFF
--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -625,7 +625,7 @@ bool GazeboRosApiPlugin::spawnSDFModel(gazebo_msgs::SpawnModel::Request &req,
   gazebo::math::Quaternion initial_q(req.initial_pose.orientation.w,req.initial_pose.orientation.x,req.initial_pose.orientation.y,req.initial_pose.orientation.z);
 
   // refernce frame for initial pose definition, modify initial pose if defined
-  gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.reference_frame));
+  gazebo::physics::EntityPtr frame = world_->GetEntity(req.reference_frame);
   if (frame)
   {
     // convert to relative pose
@@ -818,7 +818,7 @@ bool GazeboRosApiPlugin::getModelState(gazebo_msgs::GetModelState::Request &req,
                                        gazebo_msgs::GetModelState::Response &res)
 {
   gazebo::physics::ModelPtr model = world_->GetModel(req.model_name);
-  gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.relative_entity_name));
+  gazebo::physics::EntityPtr frame = world_->GetEntity(req.relative_entity_name);
   if (!model)
   {
     ROS_ERROR_NAMED("api_plugin", "GetModelState: model [%s] does not exist",req.model_name.c_str());
@@ -1063,7 +1063,7 @@ bool GazeboRosApiPlugin::getLinkState(gazebo_msgs::GetLinkState::Request &req,
                                       gazebo_msgs::GetLinkState::Response &res)
 {
   gazebo::physics::LinkPtr body = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.link_name));
-  gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.reference_frame));
+  gazebo::physics::EntityPtr frame = world_->GetEntity(req.reference_frame);
 
   if (!body)
   {
@@ -1413,7 +1413,7 @@ bool GazeboRosApiPlugin::setModelState(gazebo_msgs::SetModelState::Request &req,
   }
   else
   {
-    gazebo::physics::LinkPtr relative_entity = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.model_state.reference_frame));
+    gazebo::physics::EntityPtr relative_entity = world_->GetEntity(req.model_state.reference_frame);
     if (relative_entity)
     {
       gazebo::math::Pose  frame_pose = relative_entity->GetWorldPose(); // - myBody->GetCoMPose();
@@ -1630,7 +1630,7 @@ bool GazeboRosApiPlugin::setLinkState(gazebo_msgs::SetLinkState::Request &req,
                                       gazebo_msgs::SetLinkState::Response &res)
 {
   gazebo::physics::LinkPtr body = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.link_state.link_name));
-  gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.link_state.reference_frame));
+  gazebo::physics::EntityPtr frame = world_->GetEntity(req.link_state.reference_frame);
   if (!body)
   {
     ROS_ERROR_NAMED("api_plugin", "Updating LinkState: link [%s] does not exist",req.link_state.link_name.c_str());
@@ -1718,7 +1718,7 @@ bool GazeboRosApiPlugin::applyBodyWrench(gazebo_msgs::ApplyBodyWrench::Request &
                                          gazebo_msgs::ApplyBodyWrench::Response &res)
 {
   gazebo::physics::LinkPtr body = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.body_name));
-  gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.reference_frame));
+  gazebo::physics::EntityPtr frame = world_->GetEntity(req.reference_frame);
   if (!body)
   {
     ROS_ERROR_NAMED("api_plugin", "ApplyBodyWrench: body [%s] does not exist",req.body_name.c_str());

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -639,9 +639,8 @@ bool GazeboRosApiPlugin::spawnSDFModel(gazebo_msgs::SpawnModel::Request &req,
 #else
     ignition::math::Pose3d frame_pose = frame->GetWorldPose().Ign();
 #endif
-    gazebo::math::Pose frame_pose = frame->GetWorldPose();
-    initial_xyz = frame_pose.pos + frame_pose.rot.RotateVector(initial_xyz);
-    initial_q = frame_pose.rot * initial_q;
+    initial_xyz = frame_pose.Pos() + frame_pose.Rot().RotateVector(initial_xyz);
+    initial_q = frame_pose.Rot() * initial_q;
   }
 
   /// @todo: map is really wrong, need to use tf here somehow


### PR DESCRIPTION
I noticed a lot of errors when using relative reference frames in Gazebo. When spawning the object, wrong multiplication order of quaternions is applied (as per [here](https://bitbucket.org/osrf/gazebo/src/a29d8dabed9a14fb6bafdcd31c84b160c00b127c/gazebo/math/Quaternion.cc?at=gazebo7&fileviewer=file-view-default#Quaternion.cc-391)). The operation q1 *= q2 results in q1 = q1 * q2, but we wish to have q1 = q2 * q1, since we apply rotation to q1. 

When obtaining the relative pose of the object w.r.t. to a frame, I noticed strange and inconsistent transformations. I used the reference for chaining transformations defined [here](http://osrf-distributions.s3.amazonaws.com/gazebo/api/dev/classgazebo_1_1math_1_1Pose.html) to make the transformations cleaner.

Also, instead of using the relative entity, in the whole code the entity is transformed to a link, which does not allow for specifying a model as a relative entity. 