### PR TITLE
gazebo_ros_api_plugin: improve plugin xml parsing when spawning model (kinetic-devel)

### DIFF
--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -2355,7 +2355,8 @@ void GazeboRosApiPlugin::walkChildAddRobotNamespace(TiXmlNode* model_xml)
   child = model_xml->IterateChildren(child);
   while (child != NULL)
   {
-    if (child->ValueStr().find(std::string("plugin")) == 0)
+    if (child->Type() == TiXmlNode::TINYXML_ELEMENT &&
+        child->ValueStr().compare(std::string("plugin")) == 0)
     {
       if (child->FirstChildElement("robotNamespace") == NULL)
       {


### PR DESCRIPTION
{ port of pull request #584 }
Spawning a model with an xml comment that starts with plugin causes a seg-fault:
`<!--plugin-->`
or
`<!--plugin filename="lib.so"/-->`
Checking the `Type()` prevents trying to add child elements to xml comments, which is the source of the seg-fault. I also switched from `find` to `compare` to make sure that only `<plugin>` blocks are affected instead of elements that start with `plugin` like `<plugin1>`, `<pluginCustom>`, etc.

It should be easy to add a test for this that just spawns some simple models with these xml tags added.

Here's the backtrace I was seeing:

* https://gist.github.com/scpeters/87c9a8c81e0a279ffe7747727a51e9c9