### PR TITLE
gazebo_plugins: throw error in case a joint is not found

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_joint_state_publisher.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_state_publisher.cpp
@@ -81,7 +81,11 @@ void GazeboRosJointStatePublisher::Load ( physics::ModelPtr _parent, sdf::Elemen
     last_update_time_ = this->world_->GetSimTime();
 
     for ( unsigned int i = 0; i< joint_names_.size(); i++ ) {
-        joints_.push_back ( this->parent_->GetJoint ( joint_names_[i] ) );
+        physics::JointPtr joint = this->parent_->GetJoint(joint_names_[i]);
+        if (!joint) {
+            ROS_FATAL_NAMED("joint_state_publisher", "Joint %s does not exist!", joint_names_[i].c_str());
+        }
+        joints_.push_back ( joint );
         ROS_INFO_NAMED("joint_state_publisher", "GazeboRosJointStatePublisher is going to publish joint: %s", joint_names_[i].c_str() );
     }
 


### PR DESCRIPTION
Gazebo would segfault if the joint_state_publisher plugin is used with a joint which is not defined. This is kind of hard to debug so I throw a fatal error.

This can be tested by taking a working urdf model using the joint state publisher with a joint name that does not exist. For example:
```
   <gazebo>
     <plugin name="joint_state_publisher" filename="libgazebo_ros_joint_state_publisher.so">
       <jointName>joint_name_that_does_not_exist</jointName>
     </plugin>
   </gazebo>
``` 

The issue was initially posted to the gazebo repository here: https://bitbucket.org/osrf/gazebo/issues/2330/gazebo-segfaults-on-launch.

Cheers!