### PR TITLE
[gazebo_ros_imu] Add Gaussian noise parameter for yaw angle of IMU

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_imu.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_imu.h
@@ -97,6 +97,9 @@ namespace gazebo
     /// \brief Gaussian noise
     private: double gaussian_noise_;
 
+    /// \brief Gaussian noise for yaw
+    private: double yaw_gaussian_noise_;
+
     /// \brief Gaussian noise generator
     private: double GaussianKernel(double mu, double sigma);
 

--- a/gazebo_plugins/src/gazebo_ros_imu.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu.cpp
@@ -231,8 +231,9 @@ void GazeboRosIMU::UpdateChild()
     rot = pose.rot;
 
     // apply yaw noise
-    math::Quaternion yaw_error;
-    yaw_error.SetFromEuler(math::Vector3(
+    
+    ignition::math::Quaterniond yaw_error;
+    yaw_error.Euler(ignition::math::Vector3d(
         0,
         0,
         this->GaussianKernel(0, this->yaw_gaussian_noise_)

--- a/gazebo_plugins/src/gazebo_ros_imu.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu.cpp
@@ -93,8 +93,8 @@ void GazeboRosIMU::LoadThread()
 
   if (!this->sdf->HasElement("yawGaussianNoise"))
   {
-    ROS_INFO_NAMED("imu", "imu plugin missing <yawGaussianNoise>, defaults to 0.0");
-    this->yaw_gaussian_noise_ = 0.0;
+    ROS_INFO_NAMED("imu", "imu plugin missing <yawGaussianNoise>, defaults to <gaussianNoise>");
+    this->yaw_gaussian_noise_ = this->gaussian_noise_;
   }
   else
     this->yaw_gaussian_noise_ = this->sdf->Get<double>("yawGaussianNoise");


### PR DESCRIPTION
Add parameter to simulate Gaussian noise for the yaw angle of the IMU orientation. Variance of the yaw angle in the covariance matrix is set accordingly.