### PR TITLE
Feature/make gazebo 9 compatible

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_imu.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_imu.h
@@ -75,7 +75,7 @@ namespace gazebo
     private: std::string topic_name_;
 
     /// \brief allow specifying constant xyz and rpy offsets
-    private: math::Pose offset_;
+    private: ignition::math::Pose3d offset_;
 
     /// \brief A mutex to lock access to fields
     /// that are used in message callbacks
@@ -83,16 +83,16 @@ namespace gazebo
 
     /// \brief save last_time
     private: common::Time last_time_;
-    private: math::Vector3 last_vpos_;
-    private: math::Vector3 last_veul_;
-    private: math::Vector3 apos_;
-    private: math::Vector3 aeul_;
+    private: ignition::math::Vector3d last_vpos_;
+    private: ignition::math::Vector3d last_veul_;
+    private: ignition::math::Vector3d apos_;
+    private: ignition::math::Vector3d aeul_;
 
     // rate control
     private: double update_rate_;
 
     /// \brief: keep initial pose to offset orientation in imu message
-    private: math::Pose initial_pose_;
+    private: ignition::math::Pose3d initial_pose_;
 
     /// \brief Gaussian noise
     private: double gaussian_noise_;

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_imu_sensor.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_imu_sensor.h
@@ -1,13 +1,13 @@
 /* Copyright [2015] [Alessandro Settimi]
- * 
+ *
  * email: ale.settimi@gmail.com
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -62,7 +62,7 @@ namespace gazebo
     /// \param mu offset value.
     /// \param sigma scaling value.
     double GuassianKernel(double mu, double sigma);
-    
+
     /// \brief Ros NodeHandle pointer.
     ros::NodeHandle* node;
     /// \brief Ros Publisher for imu data.
@@ -80,6 +80,7 @@ namespace gazebo
     sdf::ElementPtr sdf;
     /// \brief Orientation data from the sensor.
     ignition::math::Quaterniond orientation;
+
     /// \brief Linear acceleration data from the sensor.
     ignition::math::Vector3d accelerometer_data;
     /// \brief Angular velocity data from the sensor.

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_imu_sensor.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_imu_sensor.h
@@ -79,12 +79,12 @@ namespace gazebo
     /// \brief Pointer to the sdf config file.
     sdf::ElementPtr sdf;
     /// \brief Orientation data from the sensor.
-    gazebo::math::Quaternion orientation;
+    ignition::math::Quaterniond orientation;
     /// \brief Linear acceleration data from the sensor.
-    math::Vector3 accelerometer_data;
+    ignition::math::Vector3d accelerometer_data;
     /// \brief Angular velocity data from the sensor.
-    math::Vector3 gyroscope_data;
-    
+    ignition::math::Vector3d gyroscope_data;
+
     /// \brief Seed for the Gaussian noise generator.
     unsigned int seed;
 
@@ -100,7 +100,7 @@ namespace gazebo
     /// \brief Gaussian noise.
     double gaussian_noise;
     /// \brief Offset parameter, position part is unused.
-    math::Pose offset;
+    ignition::math::Pose3d offset;
   };
 }
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_imu_sensor.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_imu_sensor.h
@@ -19,8 +19,8 @@
 
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/common/UpdateInfo.hh>
-#include <gazebo/math/Vector3.hh>
-#include <gazebo/math/Pose.hh>
+#include <ignition/math/Vector3.hh>
+#include <ignition/math/Pose3.hh>
 #include <ros/ros.h>
 #include <sensor_msgs/Imu.h>
 #include <string>

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_p3d.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_p3d.h
@@ -89,21 +89,21 @@ namespace gazebo
     private: std::string tf_frame_name_;
 
     /// \brief allow specifying constant xyz and rpy offsets
-    private: math::Pose offset_;
+    private: ignition::math::Pose3d offset_;
 
     /// \brief mutex to lock access to fields used in message callbacks
     private: boost::mutex lock;
 
     /// \brief save last_time
     private: common::Time last_time_;
-    private: math::Vector3 last_vpos_;
-    private: math::Vector3 last_veul_;
-    private: math::Vector3 apos_;
-    private: math::Vector3 aeul_;
-    private: math::Vector3 last_frame_vpos_;
-    private: math::Vector3 last_frame_veul_;
-    private: math::Vector3 frame_apos_;
-    private: math::Vector3 frame_aeul_;
+    private: ignition::math::Vector3d last_vpos_;
+    private: ignition::math::Vector3d last_veul_;
+    private: ignition::math::Vector3d apos_;
+    private: ignition::math::Vector3d aeul_;
+    private: ignition::math::Vector3d last_frame_vpos_;
+    private: ignition::math::Vector3d last_frame_veul_;
+    private: ignition::math::Vector3d frame_apos_;
+    private: ignition::math::Vector3d frame_aeul_;
 
     // rate control
     private: double update_rate_;

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_planar_move.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_planar_move.h
@@ -90,7 +90,7 @@ namespace gazebo {
       double rot_;
       bool alive_;
       common::Time last_odom_publish_time_;
-      math::Pose last_odom_pose_;
+      ignition::math::Pose3d last_odom_pose_;
 
   };
 

--- a/gazebo_plugins/src/gazebo_ros_block_laser.cpp
+++ b/gazebo_plugins/src/gazebo_ros_block_laser.cpp
@@ -82,7 +82,7 @@ void GazeboRosBlockLaser::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
   std::string worldName = _parent->WorldName();
   this->world_ = physics::get_world(worldName);
 
-  last_update_time_ = this->world_->GetSimTime();
+  last_update_time_ = this->world_->SimTime();
 
   this->node_ = transport::NodePtr(new transport::Node());
   this->node_->Init(worldName);

--- a/gazebo_plugins/src/gazebo_ros_block_laser.cpp
+++ b/gazebo_plugins/src/gazebo_ros_block_laser.cpp
@@ -236,8 +236,8 @@ void GazeboRosBlockLaser::PutLaserData(common::Time &_updateTime)
   auto maxAngle = this->parent_ray_sensor_->AngleMax();
   auto minAngle = this->parent_ray_sensor_->AngleMin();
 #else
-  math::Angle maxAngle = this->parent_ray_sensor_->GetAngleMax();
-  math::Angle minAngle = this->parent_ray_sensor_->GetAngleMin();
+  ignition::math::Angle maxAngle = this->parent_ray_sensor_->GetAngleMax();
+  ignition::math::Angle minAngle = this->parent_ray_sensor_->GetAngleMin();
 #endif
 
   double maxRange = this->parent_ray_sensor_->RangeMax();
@@ -251,8 +251,8 @@ void GazeboRosBlockLaser::PutLaserData(common::Time &_updateTime)
   auto verticalMaxAngle = this->parent_ray_sensor_->VerticalAngleMax();
   auto verticalMinAngle = this->parent_ray_sensor_->VerticalAngleMin();
 #else
-  math::Angle verticalMaxAngle = this->parent_ray_sensor_->GetVerticalAngleMax();
-  math::Angle verticalMinAngle = this->parent_ray_sensor_->GetVerticalAngleMin();
+  ignition::math::Angle verticalMaxAngle = this->parent_ray_sensor_->GetVerticalAngleMax();
+  ignition::math::Angle verticalMinAngle = this->parent_ray_sensor_->GetVerticalAngleMin();
 #endif
 
   double yDiff = maxAngle.Radian() - minAngle.Radian();
@@ -405,9 +405,9 @@ void GazeboRosBlockLaser::OnStats( const boost::shared_ptr<msgs::WorldStatistics
 {
   this->sim_time_  = msgs::Convert( _msg->sim_time() );
 
-  math::Pose pose;
-  pose.pos.x = 0.5*sin(0.01*this->sim_time_.Double());
-  gzdbg << "plugin simTime [" << this->sim_time_.Double() << "] update pose [" << pose.pos.x << "]\n";
+  ignition::math::Pose3d pose;
+  pose.Pos().X() = 0.5 * sin(0.01 * this->sim_time_.Double());
+  gzdbg << "plugin simTime [" << this->sim_time_.Double() << "] update pose [" << pose.Pos().X() << "]\n";
 }
 
 

--- a/gazebo_plugins/src/gazebo_ros_bumper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_bumper.cpp
@@ -32,9 +32,9 @@
 #include <sdf/Param.hh>
 #include <gazebo/common/Exception.hh>
 #include <gazebo/sensors/SensorTypes.hh>
-#include <gazebo/math/Pose.hh>
-#include <gazebo/math/Quaternion.hh>
-#include <gazebo/math/Vector3.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Quaternion.hh>
+#include <ignition/math/Vector3.hh>
 
 #include <tf/tf.h>
 
@@ -264,12 +264,12 @@ void GazeboRosBumper::OnContact()
 
       // set wrenches
       geometry_msgs::Wrench wrench;
-      wrench.force.x  = force.x;
-      wrench.force.y  = force.y;
-      wrench.force.z  = force.z;
-      wrench.torque.x = torque.x;
-      wrench.torque.y = torque.y;
-      wrench.torque.z = torque.z;
+      wrench.force.x  = force.X();
+      wrench.force.y  = force.Y();
+      wrench.force.z  = force.Z();
+      wrench.torque.x = torque.X();
+      wrench.torque.y = torque.Y();
+      wrench.torque.z = torque.Z();
       state.wrenches.push_back(wrench);
 
       total_wrench.force.x  += wrench.force.x;
@@ -287,9 +287,9 @@ void GazeboRosBumper::OnContact()
                                    contact.position(j).z()) -
           frame_pos);
       geometry_msgs::Vector3 contact_position;
-      contact_position.x = position.x;
-      contact_position.y = position.y;
-      contact_position.z = position.z;
+      contact_position.x = position.X();
+      contact_position.y = position.Y();
+      contact_position.z = position.Z();
       state.contact_positions.push_back(contact_position);
 
       // rotate normal into user specified frame.
@@ -299,9 +299,9 @@ void GazeboRosBumper::OnContact()
                                    contact.normal(j).z()));
       // set contact normals
       geometry_msgs::Vector3 contact_normal;
-      contact_normal.x = normal.x;
-      contact_normal.y = normal.y;
-      contact_normal.z = normal.z;
+      contact_normal.x = normal.X();
+      contact_normal.y = normal.Y();
+      contact_normal.z = normal.Z();
       state.contact_normals.push_back(contact_normal);
 
       // set contact depth, interpenetration

--- a/gazebo_plugins/src/gazebo_ros_bumper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_bumper.cpp
@@ -157,7 +157,7 @@ void GazeboRosBumper::OnContact()
       *Simulator::Instance()->GetMRMutex());
     // look through all models in the world, search for body
     // name that matches frameName
-    phyaics::Model_V all_models = World::Instance()->GetModels();
+    phyaics::Model_V all_models = World::Instance()->Models();
     for (physics::Model_V::iterator iter = all_models.begin();
       iter != all_models.end(); iter++)
     {
@@ -183,7 +183,7 @@ void GazeboRosBumper::OnContact()
   /*
   if (myFrame)
   {
-    frame_pose = myFrame->GetWorldPose();  //-this->myBody->GetCoMPose();
+    frame_pose = myFrame->WorldPose();  //-this->myBody->GetCoMPose();
     frame_pos = frame_pose.pos;
     frame_rot = frame_pose.rot;
   }

--- a/gazebo_plugins/src/gazebo_ros_bumper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_bumper.cpp
@@ -177,9 +177,9 @@ void GazeboRosBumper::OnContact()
 */
   // get reference frame (body(link)) pose and subtract from it to get
   // relative force, torque, position and normal vectors
