### PR TITLE
[gazebo_ros] don't overwrite parameter "use_sim_time"

### DIFF
--- a/gazebo_ros/launch/empty_world.launch
+++ b/gazebo_ros/launch/empty_world.launch
@@ -19,9 +19,10 @@
   <arg name="pub_clock_frequency" default="100"/>
 
   <!-- set use_sim_time flag -->
-  <group if="$(arg use_sim_time)">
+<!--  <group if="$(arg use_sim_time)">
     <param name="/use_sim_time" value="true" />
-  </group>
+  </group> -->
+  <param name="/use_sim_time" value="$(arg use_sim_time)"/>
 
   <!-- set command arguments -->
   <arg unless="$(arg paused)" name="command_arg1" value=""/>

--- a/gazebo_ros/launch/empty_world.launch
+++ b/gazebo_ros/launch/empty_world.launch
@@ -19,9 +19,6 @@
   <arg name="pub_clock_frequency" default="100"/>
 
   <!-- set use_sim_time flag -->
-<!--  <group if="$(arg use_sim_time)">
-    <param name="/use_sim_time" value="true" />
-  </group> -->
   <param name="/use_sim_time" value="$(arg use_sim_time)"/>
 
   <!-- set command arguments -->

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -500,7 +500,8 @@ void GazeboRosApiPlugin::advertiseServices()
 
 
   // set param for use_sim_time if not set by user already
-  nh_->setParam("/use_sim_time", true);
+  if(!(nh_->hasParam("/use_sim_time")))
+    nh_->setParam("/use_sim_time", true);
 
   // todo: contemplate setting environment variable ROBOT=sim here???
   nh_->getParam("pub_clock_frequency", pub_clock_frequency_);


### PR DESCRIPTION
gazebo_ros doesn't overwrite the parameter "use_sim_time", if the parameter is present on parameter-server
