### PR TITLE
Fix gazebo8 warnings part 1: replace Events::Disconnect* with pointer reset

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_f3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_f3d.cpp
@@ -39,7 +39,7 @@ GazeboRosF3D::GazeboRosF3D()
 // Destructor
 GazeboRosF3D::~GazeboRosF3D()
 {
-  event::Events::DisconnectWorldUpdateBegin(this->update_connection_);
+  this->update_connection_.reset();
   // Custom Callback Queue
   this->queue_.clear();
   this->queue_.disable();

--- a/gazebo_plugins/src/gazebo_ros_force.cpp
+++ b/gazebo_plugins/src/gazebo_ros_force.cpp
@@ -46,7 +46,7 @@ GazeboRosForce::GazeboRosForce()
 // Destructor
 GazeboRosForce::~GazeboRosForce()
 {
-  event::Events::DisconnectWorldUpdateBegin(this->update_connection_);
+  this->update_connection_.reset();
 
   // Custom Callback Queue
   this->queue_.clear();

--- a/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
@@ -39,7 +39,7 @@ GazeboRosFT::GazeboRosFT()
 // Destructor
 GazeboRosFT::~GazeboRosFT()
 {
-  event::Events::DisconnectWorldUpdateBegin(this->update_connection_);
+  this->update_connection_.reset();
   // Custom Callback Queue
   this->queue_.clear();
   this->queue_.disable();

--- a/gazebo_plugins/src/gazebo_ros_imu.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu.cpp
@@ -38,7 +38,7 @@ GazeboRosIMU::GazeboRosIMU()
 // Destructor
 GazeboRosIMU::~GazeboRosIMU()
 {
-  event::Events::DisconnectWorldUpdateBegin(this->update_connection_);
+  this->update_connection_.reset();
   // Finalize the controller
   this->rosnode_->shutdown();
   this->callback_queue_thread_.join();

--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -247,7 +247,7 @@ gazebo::GazeboRosImuSensor::~GazeboRosImuSensor()
 {
   if (connection.get())
   {
-    gazebo::event::Events::DisconnectWorldUpdateBegin(connection);
+    connection.reset();
     connection = gazebo::event::ConnectionPtr();
   }
 

--- a/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
@@ -47,7 +47,7 @@ ROS_DEPRECATED GazeboRosJointPoseTrajectory::GazeboRosJointPoseTrajectory()  // 
 // Destructor
 GazeboRosJointPoseTrajectory::~GazeboRosJointPoseTrajectory()
 {
-  event::Events::DisconnectWorldUpdateBegin(this->update_connection_);
+  this->update_connection_.reset();
   // Finalize the controller
   this->rosnode_->shutdown();
   this->queue_.clear();

--- a/gazebo_plugins/src/gazebo_ros_joint_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_trajectory.cpp
@@ -48,7 +48,7 @@ ROS_DEPRECATED GazeboRosJointTrajectory::GazeboRosJointTrajectory()  // replaced
 // Destructor
 GazeboRosJointTrajectory::~GazeboRosJointTrajectory()
 {
-  event::Events::DisconnectWorldUpdateBegin(this->update_connection_);
+  this->update_connection_.reset();
   // Finalize the controller
   this->rosnode_->shutdown();
   this->queue_.clear();

--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -36,7 +36,7 @@ GazeboRosP3D::GazeboRosP3D()
 // Destructor
 GazeboRosP3D::~GazeboRosP3D()
 {
-  event::Events::DisconnectWorldUpdateBegin(this->update_connection_);
+  this->update_connection_.reset();
   // Finalize the controller
   this->rosnode_->shutdown();
   this->p3d_queue_.clear();

--- a/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
@@ -44,7 +44,7 @@ GazeboRosVacuumGripper::GazeboRosVacuumGripper()
 // Destructor
 GazeboRosVacuumGripper::~GazeboRosVacuumGripper()
 {
-  event::Events::DisconnectWorldUpdateBegin(update_connection_);
+  update_connection_.reset();
 
   // Custom Callback Queue
   queue_.clear();

--- a/gazebo_plugins/src/gazebo_ros_video.cpp
+++ b/gazebo_plugins/src/gazebo_ros_video.cpp
@@ -115,7 +115,7 @@ namespace gazebo
 
   // Destructor
   GazeboRosVideo::~GazeboRosVideo() {
-    event::Events::DisconnectWorldUpdateBegin(update_connection_);
+    update_connection_.reset();
 
     // Custom Callback Queue
     queue_.clear();

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -44,7 +44,7 @@ GazeboRosApiPlugin::~GazeboRosApiPlugin()
   ROS_DEBUG_STREAM_NAMED("api_plugin","GazeboRosApiPlugin Deconstructor start");
 
   // Unload the sigint event
-  gazebo::event::Events::DisconnectSigInt(sigint_event_);
+  sigint_event_.reset();
   ROS_DEBUG_STREAM_NAMED("api_plugin","After sigint_event unload");
 
   // Don't attempt to unload this plugin if it was never loaded in the Load() function
@@ -55,16 +55,16 @@ GazeboRosApiPlugin::~GazeboRosApiPlugin()
   }
 
   // Disconnect slots
-  gazebo::event::Events::DisconnectWorldCreated(load_gazebo_ros_api_plugin_event_);
-  gazebo::event::Events::DisconnectWorldUpdateBegin(wrench_update_event_);
-  gazebo::event::Events::DisconnectWorldUpdateBegin(force_update_event_);
-  gazebo::event::Events::DisconnectWorldUpdateBegin(time_update_event_);
+  load_gazebo_ros_api_plugin_event_.reset();
+  wrench_update_event_.reset();
+  force_update_event_.reset();
+  time_update_event_.reset();
   ROS_DEBUG_STREAM_NAMED("api_plugin","Slots disconnected");
 
   if (pub_link_states_connection_count_ > 0) // disconnect if there are subscribers on exit
-    gazebo::event::Events::DisconnectWorldUpdateBegin(pub_link_states_event_);
+    pub_link_states_event_.reset();
   if (pub_model_states_connection_count_ > 0) // disconnect if there are subscribers on exit
-    gazebo::event::Events::DisconnectWorldUpdateBegin(pub_model_states_event_);
+    pub_model_states_event_.reset();
   ROS_DEBUG_STREAM_NAMED("api_plugin","Disconnected World Updates");
 
   // Stop the multi threaded ROS spinner
@@ -527,7 +527,7 @@ void GazeboRosApiPlugin::onLinkStatesDisconnect()
   pub_link_states_connection_count_--;
   if (pub_link_states_connection_count_ <= 0) // disconnect with no subscribers
   {
-    gazebo::event::Events::DisconnectWorldUpdateBegin(pub_link_states_event_);
+    pub_link_states_event_.reset();
     if (pub_link_states_connection_count_ < 0) // should not be possible
       ROS_ERROR_NAMED("api_plugin", "One too mandy disconnect from pub_link_states_ in gazebo_ros.cpp? something weird");
   }
@@ -538,7 +538,7 @@ void GazeboRosApiPlugin::onModelStatesDisconnect()
   pub_model_states_connection_count_--;
   if (pub_model_states_connection_count_ <= 0) // disconnect with no subscribers
   {
-    gazebo::event::Events::DisconnectWorldUpdateBegin(pub_model_states_event_);
+    pub_model_states_event_.reset();
     if (pub_model_states_connection_count_ < 0) // should not be possible
       ROS_ERROR_NAMED("api_plugin", "One too mandy disconnect from pub_model_states_ in gazebo_ros.cpp? something weird");
   }

--- a/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
+++ b/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
@@ -51,7 +51,7 @@ namespace gazebo_ros_control
 GazeboRosControlPlugin::~GazeboRosControlPlugin()
 {
   // Disconnect from gazebo events
-  gazebo::event::Events::DisconnectWorldUpdateBegin(update_connection_);
+  update_connection_.reset();
 }
 
 // Overloaded Gazebo entry point


### PR DESCRIPTION
Alternative to #613 split into many parts.

~~~
sed -i \
  -e 's@[gazebo:]*event::Events::Disconnect[A-Za-z]*(\([^)]*\));@\1.reset();@' \
  $(grep -rlI Events::Disconnect .)
~~~

There were [983 warnings](https://build.osrfoundation.org/job/ros_gazebo8_pkgs-ci-pr_any_kinetic-xenial-amd64/26/) for #542; this should reduce that.