-  math::Pose pose, frame_pose;
-  math::Quaternion rot, frame_rot;
-  math::Vector3 pos, frame_pos;
+  ignition::math::Pose3d pose, frame_pose;
+  ignition::math::Quaterniond rot, frame_rot;
+  ignition::math::Vector3d pos, frame_pos;
   /*
   if (myFrame)
   {
@@ -192,9 +192,9 @@ void GazeboRosBumper::OnContact()
   {
     // no specific frames specified, use identity pose, keeping
     // relative frame at inertial origin
-    frame_pos = math::Vector3(0, 0, 0);
-    frame_rot = math::Quaternion(1, 0, 0, 0);  // gazebo u,x,y,z == identity
-    frame_pose = math::Pose(frame_pos, frame_rot);
+    frame_pos = ignition::math::Vector3d(0, 0, 0);
+    frame_rot = ignition::math::Quaterniond(1, 0, 0, 0);  // gazebo u,x,y,z == identity
+    frame_pose = ignition::math::Pose3d(frame_pos, frame_rot);
   }
 
 
@@ -253,11 +253,11 @@ void GazeboRosBumper::OnContact()
 
       // Get force, torque and rotate into user specified frame.
       // frame_rot is identity if world is used (default for now)
-      math::Vector3 force = frame_rot.RotateVectorReverse(math::Vector3(
+      ignition::math::Vector3d force = frame_rot.RotateVectorReverse(ignition::math::Vector3d(
                               contact.wrench(j).body_1_wrench().force().x(),
                             contact.wrench(j).body_1_wrench().force().y(),
                             contact.wrench(j).body_1_wrench().force().z()));
-      math::Vector3 torque = frame_rot.RotateVectorReverse(math::Vector3(
+      ignition::math::Vector3d torque = frame_rot.RotateVectorReverse(ignition::math::Vector3d(
                             contact.wrench(j).body_1_wrench().torque().x(),
                             contact.wrench(j).body_1_wrench().torque().y(),
                             contact.wrench(j).body_1_wrench().torque().z()));
@@ -281,10 +281,11 @@ void GazeboRosBumper::OnContact()
 
       // transform contact positions into relative frame
       // set contact positions
-      gazebo::math::Vector3 position = frame_rot.RotateVectorReverse(
-          math::Vector3(contact.position(j).x(),
-                        contact.position(j).y(),
-                        contact.position(j).z()) - frame_pos);
+      ignition::math::Vector3d position = frame_rot.RotateVectorReverse(
+          ignition::math::Vector3d(contact.position(j).x(),
+                                   contact.position(j).y(),
+                                   contact.position(j).z()) -
+          frame_pos);
       geometry_msgs::Vector3 contact_position;
       contact_position.x = position.x;
       contact_position.y = position.y;
@@ -293,10 +294,9 @@ void GazeboRosBumper::OnContact()
 
       // rotate normal into user specified frame.
       // frame_rot is identity if world is used.
-      math::Vector3 normal = frame_rot.RotateVectorReverse(
-          math::Vector3(contact.normal(j).x(),
-                        contact.normal(j).y(),
-                        contact.normal(j).z()));
+      ignition::math::Vector3d normal = frame_rot.RotateVectorReverse(
+          ignition::math::Vector3d(contact.normal(j).x(), contact.normal(j).y(),
+                                   contact.normal(j).z()));
       // set contact normals
       geometry_msgs::Vector3 contact_normal;
       contact_normal.x = normal.x;

--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -356,7 +356,7 @@ void GazeboRosCameraUtils::SetHFOV(const std_msgs::Float64::ConstPtr& hfov)
 #if GAZEBO_MAJOR_VERSION >= 7
   this->camera_->SetHFOV(ignition::math::Angle(hfov->data));
 #else
-  this->camera_->SetHFOV(gazebo::math::Angle(hfov->data));
+  this->camera_->SetHFOV(ignition::math::Angle(hfov->data));
 #endif
 }
 
@@ -477,7 +477,7 @@ void GazeboRosCameraUtils::Init()
   else
   {
     // check against float precision
-    if (!gazebo::math::equal(this->focal_length_, computed_focal_length))
+    if (!ignition::math::equal(this->focal_length_, computed_focal_length))
     {
       ROS_WARN_NAMED("camera_utils", "The <focal_length>[%f] you have provided for camera_ [%s]"
                " is inconsistent with specified image_width [%d] and"

--- a/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
@@ -52,7 +52,7 @@
 
 #include <gazebo_plugins/gazebo_ros_diff_drive.h>
 
-#include <gazebo/math/gzmath.hh>
+#include <ignition/math.hh>
 #include <sdf/sdf.hh>
 
 #include <ros/ros.h>
@@ -210,7 +210,7 @@ void GazeboRosDiffDrive::publishWheelJointState()
 
     for ( int i = 0; i < 2; i++ ) {
         physics::JointPtr joint = joints_[i];
-        math::Angle angle = joint->GetAngle ( 0 );
+        ignition::math::Angle angle = joint->GetAngle ( 0 );
         joint_state_.name[i] = joint->GetName();
         joint_state_.position[i] = angle.Radian () ;
     }
@@ -225,10 +225,10 @@ void GazeboRosDiffDrive::publishWheelTF()
         std::string wheel_frame = gazebo_ros_->resolveTF(joints_[i]->GetChild()->GetName ());
         std::string wheel_parent_frame = gazebo_ros_->resolveTF(joints_[i]->GetParent()->GetName ());
 
-        math::Pose poseWheel = joints_[i]->GetChild()->GetRelativePose();
+        ignition::math::Pose3d poseWheel = joints_[i]->GetChild()->GetRelativePose();
 
-        tf::Quaternion qt ( poseWheel.rot.x, poseWheel.rot.y, poseWheel.rot.z, poseWheel.rot.w );
-        tf::Vector3 vt ( poseWheel.pos.x, poseWheel.pos.y, poseWheel.pos.z );
+        tf::Quaternion qt ( poseWheel.Rot().X(), poseWheel.Rot().Y(), poseWheel.Rot().Z(), poseWheel.Rot().W() );
+        tf::Vector3 vt ( poseWheel.Pos().X(), poseWheel.Pos().Y(), poseWheel.Pos().Z() );
 
         tf::Transform tfWheel ( qt, vt );
         transform_broadcaster_->sendTransform (
@@ -431,9 +431,9 @@ void GazeboRosDiffDrive::publishOdometry ( double step_time )
     }
     if ( odom_source_ == WORLD ) {
         // getting data form gazebo world
-        math::Pose pose = parent->GetWorldPose();
-        qt = tf::Quaternion ( pose.rot.x, pose.rot.y, pose.rot.z, pose.rot.w );
-        vt = tf::Vector3 ( pose.pos.x, pose.pos.y, pose.pos.z );
+        ignition::math::Pose3d pose = parent->GetWorldPose();
+        qt = tf::Quaternion ( pose.Rot().X(), pose.Rot().Y(), pose.Rot().Z(), pose.Rot().W() );
+        vt = tf::Vector3 ( pose.Pos().X(), pose.Pos().Y(), pose.Pos().Z() );
 
         odom_.pose.pose.position.x = vt.x();
         odom_.pose.pose.position.y = vt.y();
@@ -445,14 +445,14 @@ void GazeboRosDiffDrive::publishOdometry ( double step_time )
         odom_.pose.pose.orientation.w = qt.w();
 
         // get velocity in /odom frame
-        math::Vector3 linear;
+        ignition::math::Vector3d linear;
         linear = parent->GetWorldLinearVel();
-        odom_.twist.twist.angular.z = parent->GetWorldAngularVel().z;
+        odom_.twist.twist.angular.z = parent->GetWorldAngularVel().Z();
 
         // convert velocity to child_frame_id (aka base_footprint)
-        float yaw = pose.rot.GetYaw();
-        odom_.twist.twist.linear.x = cosf ( yaw ) * linear.x + sinf ( yaw ) * linear.y;
-        odom_.twist.twist.linear.y = cosf ( yaw ) * linear.y - sinf ( yaw ) * linear.x;
+        float yaw = pose.Rot().Yaw();
+        odom_.twist.twist.linear.x = cosf ( yaw ) * linear.X() + sinf ( yaw ) * linear.Y();
+        odom_.twist.twist.linear.y = cosf ( yaw ) * linear.Y() - sinf ( yaw ) * linear.X();
     }
 
     tf::Transform base_footprint_to_odom ( qt, vt );

--- a/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
@@ -133,7 +133,7 @@ void GazeboRosDiffDrive::Load ( physics::ModelPtr _parent, sdf::ElementPtr _sdf 
     // Initialize update rate stuff
     if ( this->update_rate_ > 0.0 ) this->update_period_ = 1.0 / this->update_rate_;
     else this->update_period_ = 0.0;
-    last_update_time_ = parent->GetWorld()->GetSimTime();
+    last_update_time_ = parent->GetWorld()->SimTime();
 
     // Initialize velocity stuff
     wheel_speed_[RIGHT] = 0;
@@ -185,7 +185,7 @@ void GazeboRosDiffDrive::Load ( physics::ModelPtr _parent, sdf::ElementPtr _sdf 
 
 void GazeboRosDiffDrive::Reset()
 {
-  last_update_time_ = parent->GetWorld()->GetSimTime();
+  last_update_time_ = parent->GetWorld()->SimTime();
   pose_encoder_.x = 0;
   pose_encoder_.y = 0;
   pose_encoder_.theta = 0;
@@ -210,7 +210,7 @@ void GazeboRosDiffDrive::publishWheelJointState()
 
     for ( int i = 0; i < 2; i++ ) {
         physics::JointPtr joint = joints_[i];
-        ignition::math::Angle angle = joint->GetAngle ( 0 );
+        ignition::math::Angle angle = joint->Position ( 0 );
         joint_state_.name[i] = joint->GetName();
         joint_state_.position[i] = angle.Radian () ;
     }
@@ -225,7 +225,7 @@ void GazeboRosDiffDrive::publishWheelTF()
         std::string wheel_frame = gazebo_ros_->resolveTF(joints_[i]->GetChild()->GetName ());
         std::string wheel_parent_frame = gazebo_ros_->resolveTF(joints_[i]->GetParent()->GetName ());
 
-        ignition::math::Pose3d poseWheel = joints_[i]->GetChild()->GetRelativePose();
+        ignition::math::Pose3d poseWheel = joints_[i]->GetChild()->RelativePose();
 
         tf::Quaternion qt ( poseWheel.Rot().X(), poseWheel.Rot().Y(), poseWheel.Rot().Z(), poseWheel.Rot().W() );
         tf::Vector3 vt ( poseWheel.Pos().X(), poseWheel.Pos().Y(), poseWheel.Pos().Z() );
@@ -259,7 +259,7 @@ void GazeboRosDiffDrive::UpdateChild()
 
 
     if ( odom_source_ == ENCODER ) UpdateOdometryEncoder();
-    common::Time current_time = parent->GetWorld()->GetSimTime();
+    common::Time current_time = parent->GetWorld()->SimTime();
     double seconds_since_last_update = ( current_time - last_update_time_ ).Double();
 
     if ( seconds_since_last_update > update_period_ ) {
@@ -361,7 +361,7 @@ void GazeboRosDiffDrive::UpdateOdometryEncoder()
 {
     double vl = joints_[LEFT]->GetVelocity ( 0 );
     double vr = joints_[RIGHT]->GetVelocity ( 0 );
-    common::Time current_time = parent->GetWorld()->GetSimTime();
+    common::Time current_time = parent->GetWorld()->SimTime();
     double seconds_since_last_update = ( current_time - last_odom_update_ ).Double();
     last_odom_update_ = current_time;
 
@@ -431,7 +431,7 @@ void GazeboRosDiffDrive::publishOdometry ( double step_time )
     }
     if ( odom_source_ == WORLD ) {
         // getting data form gazebo world
-        ignition::math::Pose3d pose = parent->GetWorldPose();
+        ignition::math::Pose3d pose = parent->WorldPose();
         qt = tf::Quaternion ( pose.Rot().X(), pose.Rot().Y(), pose.Rot().Z(), pose.Rot().W() );
         vt = tf::Vector3 ( pose.Pos().X(), pose.Pos().Y(), pose.Pos().Z() );
 
@@ -446,8 +446,8 @@ void GazeboRosDiffDrive::publishOdometry ( double step_time )
 
         // get velocity in /odom frame
         ignition::math::Vector3d linear;
-        linear = parent->GetWorldLinearVel();
-        odom_.twist.twist.angular.z = parent->GetWorldAngularVel().Z();
+        linear = parent->WorldLinearVel();
+        odom_.twist.twist.angular.z = parent->WorldAngularVel().Z();
 
         // convert velocity to child_frame_id (aka base_footprint)
         float yaw = pose.Rot().Yaw();

--- a/gazebo_plugins/src/gazebo_ros_f3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_f3d.cpp
@@ -152,16 +152,16 @@ void GazeboRosF3D::UpdateChild()
   ignition::math::Vector3d force;
 
   // get force on body
-  force = this->link_->GetWorldForce();
+  force = this->link_->WorldForce();
 
   // get torque on body
-  torque = this->link_->GetWorldTorque();
+  torque = this->link_->WorldTorque();
 
   this->lock_.lock();
   // copy data into wrench message
   this->wrench_msg_.header.frame_id = this->frame_name_;
-  this->wrench_msg_.header.stamp.sec = (this->world_->GetSimTime()).sec;
-  this->wrench_msg_.header.stamp.nsec = (this->world_->GetSimTime()).nsec;
+  this->wrench_msg_.header.stamp.sec = (this->world_->SimTime()).sec;
+  this->wrench_msg_.header.stamp.nsec = (this->world_->SimTime()).nsec;
 
   this->wrench_msg_.wrench.force.x    = force.x;
   this->wrench_msg_.wrench.force.y    = force.y;

--- a/gazebo_plugins/src/gazebo_ros_f3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_f3d.cpp
@@ -163,12 +163,12 @@ void GazeboRosF3D::UpdateChild()
   this->wrench_msg_.header.stamp.sec = (this->world_->SimTime()).sec;
   this->wrench_msg_.header.stamp.nsec = (this->world_->SimTime()).nsec;
 
-  this->wrench_msg_.wrench.force.x    = force.x;
-  this->wrench_msg_.wrench.force.y    = force.y;
-  this->wrench_msg_.wrench.force.z    = force.z;
-  this->wrench_msg_.wrench.torque.x   = torque.x;
-  this->wrench_msg_.wrench.torque.y   = torque.y;
-  this->wrench_msg_.wrench.torque.z   = torque.z;
+  this->wrench_msg_.wrench.force.x    = force.X();
+  this->wrench_msg_.wrench.force.y    = force.Y();
+  this->wrench_msg_.wrench.force.z    = force.Z();
+  this->wrench_msg_.wrench.torque.x   = torque.X();
+  this->wrench_msg_.wrench.torque.y   = torque.Y();
+  this->wrench_msg_.wrench.torque.z   = torque.Z();
 
   this->pub_.publish(this->wrench_msg_);
   this->lock_.unlock();

--- a/gazebo_plugins/src/gazebo_ros_f3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_f3d.cpp
@@ -39,7 +39,6 @@ GazeboRosF3D::GazeboRosF3D()
 // Destructor
 GazeboRosF3D::~GazeboRosF3D()
 {
-  event::Events::DisconnectWorldUpdateBegin(this->update_connection_);
   // Custom Callback Queue
   this->queue_.clear();
   this->queue_.disable();

--- a/gazebo_plugins/src/gazebo_ros_f3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_f3d.cpp
@@ -149,8 +149,8 @@ void GazeboRosF3D::UpdateChild()
   if (this->f3d_connect_count_ == 0)
     return;
 
-  math::Vector3 torque;
-  math::Vector3 force;
+  ignition::math::Vector3d torque;
+  ignition::math::Vector3d force;
 
   // get force on body
   force = this->link_->GetWorldForce();

--- a/gazebo_plugins/src/gazebo_ros_force.cpp
+++ b/gazebo_plugins/src/gazebo_ros_force.cpp
@@ -46,7 +46,6 @@ GazeboRosForce::GazeboRosForce()
 // Destructor
 GazeboRosForce::~GazeboRosForce()
 {
-  event::Events::DisconnectWorldUpdateBegin(this->update_connection_);
   // Custom Callback Queue
   this->queue_.clear();
   this->queue_.disable();

--- a/gazebo_plugins/src/gazebo_ros_force.cpp
+++ b/gazebo_plugins/src/gazebo_ros_force.cpp
@@ -47,7 +47,6 @@ GazeboRosForce::GazeboRosForce()
 GazeboRosForce::~GazeboRosForce()
 {
   event::Events::DisconnectWorldUpdateBegin(this->update_connection_);
-
   // Custom Callback Queue
   this->queue_.clear();
   this->queue_.disable();

--- a/gazebo_plugins/src/gazebo_ros_force.cpp
+++ b/gazebo_plugins/src/gazebo_ros_force.cpp
@@ -137,8 +137,8 @@ void GazeboRosForce::UpdateObjectForce(const geometry_msgs::Wrench::ConstPtr& _m
 void GazeboRosForce::UpdateChild()
 {
   this->lock_.lock();
-  math::Vector3 force(this->wrench_msg_.force.x,this->wrench_msg_.force.y,this->wrench_msg_.force.z);
-  math::Vector3 torque(this->wrench_msg_.torque.x,this->wrench_msg_.torque.y,this->wrench_msg_.torque.z);
+  ignition::math::Vector3d force(this->wrench_msg_.force.x,this->wrench_msg_.force.y,this->wrench_msg_.force.z);
+  ignition::math::Vector3d torque(this->wrench_msg_.torque.x,this->wrench_msg_.torque.y,this->wrench_msg_.torque.z);
   this->link_->AddForce(force);
   this->link_->AddTorque(torque);
   this->lock_.unlock();

--- a/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
@@ -39,7 +39,6 @@ GazeboRosFT::GazeboRosFT()
 // Destructor
 GazeboRosFT::~GazeboRosFT()
 {
-  event::Events::DisconnectWorldUpdateBegin(this->update_connection_);
   // Custom Callback Queue
   this->queue_.clear();
   this->queue_.disable();

--- a/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
@@ -168,8 +168,8 @@ void GazeboRosFT::UpdateChild()
     return;
 
   physics::JointWrench wrench;
-  math::Vector3 torque;
-  math::Vector3 force;
+  ignition::math::Vector3d torque;
+  ignition::math::Vector3d force;
 
   // FIXME: Should include options for diferent frames and measure directions
   // E.g: https://bitbucket.org/osrf/gazebo/raw/default/gazebo/sensors/ForceTorqueSensor.hh

--- a/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
@@ -156,7 +156,7 @@ void GazeboRosFT::FTDisconnect()
 // Update the controller
 void GazeboRosFT::UpdateChild()
 {
-  common::Time cur_time = this->world_->GetSimTime();
+  common::Time cur_time = this->world_->SimTime();
 
   // rate control
   if (this->update_rate_ > 0 &&
@@ -183,8 +183,8 @@ void GazeboRosFT::UpdateChild()
   this->lock_.lock();
   // copy data into wrench message
   this->wrench_msg_.header.frame_id = this->frame_name_;
-  this->wrench_msg_.header.stamp.sec = (this->world_->GetSimTime()).sec;
-  this->wrench_msg_.header.stamp.nsec = (this->world_->GetSimTime()).nsec;
+  this->wrench_msg_.header.stamp.sec = (this->world_->SimTime()).sec;
+  this->wrench_msg_.header.stamp.nsec = (this->world_->SimTime()).nsec;
 
   this->wrench_msg_.wrench.force.x = force.x + this->GaussianKernel(0, this->gaussian_noise_);
   this->wrench_msg_.wrench.force.y = force.y + this->GaussianKernel(0, this->gaussian_noise_);

--- a/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
@@ -186,12 +186,12 @@ void GazeboRosFT::UpdateChild()
   this->wrench_msg_.header.stamp.sec = (this->world_->SimTime()).sec;
   this->wrench_msg_.header.stamp.nsec = (this->world_->SimTime()).nsec;
 
-  this->wrench_msg_.wrench.force.x = force.x + this->GaussianKernel(0, this->gaussian_noise_);
-  this->wrench_msg_.wrench.force.y = force.y + this->GaussianKernel(0, this->gaussian_noise_);
-  this->wrench_msg_.wrench.force.z = force.z + this->GaussianKernel(0, this->gaussian_noise_);
-  this->wrench_msg_.wrench.torque.x = torque.x + this->GaussianKernel(0, this->gaussian_noise_);
-  this->wrench_msg_.wrench.torque.y = torque.y + this->GaussianKernel(0, this->gaussian_noise_);
-  this->wrench_msg_.wrench.torque.z = torque.z + this->GaussianKernel(0, this->gaussian_noise_);
+  this->wrench_msg_.wrench.force.x = force.X() + this->GaussianKernel(0, this->gaussian_noise_);
+  this->wrench_msg_.wrench.force.y = force.Y() + this->GaussianKernel(0, this->gaussian_noise_);
+  this->wrench_msg_.wrench.force.z = force.Z() + this->GaussianKernel(0, this->gaussian_noise_);
+  this->wrench_msg_.wrench.torque.x = torque.X() + this->GaussianKernel(0, this->gaussian_noise_);
+  this->wrench_msg_.wrench.torque.y = torque.Y() + this->GaussianKernel(0, this->gaussian_noise_);
+  this->wrench_msg_.wrench.torque.z = torque.Z() + this->GaussianKernel(0, this->gaussian_noise_);
 
   this->pub_.publish(this->wrench_msg_);
   this->lock_.unlock();

--- a/gazebo_plugins/src/gazebo_ros_hand_of_god.cpp
+++ b/gazebo_plugins/src/gazebo_ros_hand_of_god.cpp
@@ -161,7 +161,7 @@ namespace gazebo
     ignition::math::Quaterniond not_a_quaternion = err_rot.GetLog();
 
     floating_link_->AddForce(
-        kl_ * err_pos - cl_ * floating_link_->GetWorldLinearVel());
+        kl_ * err_pos - cl_ * floating_link_->WorldLinearVel());
 
     floating_link_->AddRelativeTorque(
         ka_ * ignition::math::Vector3d(not_a_quaternion.x, not_a_quaternion.y, not_a_quaternion.z) - ca_ * floating_link_->GetRelativeAngularVel());

--- a/gazebo_plugins/src/gazebo_ros_hand_of_god.cpp
+++ b/gazebo_plugins/src/gazebo_ros_hand_of_god.cpp
@@ -149,22 +149,22 @@ namespace gazebo
     // Convert TF transform to Gazebo Pose
     const geometry_msgs::Vector3 &p = hog_desired_tform.transform.translation;
     const geometry_msgs::Quaternion &q = hog_desired_tform.transform.rotation;
-    gazebo::math::Pose hog_desired(
-        gazebo::math::Vector3(p.x, p.y, p.z),
-        gazebo::math::Quaternion(q.w, q.x, q.y, q.z));
+    ignition::math::Pose3d hog_desired(
+        ignition::math::Vector3d(p.x, p.y, p.z),
+        ignition::math::Quaterniond(q.w, q.x, q.y, q.z));
 
     // Relative transform from actual to desired pose
-    gazebo::math::Pose world_pose = floating_link_->GetDirtyPose();
-    gazebo::math::Vector3 err_pos = hog_desired.pos - world_pose.pos;
+    ignition::math::Pose3d world_pose = floating_link_->GetDirtyPose();
+    ignition::math::Vector3d err_pos = hog_desired.pos - world_pose.pos;
     // Get exponential coordinates for rotation
-    gazebo::math::Quaternion err_rot =  (world_pose.rot.GetAsMatrix4().Inverse() * hog_desired.rot.GetAsMatrix4()).GetRotation();
-    gazebo::math::Quaternion not_a_quaternion = err_rot.GetLog();
+    ignition::math::Quaterniond err_rot =  (world_pose.rot.GetAsMatrix4().Inverse() * hog_desired.rot.GetAsMatrix4()).GetRotation();
+    ignition::math::Quaterniond not_a_quaternion = err_rot.GetLog();
 
     floating_link_->AddForce(
         kl_ * err_pos - cl_ * floating_link_->GetWorldLinearVel());
 
     floating_link_->AddRelativeTorque(
-        ka_ * gazebo::math::Vector3(not_a_quaternion.x, not_a_quaternion.y, not_a_quaternion.z) - ca_ * floating_link_->GetRelativeAngularVel());
+        ka_ * ignition::math::Vector3d(not_a_quaternion.x, not_a_quaternion.y, not_a_quaternion.z) - ca_ * floating_link_->GetRelativeAngularVel());
 
     // Convert actual pose to TransformStamped message
     geometry_msgs::TransformStamped hog_actual_tform;

--- a/gazebo_plugins/src/gazebo_ros_hand_of_god.cpp
+++ b/gazebo_plugins/src/gazebo_ros_hand_of_god.cpp
@@ -115,8 +115,8 @@ namespace gazebo
       return;
     }
 
-    cl_ = 2.0 * sqrt(kl_*floating_link_->GetInertial()->GetMass());
-    ca_ = 2.0 * sqrt(ka_*floating_link_->GetInertial()->GetIXX());
+    cl_ = 2.0 * sqrt(kl_ * floating_link_->GetInertial()->Mass());
+    ca_ = 2.0 * sqrt(ka_ * floating_link_->GetInertial()->IXX());
 
     // Create the TF listener for the desired position of the hog
     tf_buffer_.reset(new tf2_ros::Buffer());
@@ -154,17 +154,22 @@ namespace gazebo
         ignition::math::Quaterniond(q.w, q.x, q.y, q.z));
 
     // Relative transform from actual to desired pose
-    ignition::math::Pose3d world_pose = floating_link_->GetDirtyPose();
-    ignition::math::Vector3d err_pos = hog_desired.pos - world_pose.pos;
+    ignition::math::Pose3d world_pose = floating_link_->DirtyPose();
+    ignition::math::Vector3d err_pos = hog_desired.Pos() - world_pose.Pos();
     // Get exponential coordinates for rotation
-    ignition::math::Quaterniond err_rot =  (world_pose.rot.GetAsMatrix4().Inverse() * hog_desired.rot.GetAsMatrix4()).GetRotation();
-    ignition::math::Quaterniond not_a_quaternion = err_rot.GetLog();
+    ignition::math::Quaterniond err_rot(
+        ignition::math::Matrix3d(world_pose.Rot()).Inverse() *
+        ignition::math::Matrix3d(hog_desired.Rot()));
+    ignition::math::Quaterniond not_a_quaternion = err_rot.Log();
 
     floating_link_->AddForce(
         kl_ * err_pos - cl_ * floating_link_->WorldLinearVel());
 
     floating_link_->AddRelativeTorque(
-        ka_ * ignition::math::Vector3d(not_a_quaternion.x, not_a_quaternion.y, not_a_quaternion.z) - ca_ * floating_link_->GetRelativeAngularVel());
+        ka_ * ignition::math::Vector3d(not_a_quaternion.X(),
+                                       not_a_quaternion.Y(),
+                                       not_a_quaternion.Z()) -
+        ca_ * floating_link_->RelativeAngularVel());
 
     // Convert actual pose to TransformStamped message
     geometry_msgs::TransformStamped hog_actual_tform;
@@ -174,14 +179,14 @@ namespace gazebo
 
     hog_actual_tform.child_frame_id = frame_id_ + "_actual";
 
-    hog_actual_tform.transform.translation.x = world_pose.pos.x;
-    hog_actual_tform.transform.translation.y = world_pose.pos.y;
-    hog_actual_tform.transform.translation.z = world_pose.pos.z;
+    hog_actual_tform.transform.translation.x = world_pose.Pos().X();
+    hog_actual_tform.transform.translation.y = world_pose.Pos().Y();
+    hog_actual_tform.transform.translation.z = world_pose.Pos().Z();
 
-    hog_actual_tform.transform.rotation.w = world_pose.rot.w;
-    hog_actual_tform.transform.rotation.x = world_pose.rot.x;
-    hog_actual_tform.transform.rotation.y = world_pose.rot.y;
-    hog_actual_tform.transform.rotation.z = world_pose.rot.z;
+    hog_actual_tform.transform.rotation.w = world_pose.Rot().W();
+    hog_actual_tform.transform.rotation.x = world_pose.Rot().X();
+    hog_actual_tform.transform.rotation.y = world_pose.Rot().Y();
+    hog_actual_tform.transform.rotation.z = world_pose.Rot().Z();
 
     tf_broadcaster_->sendTransform(hog_actual_tform);
   }

--- a/gazebo_plugins/src/gazebo_ros_imu.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu.cpp
@@ -147,7 +147,7 @@ void GazeboRosIMU::LoadThread()
 
   // assert that the body by link_name_ exists
   this->link = boost::dynamic_pointer_cast<physics::Link>(
-    this->world_->GetEntity(this->link_name_));
+    this->world_->EntityByName(this->link_name_));
   if (!this->link)
   {
     ROS_FATAL_NAMED("imu", "gazebo_ros_imu plugin error: bodyName: %s does not exist\n",
@@ -171,11 +171,11 @@ void GazeboRosIMU::LoadThread()
   }
 
   // Initialize the controller
-  this->last_time_ = this->world_->GetSimTime();
+  this->last_time_ = this->world_->SimTime();
 
   // this->initial_pose_ = this->link->GetPose();
-  this->last_vpos_ = this->link->GetWorldLinearVel();
-  this->last_veul_ = this->link->GetWorldAngularVel();
+  this->last_vpos_ = this->link->WorldLinearVel();
+  this->last_veul_ = this->link->WorldAngularVel();
   this->apos_ = 0;
   this->aeul_ = 0;
 
@@ -203,7 +203,7 @@ bool GazeboRosIMU::ServiceCallback(std_srvs::Empty::Request &req,
 // Update the controller
 void GazeboRosIMU::UpdateChild()
 {
-  common::Time cur_time = this->world_->GetSimTime();
+  common::Time cur_time = this->world_->SimTime();
 
   // rate control
   if (this->update_rate_ > 0 &&
@@ -217,7 +217,7 @@ void GazeboRosIMU::UpdateChild()
     ignition::math::Vector3d pos;
 
     // Get Pose/Orientation ///@todo: verify correctness
-    pose = this->link->GetWorldPose();
+    pose = this->link->WorldPose();
     // apply xyz offsets and get position and rotation components
     pos = pose.Pos() + this->offset_.Pos();
     rot = pose.Rot();
@@ -227,8 +227,8 @@ void GazeboRosIMU::UpdateChild()
     rot.Normalize();
 
     // get Rates
-    ignition::math::Vector3d vpos = this->link->GetWorldLinearVel();
-    ignition::math::Vector3d veul = this->link->GetWorldAngularVel();
+    ignition::math::Vector3d vpos = this->link->WorldLinearVel();
+    ignition::math::Vector3d veul = this->link->WorldAngularVel();
 
     // differentiate to get accelerations
     double tmp_dt = this->last_time_.Double() - cur_time.Double();

--- a/gazebo_plugins/src/gazebo_ros_imu.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu.cpp
@@ -102,18 +102,19 @@ void GazeboRosIMU::LoadThread()
   if (!this->sdf->HasElement("xyzOffset"))
   {
     ROS_INFO_NAMED("imu", "imu plugin missing <xyzOffset>, defaults to 0s");
-    this->offset_.pos = math::Vector3(0, 0, 0);
+    this->offset_.Pos() = ignition::math::Vector3d(0.0, 0.0, 0.0);
   }
   else
-    this->offset_.pos = this->sdf->Get<math::Vector3>("xyzOffset");
+    this->offset_.Pos() = this->sdf->Get<ignition::math::Vector3d>("xyzOffset");
 
   if (!this->sdf->HasElement("rpyOffset"))
   {
     ROS_INFO_NAMED("imu", "imu plugin missing <rpyOffset>, defaults to 0s");
-    this->offset_.rot = math::Vector3(0, 0, 0);
+    this->offset_.Rot() = ignition::math::Quaterniond(1.0, 0.0, 0.0, 0.0);
   }
   else
-    this->offset_.rot = this->sdf->Get<math::Vector3>("rpyOffset");
+    this->offset_.Rot() = ignition::math::Quaterniond(
+        this->sdf->Get<ignition::math::Vector3d>("rpyOffset"));
 
   if (!this->sdf->HasElement("updateRate"))
   {
@@ -212,23 +213,23 @@ void GazeboRosIMU::UpdateChild()
 
   if ((this->pub_.getNumSubscribers() > 0 && this->topic_name_ != ""))
   {
-    math::Pose pose;
-    math::Quaternion rot;
-    math::Vector3 pos;
+    ignition::math::Pose3d pose;
+    ignition::math::Quaterniond rot;
+    ignition::math::Vector3d pos;
 
     // Get Pose/Orientation ///@todo: verify correctness
     pose = this->link->GetWorldPose();
     // apply xyz offsets and get position and rotation components
-    pos = pose.pos + this->offset_.pos;
-    rot = pose.rot;
+    pos = pose.Pos() + this->offset_.Pos();
+    rot = pose.Rot();
 
     // apply rpy offsets
-    rot = this->offset_.rot*rot;
+    rot = this->offset_.Rot() * rot;
     rot.Normalize();
 
     // get Rates
-    math::Vector3 vpos = this->link->GetWorldLinearVel();
-    math::Vector3 veul = this->link->GetWorldAngularVel();
+    ignition::math::Vector3d vpos = this->link->GetWorldLinearVel();
+    ignition::math::Vector3d veul = this->link->GetWorldAngularVel();
 
     // differentiate to get accelerations
     double tmp_dt = this->last_time_.Double() - cur_time.Double();
@@ -253,34 +254,34 @@ void GazeboRosIMU::UpdateChild()
     // rot = this->initial_pose_.rot*rot;
     // rot.Normalize();
 
-    this->imu_msg_.orientation.x = rot.x;
-    this->imu_msg_.orientation.y = rot.y;
-    this->imu_msg_.orientation.z = rot.z;
-    this->imu_msg_.orientation.w = rot.w;
+    this->imu_msg_.orientation.x = rot.X();
+    this->imu_msg_.orientation.y = rot.Y();
+    this->imu_msg_.orientation.z = rot.Z();
+    this->imu_msg_.orientation.w = rot.W();
 
     // pass euler angular rates
-    math::Vector3 linear_velocity(
-      veul.x + this->GaussianKernel(0, this->gaussian_noise_),
-      veul.y + this->GaussianKernel(0, this->gaussian_noise_),
-      veul.z + this->GaussianKernel(0, this->gaussian_noise_));
+    ignition::math::Vector3d linear_velocity(
+      veul.X() + this->GaussianKernel(0, this->gaussian_noise_),
+      veul.Y() + this->GaussianKernel(0, this->gaussian_noise_),
+      veul.Z() + this->GaussianKernel(0, this->gaussian_noise_));
     // rotate into local frame
     // @todo: deal with offsets!
     linear_velocity = rot.RotateVector(linear_velocity);
-    this->imu_msg_.angular_velocity.x    = linear_velocity.x;
-    this->imu_msg_.angular_velocity.y    = linear_velocity.y;
-    this->imu_msg_.angular_velocity.z    = linear_velocity.z;
+    this->imu_msg_.angular_velocity.x    = linear_velocity.X();
+    this->imu_msg_.angular_velocity.y    = linear_velocity.Y();
+    this->imu_msg_.angular_velocity.z    = linear_velocity.Z();
 
     // pass accelerations
-    math::Vector3 linear_acceleration(
-      apos_.x + this->GaussianKernel(0, this->gaussian_noise_),
-      apos_.y + this->GaussianKernel(0, this->gaussian_noise_),
-      apos_.z + this->GaussianKernel(0, this->gaussian_noise_));
+    ignition::math::Vector3d linear_acceleration(
+      apos_.X() + this->GaussianKernel(0, this->gaussian_noise_),
+      apos_.Y() + this->GaussianKernel(0, this->gaussian_noise_),
+      apos_.Z() + this->GaussianKernel(0, this->gaussian_noise_));
     // rotate into local frame
     // @todo: deal with offsets!
     linear_acceleration = rot.RotateVector(linear_acceleration);
-    this->imu_msg_.linear_acceleration.x    = linear_acceleration.x;
-    this->imu_msg_.linear_acceleration.y    = linear_acceleration.y;
-    this->imu_msg_.linear_acceleration.z    = linear_acceleration.z;
+    this->imu_msg_.linear_acceleration.x    = linear_acceleration.X();
+    this->imu_msg_.linear_acceleration.y    = linear_acceleration.Y();
+    this->imu_msg_.linear_acceleration.z    = linear_acceleration.Z();
 
     // fill in covariance matrix
     /// @todo: let user set separate linear and angular covariance values.

--- a/gazebo_plugins/src/gazebo_ros_imu.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu.cpp
@@ -38,7 +38,6 @@ GazeboRosIMU::GazeboRosIMU()
 // Destructor
 GazeboRosIMU::~GazeboRosIMU()
 {
-  event::Events::DisconnectWorldUpdateBegin(this->update_connection_);
   // Finalize the controller
   this->rosnode_->shutdown();
   this->callback_queue_thread_.join();

--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -82,28 +82,28 @@ void gazebo::GazeboRosImuSensor::UpdateChild(const gazebo::common::UpdateInfo &/
   if(imu_data_publisher.getNumSubscribers() > 0)
   {
 #if GAZEBO_MAJOR_VERSION >= 6
-    orientation = offset.rot*sensor->Orientation(); //applying offsets to the orientation measurement
+    orientation = offset.Rot() * sensor->Orientation(); //applying offsets to the orientation measurement
     accelerometer_data = sensor->LinearAcceleration();
     gyroscope_data = sensor->AngularVelocity();
 #else
-    orientation = offset.rot*sensor->GetOrientation(); //applying offsets to the orientation measurement
+    orientation = offset.Rot() * sensor->GetOrientation(); //applying offsets to the orientation measurement
     accelerometer_data = sensor->GetLinearAcceleration();
     gyroscope_data = sensor->GetAngularVelocity();
 #endif
 
     //Guassian noise is applied to all measurements
-    imu_msg.orientation.x = orientation.x + GuassianKernel(0,gaussian_noise);
-    imu_msg.orientation.y = orientation.y + GuassianKernel(0,gaussian_noise);
-    imu_msg.orientation.z = orientation.z + GuassianKernel(0,gaussian_noise);
-    imu_msg.orientation.w = orientation.w + GuassianKernel(0,gaussian_noise);
+    imu_msg.orientation.x = orientation.X() + GuassianKernel(0,gaussian_noise);
+    imu_msg.orientation.y = orientation.Y() + GuassianKernel(0,gaussian_noise);
+    imu_msg.orientation.z = orientation.Z() + GuassianKernel(0,gaussian_noise);
+    imu_msg.orientation.w = orientation.W() + GuassianKernel(0,gaussian_noise);
 
-    imu_msg.linear_acceleration.x = accelerometer_data.x + GuassianKernel(0,gaussian_noise);
-    imu_msg.linear_acceleration.y = accelerometer_data.y + GuassianKernel(0,gaussian_noise);
-    imu_msg.linear_acceleration.z = accelerometer_data.z + GuassianKernel(0,gaussian_noise);
+    imu_msg.linear_acceleration.x = accelerometer_data.X() + GuassianKernel(0,gaussian_noise);
+    imu_msg.linear_acceleration.y = accelerometer_data.Y() + GuassianKernel(0,gaussian_noise);
+    imu_msg.linear_acceleration.z = accelerometer_data.Z() + GuassianKernel(0,gaussian_noise);
 
-    imu_msg.angular_velocity.x = gyroscope_data.x + GuassianKernel(0,gaussian_noise);
-    imu_msg.angular_velocity.y = gyroscope_data.y + GuassianKernel(0,gaussian_noise);
-    imu_msg.angular_velocity.z = gyroscope_data.z + GuassianKernel(0,gaussian_noise);
+    imu_msg.angular_velocity.x = gyroscope_data.X() + GuassianKernel(0,gaussian_noise);
+    imu_msg.angular_velocity.y = gyroscope_data.Y() + GuassianKernel(0,gaussian_noise);
+    imu_msg.angular_velocity.z = gyroscope_data.Z() + GuassianKernel(0,gaussian_noise);
 
     //covariance is related to the Gaussian noise
     double gn2 = gaussian_noise*gaussian_noise;
@@ -219,25 +219,34 @@ bool gazebo::GazeboRosImuSensor::LoadParameters()
   //POSITION OFFSET, UNUSED
   if (sdf->HasElement("xyzOffset"))
   {
-    offset.pos =  sdf->Get<math::Vector3>("xyzOffset");
-    ROS_INFO_STREAM("<xyzOffset> set to: " << offset.pos[0] << ' ' << offset.pos[1] << ' ' << offset.pos[2]);
+    offset.Pos() =  sdf->Get<ignition::math::Vector3d>("xyzOffset");
+    ROS_INFO_STREAM("<xyzOffset> set to: " << offset.Pos().X() << ' '
+                                           << offset.Pos().Y() << ' '
+                                           << offset.Pos().Z());
   }
   else
   {
-    offset.pos = ignition::math::Vector3d(0, 0, 0);
-    ROS_WARN_STREAM("missing <xyzOffset>, set to default: " << offset.pos[0] << ' ' << offset.pos[1] << ' ' << offset.pos[2]);
+    offset.Pos() = ignition::math::Vector3d(0.0, 0.0, 0.0);
+    ROS_WARN_STREAM("missing <xyzOffset>, set to default: "
+                    << offset.Pos().X() << ' ' << offset.Pos().Y() << ' '
+                    << offset.Pos().Z());
   }
 
   //ORIENTATION OFFSET
   if (sdf->HasElement("rpyOffset"))
   {
-    offset.rot =  sdf->Get<math::Vector3>("rpyOffset");
-    ROS_INFO_STREAM("<rpyOffset> set to: " << offset.rot.GetRoll() << ' ' << offset.rot.GetPitch() << ' ' << offset.rot.GetYaw());
+    offset.Rot() = ignition::math::Quaterniond(
+        sdf->Get<ignition::math::Vector3d>("rpyOffset"));
+    ROS_INFO_STREAM("<rpyOffset> set to: " << offset.Rot().Roll() << ' '
+                                           << offset.Rot().Pitch() << ' '
+                                           << offset.Rot().Yaw());
   }
   else
   {
-    offset.rot = ignition::math::Vector3d(0, 0, 0);
-    ROS_WARN_STREAM("missing <rpyOffset>, set to default: " << offset.rot.GetRoll() << ' ' << offset.rot.GetPitch() << ' ' << offset.rot.GetYaw());
+    offset.Rot() = ignition::math::Quaterniond(1.0, 0.0, 0.0, 0.0);
+    ROS_WARN_STREAM("missing <rpyOffset>, set to default: "
+                    << offset.Rot().Roll() << ' ' << offset.Rot().Pitch() << ' '
+                    << offset.Rot().Yaw());
   }
 
   return true;

--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -23,9 +23,9 @@ GZ_REGISTER_SENSOR_PLUGIN(gazebo::GazeboRosImuSensor)
 
 gazebo::GazeboRosImuSensor::GazeboRosImuSensor(): SensorPlugin()
 {
-  accelerometer_data = math::Vector3(0, 0, 0);
-  gyroscope_data = math::Vector3(0, 0, 0);
-  orientation = math::Quaternion(1,0,0,0);
+  accelerometer_data = ignition::math::Vector3d(0, 0, 0);
+  gyroscope_data = ignition::math::Vector3d(0, 0, 0);
+  orientation = ignition::math::Quaterniond(1,0,0,0);
   seed=0;
   sensor=NULL;
 }
@@ -224,7 +224,7 @@ bool gazebo::GazeboRosImuSensor::LoadParameters()
   }
   else
   {
-    offset.pos = math::Vector3(0, 0, 0);
+    offset.pos = ignition::math::Vector3d(0, 0, 0);
     ROS_WARN_STREAM("missing <xyzOffset>, set to default: " << offset.pos[0] << ' ' << offset.pos[1] << ' ' << offset.pos[2]);
   }
 
@@ -236,7 +236,7 @@ bool gazebo::GazeboRosImuSensor::LoadParameters()
   }
   else
   {
-    offset.rot = math::Vector3(0, 0, 0);
+    offset.rot = ignition::math::Vector3d(0, 0, 0);
     ROS_WARN_STREAM("missing <rpyOffset>, set to default: " << offset.rot.GetRoll() << ' ' << offset.rot.GetPitch() << ' ' << offset.rot.GetYaw());
   }
 

--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -1,13 +1,13 @@
 /* Copyright [2015] [Alessandro Settimi]
- * 
+ *
  * email: ale.settimi@gmail.com
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -247,7 +247,6 @@ gazebo::GazeboRosImuSensor::~GazeboRosImuSensor()
 {
   if (connection.get())
   {
-    gazebo::event::Events::DisconnectWorldUpdateBegin(connection);
     connection = gazebo::event::ConnectionPtr();
   }
 

--- a/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
@@ -47,7 +47,6 @@ ROS_DEPRECATED GazeboRosJointPoseTrajectory::GazeboRosJointPoseTrajectory()  // 
 // Destructor
 GazeboRosJointPoseTrajectory::~GazeboRosJointPoseTrajectory()
 {
-  event::Events::DisconnectWorldUpdateBegin(this->update_connection_);
   // Finalize the controller
   this->rosnode_->shutdown();
   this->queue_.clear();

--- a/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
@@ -325,7 +325,7 @@ void GazeboRosJointPoseTrajectory::UpdateStates()
           cur_time.Double(), this->trajectory_index, this->points_.size());
 
         // get reference link pose before updates
-        math::Pose reference_pose = this->model_->GetWorldPose();
+        ignition::math::Pose3d reference_pose = this->model_->GetWorldPose();
         if (this->reference_link_)
         {
           reference_pose = this->reference_link_->GetWorldPose();

--- a/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
@@ -65,7 +65,7 @@ void GazeboRosJointPoseTrajectory::Load(physics::ModelPtr _model,
   this->sdf = _sdf;
   this->world_ = this->model_->GetWorld();
 
-  // this->world_->GetPhysicsEngine()->SetGravity(math::Vector3(0, 0, 0));
+  // this->world_->Physics()->SetGravity(math::Vector3(0, 0, 0));
 
   // load parameters
   this->robot_namespace_ = "";
@@ -170,7 +170,7 @@ void GazeboRosJointPoseTrajectory::SetTrajectory(
       this->reference_link_name_ != "map")
   {
     physics::EntityPtr ent =
-      this->world_->GetEntity(this->reference_link_name_);
+      this->world_->EntityByName(this->reference_link_name_);
     if (ent)
       this->reference_link_ = boost::dynamic_pointer_cast<physics::Link>(ent);
     if (!this->reference_link_)
@@ -221,8 +221,8 @@ void GazeboRosJointPoseTrajectory::SetTrajectory(
 
   if (this->disable_physics_updates_)
   {
-    this->physics_engine_enabled_ = this->world_->GetEnablePhysicsEngine();
-    this->world_->EnablePhysicsEngine(false);
+    this->physics_engine_enabled_ = this->world_->PhysicsEnabled();
+    this->world_->SetPhysicsEnabled(false);
   }
 }
 
@@ -294,8 +294,8 @@ bool GazeboRosJointPoseTrajectory::SetTrajectory(
   this->disable_physics_updates_ = req.disable_physics_updates;
   if (this->disable_physics_updates_)
   {
-    this->physics_engine_enabled_ = this->world_->GetEnablePhysicsEngine();
-    this->world_->EnablePhysicsEngine(false);
+    this->physics_engine_enabled_ = this->world_->PhysicsEnabled();
+    this->world_->SetPhysicsEnabled(false);
   }
 
   return true;
@@ -383,7 +383,7 @@ void GazeboRosJointPoseTrajectory::UpdateStates()
         this->reference_link_.reset();
         this->has_trajectory_ = false;
         if (this->disable_physics_updates_)
-          this->world_->EnablePhysicsEngine(this->physics_engine_enabled_);
+          this->world_->SetPhysicsEnabled(this->physics_engine_enabled_);
       }
     }
   }

--- a/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
@@ -142,7 +142,7 @@ void GazeboRosJointPoseTrajectory::LoadThread()
   }
 #endif
 
-  this->last_time_ = this->world_->GetSimTime();
+  this->last_time_ = this->world_->SimTime();
 
   // start custom queue for joint trajectory plugin ros topics
   this->callback_queue_thread_ =
@@ -210,7 +210,7 @@ void GazeboRosJointPoseTrajectory::SetTrajectory(
   // trajectory start time
   this->trajectory_start = gazebo::common::Time(trajectory->header.stamp.sec,
                                                 trajectory->header.stamp.nsec);
-  common::Time cur_time = this->world_->GetSimTime();
+  common::Time cur_time = this->world_->SimTime();
   if (this->trajectory_start < cur_time)
     this->trajectory_start = cur_time;
 
@@ -309,7 +309,7 @@ void GazeboRosJointPoseTrajectory::UpdateStates()
   boost::mutex::scoped_lock lock(this->update_mutex);
   if (this->has_trajectory_)
   {
-    common::Time cur_time = this->world_->GetSimTime();
+    common::Time cur_time = this->world_->SimTime();
     // roll out trajectory via set model configuration
     // gzerr << "i[" << trajectory_index  << "] time "
     //       << trajectory_start << " now: " << cur_time << " : "<< "\n";
@@ -324,10 +324,10 @@ void GazeboRosJointPoseTrajectory::UpdateStates()
           cur_time.Double(), this->trajectory_index, this->points_.size());
 
         // get reference link pose before updates
-        ignition::math::Pose3d reference_pose = this->model_->GetWorldPose();
+        ignition::math::Pose3d reference_pose = this->model_->WorldPose();
         if (this->reference_link_)
         {
-          reference_pose = this->reference_link_->GetWorldPose();
+          reference_pose = this->reference_link_->WorldPose();
         }
 
         // trajectory roll-out based on time:

--- a/gazebo_plugins/src/gazebo_ros_joint_state_publisher.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_state_publisher.cpp
@@ -124,7 +124,7 @@ void GazeboRosJointStatePublisher::publishJointStates() {
 
     for ( int i = 0; i < joints_.size(); i++ ) {
         physics::JointPtr joint = joints_[i];
-        math::Angle angle = joint->GetAngle ( 0 );
+        ignition::math::Angle angle = joint->GetAngle ( 0 );
         joint_state_.name[i] = joint->GetName();
         joint_state_.position[i] = angle.Radian () ;
     }

--- a/gazebo_plugins/src/gazebo_ros_joint_state_publisher.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_state_publisher.cpp
@@ -78,7 +78,7 @@ void GazeboRosJointStatePublisher::Load ( physics::ModelPtr _parent, sdf::Elemen
     } else {
         this->update_period_ = 0.0;
     }
-    last_update_time_ = this->world_->GetSimTime();
+    last_update_time_ = this->world_->SimTime();
 
     for ( unsigned int i = 0; i< joint_names_.size(); i++ ) {
         physics::JointPtr joint = this->parent_->GetJoint(joint_names_[i]);
@@ -94,7 +94,7 @@ void GazeboRosJointStatePublisher::Load ( physics::ModelPtr _parent, sdf::Elemen
     tf_prefix_ = tf::getPrefixParam ( *rosnode_ );
     joint_state_publisher_ = rosnode_->advertise<sensor_msgs::JointState> ( "joint_states",1000 );
 
-    last_update_time_ = this->world_->GetSimTime();
+    last_update_time_ = this->world_->SimTime();
     // Listen to the update event. This event is broadcast every
     // simulation iteration.
     this->updateConnection = event::Events::ConnectWorldUpdateBegin (
@@ -103,7 +103,7 @@ void GazeboRosJointStatePublisher::Load ( physics::ModelPtr _parent, sdf::Elemen
 
 void GazeboRosJointStatePublisher::OnUpdate ( const common::UpdateInfo & _info ) {
     // Apply a small linear velocity to the model.
-    common::Time current_time = this->world_->GetSimTime();
+    common::Time current_time = this->world_->SimTime();
     double seconds_since_last_update = ( current_time - last_update_time_ ).Double();
     if ( seconds_since_last_update > update_period_ ) {
 
@@ -124,7 +124,7 @@ void GazeboRosJointStatePublisher::publishJointStates() {
 
     for ( int i = 0; i < joints_.size(); i++ ) {
         physics::JointPtr joint = joints_[i];
-        ignition::math::Angle angle = joint->GetAngle ( 0 );
+        ignition::math::Angle angle = joint->Position ( 0 );
         joint_state_.name[i] = joint->GetName();
         joint_state_.position[i] = angle.Radian () ;
     }

--- a/gazebo_plugins/src/gazebo_ros_joint_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_trajectory.cpp
@@ -144,7 +144,7 @@ void GazeboRosJointTrajectory::LoadThread()
   }
 #endif
 
-  this->last_time_ = this->world_->GetSimTime();
+  this->last_time_ = this->world_->SimTime();
 
   // start custom queue for joint trajectory plugin ros topics
   this->callback_queue_thread_ =
@@ -212,7 +212,7 @@ void GazeboRosJointTrajectory::SetTrajectory(
   // trajectory start time
   this->trajectory_start = gazebo::common::Time(trajectory->header.stamp.sec,
                                                 trajectory->header.stamp.nsec);
-  common::Time cur_time = this->world_->GetSimTime();
+  common::Time cur_time = this->world_->SimTime();
   if (this->trajectory_start < cur_time)
     this->trajectory_start = cur_time;
 
@@ -311,7 +311,7 @@ void GazeboRosJointTrajectory::UpdateStates()
   boost::mutex::scoped_lock lock(this->update_mutex);
   if (this->has_trajectory_)
   {
-    common::Time cur_time = this->world_->GetSimTime();
+    common::Time cur_time = this->world_->SimTime();
     // roll out trajectory via set model configuration
     // gzerr << "i[" << trajectory_index  << "] time "
     //       << trajectory_start << " now: " << cur_time << " : "<< "\n";
@@ -326,10 +326,10 @@ void GazeboRosJointTrajectory::UpdateStates()
           cur_time.Double(), this->trajectory_index, this->points_.size());
 
         // get reference link pose before updates
-        ignition::math::Pose3d reference_pose = this->model_->GetWorldPose();
+        ignition::math::Pose3d reference_pose = this->model_->WorldPose();
         if (this->reference_link_)
         {
-          reference_pose = this->reference_link_->GetWorldPose();
+          reference_pose = this->reference_link_->WorldPose();
         }
 
         // trajectory roll-out based on time:

--- a/gazebo_plugins/src/gazebo_ros_joint_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_trajectory.cpp
@@ -48,7 +48,6 @@ ROS_DEPRECATED GazeboRosJointTrajectory::GazeboRosJointTrajectory()  // replaced
 // Destructor
 GazeboRosJointTrajectory::~GazeboRosJointTrajectory()
 {
-  event::Events::DisconnectWorldUpdateBegin(this->update_connection_);
   // Finalize the controller
   this->rosnode_->shutdown();
   this->queue_.clear();

--- a/gazebo_plugins/src/gazebo_ros_joint_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_trajectory.cpp
@@ -66,7 +66,7 @@ void GazeboRosJointTrajectory::Load(physics::ModelPtr _model,
   this->sdf = _sdf;
   this->world_ = this->model_->GetWorld();
 
-  // this->world_->GetPhysicsEngine()->SetGravity(math::Vector3(0, 0, 0));
+  // this->world_->Physics()->SetGravity(math::Vector3(0, 0, 0));
 
   // load parameters
   this->robot_namespace_ = "";
@@ -172,7 +172,7 @@ void GazeboRosJointTrajectory::SetTrajectory(
       this->reference_link_name_ != "map")
   {
     physics::EntityPtr ent =
-      this->world_->GetEntity(this->reference_link_name_);
+      this->world_->EntityByName(this->reference_link_name_);
     if (ent)
       this->reference_link_ = boost::dynamic_pointer_cast<physics::Link>(ent);
     if (!this->reference_link_)
@@ -223,8 +223,8 @@ void GazeboRosJointTrajectory::SetTrajectory(
 
   if (this->disable_physics_updates_)
   {
-    this->physics_engine_enabled_ = this->world_->GetEnablePhysicsEngine();
-    this->world_->EnablePhysicsEngine(false);
+    this->physics_engine_enabled_ = this->world_->PhysicsEnabled();
+    this->world_->SetPhysicsEnabled(false);
   }
 }
 
@@ -296,8 +296,8 @@ bool GazeboRosJointTrajectory::SetTrajectory(
   this->disable_physics_updates_ = req.disable_physics_updates;
   if (this->disable_physics_updates_)
   {
-    this->physics_engine_enabled_ = this->world_->GetEnablePhysicsEngine();
-    this->world_->EnablePhysicsEngine(false);
+    this->physics_engine_enabled_ = this->world_->PhysicsEnabled();
+    this->world_->SetPhysicsEnabled(false);
   }
 
   return true;
@@ -385,7 +385,7 @@ void GazeboRosJointTrajectory::UpdateStates()
         this->reference_link_.reset();
         this->has_trajectory_ = false;
         if (this->disable_physics_updates_)
-          this->world_->EnablePhysicsEngine(this->physics_engine_enabled_);
+          this->world_->SetPhysicsEnabled(this->physics_engine_enabled_);
       }
     }
   }

--- a/gazebo_plugins/src/gazebo_ros_joint_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_trajectory.cpp
@@ -327,7 +327,7 @@ void GazeboRosJointTrajectory::UpdateStates()
           cur_time.Double(), this->trajectory_index, this->points_.size());
 
         // get reference link pose before updates
-        math::Pose reference_pose = this->model_->GetWorldPose();
+        ignition::math::Pose3d reference_pose = this->model_->GetWorldPose();
         if (this->reference_link_)
         {
           reference_pose = this->reference_link_->GetWorldPose();

--- a/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
+++ b/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
@@ -435,7 +435,7 @@ void GazeboRosOpenniKinect::PublishCameraInfo()
   if (this->depth_info_connect_count_ > 0)
   {
     this->sensor_update_time_ = this->parentSensor_->LastMeasurementTime();
-    common::Time cur_time = this->world_->GetSimTime();
+    common::Time cur_time = this->world_->SimTime();
     if (this->sensor_update_time_ - this->last_depth_image_camera_info_update_time_ >= this->update_period_)
     {
       this->PublishCameraInfo(this->depth_image_camera_info_pub_);

--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -149,10 +149,10 @@ void GazeboRosP3D::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf)
       this->rosnode_->advertise<nav_msgs::Odometry>(this->topic_name_, 1);
   }
 
-  this->last_time_ = this->world_->GetSimTime();
+  this->last_time_ = this->world_->SimTime();
   // initialize body
-  this->last_vpos_ = this->link_->GetWorldLinearVel();
-  this->last_veul_ = this->link_->GetWorldAngularVel();
+  this->last_vpos_ = this->link_->WorldLinearVel();
+  this->last_veul_ = this->link_->WorldAngularVel();
   this->apos_ = 0;
   this->aeul_ = 0;
 
@@ -178,8 +178,8 @@ void GazeboRosP3D::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf)
     ROS_DEBUG_NAMED("p3d", "got body %s", this->reference_link_->GetName().c_str());
     this->frame_apos_ = 0;
     this->frame_aeul_ = 0;
-    this->last_frame_vpos_ = this->reference_link_->GetWorldLinearVel();
-    this->last_frame_veul_ = this->reference_link_->GetWorldAngularVel();
+    this->last_frame_vpos_ = this->reference_link_->WorldLinearVel();
+    this->last_frame_veul_ = this->reference_link_->WorldAngularVel();
   }
 
 
@@ -201,7 +201,7 @@ void GazeboRosP3D::UpdateChild()
   if (!this->link_)
     return;
 
-  common::Time cur_time = this->world_->GetSimTime();
+  common::Time cur_time = this->world_->SimTime();
 
   // rate control
   if (this->update_rate_ > 0 &&
@@ -230,23 +230,23 @@ void GazeboRosP3D::UpdateChild()
         ignition::math::Vector3d frame_veul;
 
         // get inertial Rates
-        ignition::math::Vector3d vpos = this->link_->GetWorldLinearVel();
-        ignition::math::Vector3d veul = this->link_->GetWorldAngularVel();
+        ignition::math::Vector3d vpos = this->link_->WorldLinearVel();
+        ignition::math::Vector3d veul = this->link_->WorldAngularVel();
 
         // Get Pose/Orientation
-        pose = this->link_->GetWorldPose();
+        pose = this->link_->WorldPose();
 
         // Apply Reference Frame
         if (this->reference_link_)
         {
           // convert to relative pose
-          frame_pose = this->reference_link_->GetWorldPose();
+          frame_pose = this->reference_link_->WorldPose();
           pose.Pos() = pose.Pos() - frame_pose.Pos();
           pose.Pos() = frame_pose.Rot().RotateVectorReverse(pose.Pos());
           pose.Rot() *= frame_pose.Rot().Inverse();
           // convert to relative rates
-          frame_vpos = this->reference_link_->GetWorldLinearVel();
-          frame_veul = this->reference_link_->GetWorldAngularVel();
+          frame_vpos = this->reference_link_->WorldLinearVel();
+          frame_veul = this->reference_link_->WorldAngularVel();
           vpos = frame_pose.Rot().RotateVector(vpos - frame_vpos);
           veul = frame_pose.Rot().RotateVector(veul - frame_veul);
         }

--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -36,7 +36,6 @@ GazeboRosP3D::GazeboRosP3D()
 // Destructor
 GazeboRosP3D::~GazeboRosP3D()
 {
-  event::Events::DisconnectWorldUpdateBegin(this->update_connection_);
   // Finalize the controller
   this->rosnode_->shutdown();
   this->p3d_queue_.clear();

--- a/gazebo_plugins/src/gazebo_ros_planar_move.cpp
+++ b/gazebo_plugins/src/gazebo_ros_planar_move.cpp
@@ -112,8 +112,8 @@ namespace gazebo
       odometry_rate_ = sdf->GetElement("odometryRate")->Get<double>();
     }
 
-    last_odom_publish_time_ = parent_->GetWorld()->GetSimTime();
-    last_odom_pose_ = parent_->GetWorldPose();
+    last_odom_publish_time_ = parent_->GetWorld()->SimTime();
+    last_odom_pose_ = parent_->WorldPose();
     x_ = 0;
     y_ = 0;
     rot_ = 0;
@@ -160,7 +160,7 @@ namespace gazebo
   void GazeboRosPlanarMove::UpdateChild()
   {
     boost::mutex::scoped_lock scoped_lock(lock);
-    ignition::math::Pose3d pose = parent_->GetWorldPose();
+    ignition::math::Pose3d pose = parent_->WorldPose();
     float yaw = pose.Rot().Yaw();
     parent_->SetLinearVel(ignition::math::Vector3d(
           x_ * cosf(yaw) - y_ * sinf(yaw),
@@ -168,7 +168,7 @@ namespace gazebo
           0.0));
     parent_->SetAngularVel(ignition::math::Vector3d(0.0, 0.0, rot_));
     if (odometry_rate_ > 0.0) {
-      common::Time current_time = parent_->GetWorld()->GetSimTime();
+      common::Time current_time = parent_->GetWorld()->SimTime();
       double seconds_since_last_update =
         (current_time - last_odom_publish_time_).Double();
       if (seconds_since_last_update > (1.0 / odometry_rate_)) {
@@ -214,7 +214,7 @@ namespace gazebo
       tf::resolve(tf_prefix_, robot_base_frame_);
 
     // getting data for base_footprint to odom transform
-    ignition::math::Pose3d pose = this->parent_->GetWorldPose();
+    ignition::math::Pose3d pose = this->parent_->WorldPose();
 
     tf::Quaternion qt(pose.Rot().X(), pose.Rot().Y(), pose.Rot().Z(), pose.Rot().W());
     tf::Vector3 vt(pose.Pos().X(), pose.Pos().Y(), pose.Pos().Z());

--- a/gazebo_plugins/src/gazebo_ros_planar_move.cpp
+++ b/gazebo_plugins/src/gazebo_ros_planar_move.cpp
@@ -160,13 +160,13 @@ namespace gazebo
   void GazeboRosPlanarMove::UpdateChild()
   {
     boost::mutex::scoped_lock scoped_lock(lock);
-    math::Pose pose = parent_->GetWorldPose();
-    float yaw = pose.rot.GetYaw();
-    parent_->SetLinearVel(math::Vector3(
+    ignition::math::Pose3d pose = parent_->GetWorldPose();
+    float yaw = pose.Rot().Yaw();
+    parent_->SetLinearVel(ignition::math::Vector3d(
           x_ * cosf(yaw) - y_ * sinf(yaw),
           y_ * cosf(yaw) + x_ * sinf(yaw),
-          0));
-    parent_->SetAngularVel(math::Vector3(0, 0, rot_));
+          0.0));
+    parent_->SetAngularVel(ignition::math::Vector3d(0.0, 0.0, rot_));
     if (odometry_rate_ > 0.0) {
       common::Time current_time = parent_->GetWorld()->GetSimTime();
       double seconds_since_last_update =
@@ -214,10 +214,10 @@ namespace gazebo
       tf::resolve(tf_prefix_, robot_base_frame_);
 
     // getting data for base_footprint to odom transform
-    math::Pose pose = this->parent_->GetWorldPose();
+    ignition::math::Pose3d pose = this->parent_->GetWorldPose();
 
-    tf::Quaternion qt(pose.rot.x, pose.rot.y, pose.rot.z, pose.rot.w);
-    tf::Vector3 vt(pose.pos.x, pose.pos.y, pose.pos.z);
+    tf::Quaternion qt(pose.Rot().X(), pose.Rot().Y(), pose.Rot().Z(), pose.Rot().W());
+    tf::Vector3 vt(pose.Pos().X(), pose.Pos().Y(), pose.Pos().Z());
 
     tf::Transform base_footprint_to_odom(qt, vt);
     transform_broadcaster_->sendTransform(
@@ -225,13 +225,13 @@ namespace gazebo
             base_footprint_frame));
 
     // publish odom topic
-    odom_.pose.pose.position.x = pose.pos.x;
-    odom_.pose.pose.position.y = pose.pos.y;
+    odom_.pose.pose.position.x = pose.Pos().X();
+    odom_.pose.pose.position.y = pose.Pos().Y();
 
-    odom_.pose.pose.orientation.x = pose.rot.x;
-    odom_.pose.pose.orientation.y = pose.rot.y;
-    odom_.pose.pose.orientation.z = pose.rot.z;
-    odom_.pose.pose.orientation.w = pose.rot.w;
+    odom_.pose.pose.orientation.x = pose.Rot().X();
+    odom_.pose.pose.orientation.y = pose.Rot().Y();
+    odom_.pose.pose.orientation.z = pose.Rot().Z();
+    odom_.pose.pose.orientation.w = pose.Rot().W();
     odom_.pose.covariance[0] = 0.00001;
     odom_.pose.covariance[7] = 0.00001;
     odom_.pose.covariance[14] = 1000000000000.0;
@@ -240,9 +240,9 @@ namespace gazebo
     odom_.pose.covariance[35] = 0.001;
 
     // get velocity in /odom frame
-    math::Vector3 linear;
-    linear.x = (pose.pos.x - last_odom_pose_.pos.x) / step_time;
-    linear.y = (pose.pos.y - last_odom_pose_.pos.y) / step_time;
+    ignition::math::Vector3d linear;
+    linear.X() = (pose.Pos().X() - last_odom_pose_.Pos().X()) / step_time;
+    linear.Y() = (pose.Pos().Y() - last_odom_pose_.Pos().Y()) / step_time;
     if (rot_ > M_PI / step_time)
     {
       // we cannot calculate the angular velocity correctly
@@ -250,8 +250,8 @@ namespace gazebo
     }
     else
     {
-      float last_yaw = last_odom_pose_.rot.GetYaw();
-      float current_yaw = pose.rot.GetYaw();
+      float last_yaw = last_odom_pose_.Rot().Yaw();
+      float current_yaw = pose.Rot().Yaw();
       while (current_yaw < last_yaw - M_PI) current_yaw += 2 * M_PI;
       while (current_yaw > last_yaw + M_PI) current_yaw -= 2 * M_PI;
       float angular_diff = current_yaw - last_yaw;
@@ -260,9 +260,9 @@ namespace gazebo
     last_odom_pose_ = pose;
 
     // convert velocity to child_frame_id (aka base_footprint)
-    float yaw = pose.rot.GetYaw();
-    odom_.twist.twist.linear.x = cosf(yaw) * linear.x + sinf(yaw) * linear.y;
-    odom_.twist.twist.linear.y = cosf(yaw) * linear.y - sinf(yaw) * linear.x;
+    float yaw = pose.Rot().Yaw();
+    odom_.twist.twist.linear.x = cosf(yaw) * linear.X() + sinf(yaw) * linear.Y();
+    odom_.twist.twist.linear.y = cosf(yaw) * linear.Y() - sinf(yaw) * linear.X();
 
     odom_.header.stamp = current_time;
     odom_.header.frame_id = odom_frame;

--- a/gazebo_plugins/src/gazebo_ros_projector.cpp
+++ b/gazebo_plugins/src/gazebo_ros_projector.cpp
@@ -82,7 +82,7 @@ void GazeboRosProjector::Load( physics::ModelPtr _parent, sdf::ElementPtr _sdf )
   // Create a new transport node for talking to the projector
   this->node_.reset(new transport::Node());
   // Initialize the node with the world name
-  this->node_->Init(this->world_->GetName());
+  this->node_->Init(this->world_->Name());
   // Setting projector topic
   std::string name = std::string("~/") + _parent->GetName() + "/" +
                       _sdf->Get<std::string>("projector");

--- a/gazebo_plugins/src/gazebo_ros_prosilica.cpp
+++ b/gazebo_plugins/src/gazebo_ros_prosilica.cpp
@@ -333,7 +333,7 @@ void GazeboRosProsilica::OnStats( const boost::shared_ptr<msgs::WorldStatistics 
 {
   this->simTime  = msgs::Convert( _msg->sim_time() );
 
-  math::Pose pose;
+  ignition::math::Pose3d pose;
   pose.pos.x = 0.5*sin(0.01*this->simTime.Double());
   gzdbg << "plugin simTime [" << this->simTime.Double() << "] update pose [" << pose.pos.x << "]\n";
 }

--- a/gazebo_plugins/src/gazebo_ros_range.cpp
+++ b/gazebo_plugins/src/gazebo_ros_range.cpp
@@ -243,7 +243,7 @@ void GazeboRosRange::OnNewLaserScans()
 {
   if (this->topic_name_ != "")
   {
-    common::Time cur_time = this->world_->GetSimTime();
+    common::Time cur_time = this->world_->SimTime();
     if (cur_time - this->last_update_time_ >= this->update_period_)
     {
       common::Time sensor_update_time =

--- a/gazebo_plugins/src/gazebo_ros_skid_steer_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_skid_steer_drive.cpp
@@ -42,7 +42,7 @@
 
 #include <gazebo_plugins/gazebo_ros_skid_steer_drive.h>
 
-#include <gazebo/math/gzmath.hh>
+#include <ignition/math.hh>
 #include <sdf/sdf.hh>
 
 #include <ros/ros.h>
@@ -406,8 +406,8 @@ namespace gazebo {
     // getting data for base_footprint to odom transform
     ignition::math::Pose3d pose = this->parent->WorldPose();
 
-    tf::Quaternion qt(pose.rot.x, pose.rot.y, pose.rot.z, pose.rot.w);
-    tf::Vector3 vt(pose.pos.x, pose.pos.y, pose.pos.z);
+    tf::Quaternion qt(pose.Rot().X(), pose.Rot().Y(), pose.Rot().Z(), pose.Rot().W());
+    tf::Vector3 vt(pose.Pos().X(), pose.Pos().Y(), pose.Pos().Z());
 
     tf::Transform base_footprint_to_odom(qt, vt);
     if (this->broadcast_tf_) {
@@ -419,13 +419,13 @@ namespace gazebo {
     }
 
     // publish odom topic
-    odom_.pose.pose.position.x = pose.pos.x;
-    odom_.pose.pose.position.y = pose.pos.y;
+    odom_.pose.pose.position.x = pose.Pos().X();
+    odom_.pose.pose.position.y = pose.Pos().Y();
 
-    odom_.pose.pose.orientation.x = pose.rot.x;
-    odom_.pose.pose.orientation.y = pose.rot.y;
-    odom_.pose.pose.orientation.z = pose.rot.z;
-    odom_.pose.pose.orientation.w = pose.rot.w;
+    odom_.pose.pose.orientation.x = pose.Rot().X();
+    odom_.pose.pose.orientation.y = pose.Rot().Y();
+    odom_.pose.pose.orientation.z = pose.Rot().Z();
+    odom_.pose.pose.orientation.w = pose.Rot().W();
     odom_.pose.covariance[0] = this->covariance_x_;
     odom_.pose.covariance[7] = this->covariance_y_;
     odom_.pose.covariance[14] = 1000000000000.0;
@@ -436,12 +436,12 @@ namespace gazebo {
     // get velocity in /odom frame
     ignition::math::Vector3d linear;
     linear = this->parent->WorldLinearVel();
-    odom_.twist.twist.angular.z = this->parent->WorldAngularVel().z;
+    odom_.twist.twist.angular.z = this->parent->WorldAngularVel().Z();
 
     // convert velocity to child_frame_id (aka base_footprint)
-    float yaw = pose.rot.GetYaw();
-    odom_.twist.twist.linear.x = cosf(yaw) * linear.x + sinf(yaw) * linear.y;
-    odom_.twist.twist.linear.y = cosf(yaw) * linear.y - sinf(yaw) * linear.x;
+    float yaw = pose.Rot().Yaw();
+    odom_.twist.twist.linear.x = cosf(yaw) * linear.X() + sinf(yaw) * linear.Y();
+    odom_.twist.twist.linear.y = cosf(yaw) * linear.Y() - sinf(yaw) * linear.X();
     odom_.twist.covariance[0] = this->covariance_x_;
     odom_.twist.covariance[7] = this->covariance_y_;
     odom_.twist.covariance[14] = 1000000000000.0;

--- a/gazebo_plugins/src/gazebo_ros_skid_steer_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_skid_steer_drive.cpp
@@ -231,7 +231,7 @@ namespace gazebo {
     } else {
       this->update_period_ = 0.0;
     }
-    last_update_time_ = this->world->GetSimTime();
+    last_update_time_ = this->world->SimTime();
 
     // Initialize velocity stuff
     wheel_speed_[RIGHT_FRONT] = 0;
@@ -330,7 +330,7 @@ namespace gazebo {
 
   // Update the controller
   void GazeboRosSkidSteerDrive::UpdateChild() {
-    common::Time current_time = this->world->GetSimTime();
+    common::Time current_time = this->world->SimTime();
     double seconds_since_last_update =
       (current_time - last_update_time_).Double();
     if (seconds_since_last_update > update_period_) {
@@ -404,7 +404,7 @@ namespace gazebo {
 
     // TODO create some non-perfect odometry!
     // getting data for base_footprint to odom transform
-    ignition::math::Pose3d pose = this->parent->GetWorldPose();
+    ignition::math::Pose3d pose = this->parent->WorldPose();
 
     tf::Quaternion qt(pose.rot.x, pose.rot.y, pose.rot.z, pose.rot.w);
     tf::Vector3 vt(pose.pos.x, pose.pos.y, pose.pos.z);
@@ -435,8 +435,8 @@ namespace gazebo {
 
     // get velocity in /odom frame
     ignition::math::Vector3d linear;
-    linear = this->parent->GetWorldLinearVel();
-    odom_.twist.twist.angular.z = this->parent->GetWorldAngularVel().z;
+    linear = this->parent->WorldLinearVel();
+    odom_.twist.twist.angular.z = this->parent->WorldAngularVel().z;
 
     // convert velocity to child_frame_id (aka base_footprint)
     float yaw = pose.rot.GetYaw();

--- a/gazebo_plugins/src/gazebo_ros_skid_steer_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_skid_steer_drive.cpp
@@ -404,7 +404,7 @@ namespace gazebo {
 
     // TODO create some non-perfect odometry!
     // getting data for base_footprint to odom transform
-    math::Pose pose = this->parent->GetWorldPose();
+    ignition::math::Pose3d pose = this->parent->GetWorldPose();
 
     tf::Quaternion qt(pose.rot.x, pose.rot.y, pose.rot.z, pose.rot.w);
     tf::Vector3 vt(pose.pos.x, pose.pos.y, pose.pos.z);
@@ -434,7 +434,7 @@ namespace gazebo {
     odom_.pose.covariance[35] = this->covariance_yaw_;
 
     // get velocity in /odom frame
-    math::Vector3 linear;
+    ignition::math::Vector3d linear;
     linear = this->parent->GetWorldLinearVel();
     odom_.twist.twist.angular.z = this->parent->GetWorldAngularVel().z;
 

--- a/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
@@ -189,7 +189,7 @@ void GazeboRosTricycleDrive::publishWheelTF()
         std::string frame = gazebo_ros_->resolveTF ( joints[i]->GetName() );
         std::string parent_frame = gazebo_ros_->resolveTF ( joints[i]->GetParent()->GetName() );
 
-        math::Pose pose = joints[i]->GetChild()->GetRelativePose();
+        ignition::math::Pose3d pose = joints[i]->GetChild()->GetRelativePose();
 
         tf::Quaternion qt ( pose.rot.x, pose.rot.y, pose.rot.z, pose.rot.w );
         tf::Vector3 vt ( pose.pos.x, pose.pos.y, pose.pos.z );
@@ -312,7 +312,7 @@ void GazeboRosTricycleDrive::motorController ( double target_speed, double targe
 #if GAZEBO_MAJOR_VERSION >= 4
       joint_steering_->SetPosition(0, applied_angle);
 #else
-      joint_steering_->SetAngle(0, math::Angle(applied_angle));
+      joint_steering_->SetAngle(0, ignition::math::Angle(applied_angle));
 #endif
     }
     //ROS_INFO_NAMED("tricycle_drive", "target: [%3.2f, %3.2f], current: [%3.2f, %3.2f], applied: [%3.2f, %3.2f/%3.2f] ",
@@ -409,7 +409,7 @@ void GazeboRosTricycleDrive::publishOdometry ( double step_time )
     }
     if ( odom_source_ == WORLD ) {
         // getting data form gazebo world
-        math::Pose pose = parent->GetWorldPose();
+        ignition::math::Pose3d pose = parent->GetWorldPose();
         qt = tf::Quaternion ( pose.rot.x, pose.rot.y, pose.rot.z, pose.rot.w );
         vt = tf::Vector3 ( pose.pos.x, pose.pos.y, pose.pos.z );
 
@@ -423,7 +423,7 @@ void GazeboRosTricycleDrive::publishOdometry ( double step_time )
         odom_.pose.pose.orientation.w = qt.w();
 
         // get velocity in /odom frame
-        math::Vector3 linear;
+        ignition::math::Vector3d linear;
         linear = parent->GetWorldLinearVel();
         odom_.twist.twist.angular.z = parent->GetWorldAngularVel().z;
 

--- a/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
@@ -120,7 +120,7 @@ void GazeboRosTricycleDrive::Load ( physics::ModelPtr _parent, sdf::ElementPtr _
     // Initialize update rate stuff
     if ( this->update_rate_ > 0.0 ) this->update_period_ = 1.0 / this->update_rate_;
     else this->update_period_ = 0.0;
-    last_actuator_update_ = parent->GetWorld()->GetSimTime();
+    last_actuator_update_ = parent->GetWorld()->SimTime();
 
     // Initialize velocity stuff
     alive_ = true;
@@ -170,7 +170,7 @@ void GazeboRosTricycleDrive::publishWheelJointState()
     joint_state_.effort.resize ( joints.size() );
     for ( std::size_t i = 0; i < joints.size(); i++ ) {
         joint_state_.name[i] = joints[i]->GetName();
-        joint_state_.position[i] = joints[i]->GetAngle ( 0 ).Radian();
+        joint_state_.position[i] = joints[i]->Position ( 0 ).Radian();
         joint_state_.velocity[i] = joints[i]->GetVelocity ( 0 );
         joint_state_.effort[i] = joints[i]->GetForce ( 0 );
     }
@@ -189,7 +189,7 @@ void GazeboRosTricycleDrive::publishWheelTF()
         std::string frame = gazebo_ros_->resolveTF ( joints[i]->GetName() );
         std::string parent_frame = gazebo_ros_->resolveTF ( joints[i]->GetParent()->GetName() );
 
-        ignition::math::Pose3d pose = joints[i]->GetChild()->GetRelativePose();
+        ignition::math::Pose3d pose = joints[i]->GetChild()->RelativePose();
 
         tf::Quaternion qt ( pose.rot.x, pose.rot.y, pose.rot.z, pose.rot.w );
         tf::Vector3 vt ( pose.pos.x, pose.pos.y, pose.pos.z );
@@ -203,7 +203,7 @@ void GazeboRosTricycleDrive::publishWheelTF()
 void GazeboRosTricycleDrive::UpdateChild()
 {
     if ( odom_source_ == ENCODER ) UpdateOdometryEncoder();
-    common::Time current_time = parent->GetWorld()->GetSimTime();
+    common::Time current_time = parent->GetWorld()->SimTime();
     double seconds_since_last_update = ( current_time - last_actuator_update_ ).Double();
     if ( seconds_since_last_update > update_period_ ) {
 
@@ -254,7 +254,7 @@ void GazeboRosTricycleDrive::motorController ( double target_speed, double targe
     joint_wheel_actuated_->SetVelocity ( 0, applied_speed );
 #endif
 
-    double current_angle = joint_steering_->GetAngle ( 0 ).Radian();
+    double current_angle = joint_steering_->Position ( 0 ).Radian();
 
     // truncate target angle
     if (target_angle > +M_PI / 2.0)
@@ -349,7 +349,7 @@ void GazeboRosTricycleDrive::UpdateOdometryEncoder()
 {
     double vl = joint_wheel_encoder_left_->GetVelocity ( 0 );
     double vr = joint_wheel_encoder_right_->GetVelocity ( 0 );
-    common::Time current_time = parent->GetWorld()->GetSimTime();
+    common::Time current_time = parent->GetWorld()->SimTime();
     double seconds_since_last_update = ( current_time - last_odom_update_ ).Double();
     last_odom_update_ = current_time;
 
@@ -409,7 +409,7 @@ void GazeboRosTricycleDrive::publishOdometry ( double step_time )
     }
     if ( odom_source_ == WORLD ) {
         // getting data form gazebo world
-        ignition::math::Pose3d pose = parent->GetWorldPose();
+        ignition::math::Pose3d pose = parent->WorldPose();
         qt = tf::Quaternion ( pose.rot.x, pose.rot.y, pose.rot.z, pose.rot.w );
         vt = tf::Vector3 ( pose.pos.x, pose.pos.y, pose.pos.z );
 
@@ -424,8 +424,8 @@ void GazeboRosTricycleDrive::publishOdometry ( double step_time )
 
         // get velocity in /odom frame
         ignition::math::Vector3d linear;
-        linear = parent->GetWorldLinearVel();
-        odom_.twist.twist.angular.z = parent->GetWorldAngularVel().z;
+        linear = parent->WorldLinearVel();
+        odom_.twist.twist.angular.z = parent->WorldAngularVel().z;
 
         // convert velocity to child_frame_id (aka base_footprint)
         float yaw = pose.rot.GetYaw();

--- a/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
@@ -44,7 +44,7 @@
 
 #include <gazebo_plugins/gazebo_ros_tricycle_drive.h>
 
-#include <gazebo/math/gzmath.hh>
+#include <ignition/math.hh>
 #include <sdf/sdf.hh>
 
 #include <ros/ros.h>
@@ -170,7 +170,7 @@ void GazeboRosTricycleDrive::publishWheelJointState()
     joint_state_.effort.resize ( joints.size() );
     for ( std::size_t i = 0; i < joints.size(); i++ ) {
         joint_state_.name[i] = joints[i]->GetName();
-        joint_state_.position[i] = joints[i]->Position ( 0 ).Radian();
+        joint_state_.position[i] = joints[i]->Position ( 0 );
         joint_state_.velocity[i] = joints[i]->GetVelocity ( 0 );
         joint_state_.effort[i] = joints[i]->GetForce ( 0 );
     }
@@ -191,8 +191,8 @@ void GazeboRosTricycleDrive::publishWheelTF()
 
         ignition::math::Pose3d pose = joints[i]->GetChild()->RelativePose();
 
-        tf::Quaternion qt ( pose.rot.x, pose.rot.y, pose.rot.z, pose.rot.w );
-        tf::Vector3 vt ( pose.pos.x, pose.pos.y, pose.pos.z );
+        tf::Quaternion qt ( pose.Rot().X(), pose.Rot().Y(), pose.Rot().Z(), pose.Rot().W() );
+        tf::Vector3 vt ( pose.Pos().X(), pose.Pos().Y(), pose.Pos().Z() );
 
         tf::Transform transform ( qt, vt );
         transform_broadcaster_->sendTransform ( tf::StampedTransform ( transform, current_time, parent_frame, frame ) );
@@ -254,7 +254,7 @@ void GazeboRosTricycleDrive::motorController ( double target_speed, double targe
     joint_wheel_actuated_->SetVelocity ( 0, applied_speed );
 #endif
 
-    double current_angle = joint_steering_->Position ( 0 ).Radian();
+    double current_angle = joint_steering_->Position ( 0 );
 
     // truncate target angle
     if (target_angle > +M_PI / 2.0)
@@ -410,8 +410,8 @@ void GazeboRosTricycleDrive::publishOdometry ( double step_time )
     if ( odom_source_ == WORLD ) {
         // getting data form gazebo world
         ignition::math::Pose3d pose = parent->WorldPose();
-        qt = tf::Quaternion ( pose.rot.x, pose.rot.y, pose.rot.z, pose.rot.w );
-        vt = tf::Vector3 ( pose.pos.x, pose.pos.y, pose.pos.z );
+        qt = tf::Quaternion ( pose.Rot().X(), pose.Rot().Y(), pose.Rot().Z(), pose.Rot().W() );
+        vt = tf::Vector3 ( pose.Pos().X(), pose.Pos().Y(), pose.Pos().Z() );
 
         odom_.pose.pose.position.x = vt.x();
         odom_.pose.pose.position.y = vt.y();
@@ -425,12 +425,12 @@ void GazeboRosTricycleDrive::publishOdometry ( double step_time )
         // get velocity in /odom frame
         ignition::math::Vector3d linear;
         linear = parent->WorldLinearVel();
-        odom_.twist.twist.angular.z = parent->WorldAngularVel().z;
+        odom_.twist.twist.angular.z = parent->WorldAngularVel().Z();
 
         // convert velocity to child_frame_id (aka base_footprint)
-        float yaw = pose.rot.GetYaw();
-        odom_.twist.twist.linear.x = cosf ( yaw ) * linear.x + sinf ( yaw ) * linear.y;
-        odom_.twist.twist.linear.y = cosf ( yaw ) * linear.y - sinf ( yaw ) * linear.x;
+        float yaw = pose.Rot().Yaw();
+        odom_.twist.twist.linear.x = cosf ( yaw ) * linear.X() + sinf ( yaw ) * linear.Y();
+        odom_.twist.twist.linear.y = cosf ( yaw ) * linear.Y() - sinf ( yaw ) * linear.X();
     }
 
     tf::Transform base_footprint_to_odom ( qt, vt );

--- a/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
@@ -179,7 +179,7 @@ void GazeboRosVacuumGripper::UpdateChild()
   }
   // apply force
   lock_.lock();
-  math::Pose parent_pose = link_->GetWorldPose();
+  ignition::math::Pose3d parent_pose = link_->GetWorldPose();
   physics::Model_V models = world_->GetModels();
   for (size_t i = 0; i < models.size(); i++) {
     if (models[i]->GetName() == link_->GetName() ||
@@ -189,25 +189,25 @@ void GazeboRosVacuumGripper::UpdateChild()
     }
     physics::Link_V links = models[i]->GetLinks();
     for (size_t j = 0; j < links.size(); j++) {
-      math::Pose link_pose = links[j]->GetWorldPose();
-      math::Pose diff = parent_pose - link_pose;
-      double norm = diff.pos.GetLength();
+      ignition::math::Pose3d link_pose = links[j]->GetWorldPose();
+      ignition::math::Pose3d diff = parent_pose - link_pose;
+      double norm = diff.Pos().GetLength();
       if (norm < 0.05) {
         links[j]->SetLinearAccel(link_->GetWorldLinearAccel());
         links[j]->SetAngularAccel(link_->GetWorldAngularAccel());
         links[j]->SetLinearVel(link_->GetWorldLinearVel());
         links[j]->SetAngularVel(link_->GetWorldAngularVel());
-        double norm_force = 1 / norm;
+        double norm_force = 1.0 / norm;
         if (norm < 0.01) {
           // apply friction like force
           // TODO(unknown): should apply friction actually
-          link_pose.Set(parent_pose.pos, link_pose.rot);
+          link_pose.Set(parent_pose.Pos(), link_pose.Rot());
           links[j]->SetWorldPose(link_pose);
         }
-        if (norm_force > 20) {
-          norm_force = 20;  // max_force
+        if (norm_force > 20.0) {
+          norm_force = 20.0;  // max_force
         }
-        math::Vector3 force = norm_force * diff.pos.Normalize();
+        ignition::math::Vector3d force = norm_force * diff.Pos().Normalize();
         links[j]->AddForce(force);
         grasping_msg.data = true;
       }

--- a/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
@@ -45,7 +45,6 @@ GazeboRosVacuumGripper::GazeboRosVacuumGripper()
 GazeboRosVacuumGripper::~GazeboRosVacuumGripper()
 {
   event::Events::DisconnectWorldUpdateBegin(update_connection_);
-
   // Custom Callback Queue
   queue_.clear();
   queue_.disable();

--- a/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
@@ -177,8 +177,8 @@ void GazeboRosVacuumGripper::UpdateChild()
   }
   // apply force
   lock_.lock();
-  ignition::math::Pose3d parent_pose = link_->GetWorldPose();
-  physics::Model_V models = world_->GetModels();
+  ignition::math::Pose3d parent_pose = link_->WorldPose();
+  physics::Model_V models = world_->Models();
   for (size_t i = 0; i < models.size(); i++) {
     if (models[i]->GetName() == link_->GetName() ||
         models[i]->GetName() == parent_->GetName())
@@ -187,14 +187,14 @@ void GazeboRosVacuumGripper::UpdateChild()
     }
     physics::Link_V links = models[i]->GetLinks();
     for (size_t j = 0; j < links.size(); j++) {
-      ignition::math::Pose3d link_pose = links[j]->GetWorldPose();
+      ignition::math::Pose3d link_pose = links[j]->WorldPose();
       ignition::math::Pose3d diff = parent_pose - link_pose;
-      double norm = diff.Pos().GetLength();
+      double norm = diff.Pos().Length();
       if (norm < 0.05) {
-        links[j]->SetLinearAccel(link_->GetWorldLinearAccel());
-        links[j]->SetAngularAccel(link_->GetWorldAngularAccel());
-        links[j]->SetLinearVel(link_->GetWorldLinearVel());
-        links[j]->SetAngularVel(link_->GetWorldAngularVel());
+        links[j]->SetLinearAccel(link_->WorldLinearAccel());
+        links[j]->SetAngularAccel(link_->WorldAngularAccel());
+        links[j]->SetLinearVel(link_->WorldLinearVel());
+        links[j]->SetAngularVel(link_->WorldAngularVel());
         double norm_force = 1.0 / norm;
         if (norm < 0.01) {
           // apply friction like force

--- a/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
@@ -44,7 +44,6 @@ GazeboRosVacuumGripper::GazeboRosVacuumGripper()
 // Destructor
 GazeboRosVacuumGripper::~GazeboRosVacuumGripper()
 {
-  event::Events::DisconnectWorldUpdateBegin(update_connection_);
   // Custom Callback Queue
   queue_.clear();
   queue_.disable();

--- a/gazebo_plugins/src/gazebo_ros_video.cpp
+++ b/gazebo_plugins/src/gazebo_ros_video.cpp
@@ -115,7 +115,6 @@ namespace gazebo
 
   // Destructor
   GazeboRosVideo::~GazeboRosVideo() {
-    event::Events::DisconnectWorldUpdateBegin(update_connection_);
     // Custom Callback Queue
     queue_.clear();
     queue_.disable();

--- a/gazebo_plugins/src/gazebo_ros_video.cpp
+++ b/gazebo_plugins/src/gazebo_ros_video.cpp
@@ -116,7 +116,6 @@ namespace gazebo
   // Destructor
   GazeboRosVideo::~GazeboRosVideo() {
     event::Events::DisconnectWorldUpdateBegin(update_connection_);
-
     // Custom Callback Queue
     queue_.clear();
     queue_.disable();

--- a/gazebo_plugins/test/pub_joint_trajectory_test.cpp
+++ b/gazebo_plugins/test/pub_joint_trajectory_test.cpp
@@ -1,7 +1,7 @@
 #include <ros/ros.h>
 #include <trajectory_msgs/JointTrajectory.h>
 #include <gazebo_msgs/SetJointTrajectory.h>
-#include <gazebo/math/Quaternion.hh>
+#include <ignition/math/Quaternion.hh>
 #include <math.h>
 
 int main(int argc, char** argv)
@@ -62,15 +62,15 @@ int main(int argc, char** argv)
   sjt.request.joint_trajectory = jt;
   sjt.request.disable_physics_updates = false;
 
-  ignition::math::Quaterniond r(0, 0, M_PI);
+  ignition::math::Quaterniond r(0.0, 0.0, M_PI);
   geometry_msgs::Pose p;
-  p.position.x = 0;
-  p.position.y = 0;
-  p.position.z = 0;
-  p.orientation.x = r.x;
-  p.orientation.y = r.y;
-  p.orientation.z = r.z;
-  p.orientation.w = r.w;
+  p.position.x = 0.0;
+  p.position.y = 0.0;
+  p.position.z = 0.0;
+  p.orientation.x = r.X();
+  p.orientation.y = r.Y();
+  p.orientation.z = r.Z();
+  p.orientation.w = r.W();
   sjt.request.model_pose = p;
   sjt.request.set_model_pose = true;
 

--- a/gazebo_plugins/test/pub_joint_trajectory_test.cpp
+++ b/gazebo_plugins/test/pub_joint_trajectory_test.cpp
@@ -62,7 +62,7 @@ int main(int argc, char** argv)
   sjt.request.joint_trajectory = jt;
   sjt.request.disable_physics_updates = false;
 
-  gazebo::math::Quaternion r(0, 0, M_PI);
+  ignition::math::Quaterniond r(0, 0, M_PI);
   geometry_msgs::Pose p;
   p.position.x = 0;
   p.position.y = 0;

--- a/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
+++ b/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
@@ -31,8 +31,9 @@
 
 #include <tinyxml.h>
 
-#include <gazebo/physics/physics.hh>
 #include <gazebo/common/common.hh>
+#include <ignition/math.hh>
+#include <gazebo/physics/physics.hh>
 #include <gazebo/transport/transport.hh>
 
 // ROS
@@ -256,11 +257,11 @@ private:
 
   /// \brief Update the model name and pose of the SDF file before sending to Gazebo
   void updateSDFAttributes(TiXmlDocument &gazebo_model_xml, std::string model_name,
-                           gazebo::math::Vector3 initial_xyz, gazebo::math::Quaternion initial_q);
+                           ignition::math::Vector3d initial_xyz, ignition::math::Quaterniond initial_q);
 
   /// \brief Update the model pose of the URDF file before sending to Gazebo
   void updateURDFModelPose(TiXmlDocument &gazebo_model_xml,
-                           gazebo::math::Vector3 initial_xyz, gazebo::math::Quaternion initial_q);
+                           ignition::math::Vector3d initial_xyz, ignition::math::Quaterniond initial_q);
 
   /// \brief Update the model name of the URDF file before sending to Gazebo
   void updateURDFName(TiXmlDocument &gazebo_model_xml, std::string model_name);
@@ -274,9 +275,9 @@ private:
 
   /// \brief helper function for applyBodyWrench
   ///        shift wrench from reference frame to target frame
-  void transformWrench(gazebo::math::Vector3 &target_force, gazebo::math::Vector3 &target_torque,
-                       gazebo::math::Vector3 reference_force, gazebo::math::Vector3 reference_torque,
-                       gazebo::math::Pose target_to_reference );
+  void transformWrench(ignition::math::Vector3d &target_force, ignition::math::Vector3d &target_torque,
+                       ignition::math::Vector3d reference_force, ignition::math::Vector3d reference_torque,
+                       ignition::math::Pose3d target_to_reference );
 
   /// \brief Used for the dynamic reconfigure callback function template
   void physicsReconfigureCallback(gazebo_ros::PhysicsConfig &config, uint32_t level);
@@ -297,10 +298,10 @@ private:
   void loadGazeboRosApiPlugin(std::string world_name);
 
   /// \brief convert xml to Pose
-  gazebo::math::Pose parsePose(const std::string &str);
+  ignition::math::Pose3d parsePose(const std::string &str);
 
   /// \brief convert xml to Pose
-  gazebo::math::Vector3 parseVector3(const std::string &str);
+  ignition::math::Vector3d parseVector3(const std::string &str);
 
   // track if the desconstructor event needs to occur
   bool plugin_loaded_;
@@ -389,8 +390,8 @@ private:
   {
   public:
     gazebo::physics::LinkPtr body;
-    gazebo::math::Vector3 force;
-    gazebo::math::Vector3 torque;
+    ignition::math::Vector3d force;
+    ignition::math::Vector3d torque;
     ros::Time start_time;
     ros::Duration duration;
   };

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -23,6 +23,7 @@
 
   <build_depend>cmake_modules</build_depend>
   <build_depend>gazebo_dev</build_depend>
+  <build_depend>ignition-math3</build_depend>
   <!--
     Need to use gazebo_dev since run script needs pkg-config
     See: https://github.com/ros-simulation/gazebo_ros_pkgs/issues/323 for more info

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -23,7 +23,6 @@
 
   <build_depend>cmake_modules</build_depend>
   <build_depend>gazebo_dev</build_depend>
-  <build_depend>ignition-math3</build_depend>
   <!--
     Need to use gazebo_dev since run script needs pkg-config
     See: https://github.com/ros-simulation/gazebo_ros_pkgs/issues/323 for more info

--- a/gazebo_ros_control/src/default_robot_hw_sim.cpp
+++ b/gazebo_ros_control/src/default_robot_hw_sim.cpp
@@ -253,12 +253,12 @@ void DefaultRobotHWSim::readSim(ros::Time time, ros::Duration period)
     // Gazebo has an interesting API...
     if (joint_types_[j] == urdf::Joint::PRISMATIC)
     {
-      joint_position_[j] = sim_joints_[j]->Position(0).Radian();
+      joint_position_[j] = sim_joints_[j]->Position(0);
     }
     else
     {
       joint_position_[j] += angles::shortest_angular_distance(joint_position_[j],
-                            sim_joints_[j]->Position(0).Radian());
+                            sim_joints_[j]->Position(0));
     }
     joint_velocity_[j] = sim_joints_[j]->GetVelocity(0);
     joint_effort_[j] = sim_joints_[j]->GetForce((unsigned int)(0));

--- a/gazebo_ros_control/src/default_robot_hw_sim.cpp
+++ b/gazebo_ros_control/src/default_robot_hw_sim.cpp
@@ -253,12 +253,12 @@ void DefaultRobotHWSim::readSim(ros::Time time, ros::Duration period)
     // Gazebo has an interesting API...
     if (joint_types_[j] == urdf::Joint::PRISMATIC)
     {
-      joint_position_[j] = sim_joints_[j]->GetAngle(0).Radian();
+      joint_position_[j] = sim_joints_[j]->Position(0).Radian();
     }
     else
     {
       joint_position_[j] += angles::shortest_angular_distance(joint_position_[j],
-                            sim_joints_[j]->GetAngle(0).Radian());
+                            sim_joints_[j]->Position(0).Radian());
     }
     joint_velocity_[j] = sim_joints_[j]->GetVelocity(0);
     joint_effort_[j] = sim_joints_[j]->GetForce((unsigned int)(0));

--- a/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
+++ b/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
@@ -107,7 +107,7 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
   }
 
   // Get the Gazebo simulation period
-  ros::Duration gazebo_period(parent_model_->GetWorld()->GetPhysicsEngine()->GetMaxStepSize());
+  ros::Duration gazebo_period(parent_model_->GetWorld()->Physics()->GetMaxStepSize());
 
   // Decide the plugin control period
   if(sdf_->HasElement("controlPeriod"))

--- a/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
+++ b/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
@@ -198,7 +198,7 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
 void GazeboRosControlPlugin::Update()
 {
   // Get the simulation time and period
-  gazebo::common::Time gz_time_now = parent_model_->GetWorld()->GetSimTime();
+  gazebo::common::Time gz_time_now = parent_model_->GetWorld()->SimTime();
   ros::Time sim_time_ros(gz_time_now.sec, gz_time_now.nsec);
   ros::Duration sim_period = sim_time_ros - last_update_sim_time_ros_;
 

--- a/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
+++ b/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
@@ -48,11 +48,7 @@
 namespace gazebo_ros_control
 {
 
-GazeboRosControlPlugin::~GazeboRosControlPlugin()
-{
-  // Disconnect from gazebo events
-  gazebo::event::Events::DisconnectWorldUpdateBegin(update_connection_);
-}
+GazeboRosControlPlugin::~GazeboRosControlPlugin() {}
 
 // Overloaded Gazebo entry point
 void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::ElementPtr sdf)


### PR DESCRIPTION
These were the modification I had to do in order to compile with Gazebo9 and hence also with ignition::math.

I didn't try the backward compatibility.

**EDIT:**
So according to ci it works with gazebo8 but not earlier versions, which is expected, I guess :).