### PR TITLE
Fix gazebo8 warnings part 2: replace private member gazebo::math types with ignition (lunar-devel)

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_imu.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_imu.h
@@ -75,7 +75,7 @@ namespace gazebo
     private: std::string topic_name_;
 
     /// \brief allow specifying constant xyz and rpy offsets
-    private: math::Pose offset_;
+    private: ignition::math::Pose3d offset_;
 
     /// \brief A mutex to lock access to fields
     /// that are used in message callbacks
@@ -83,16 +83,16 @@ namespace gazebo
 
     /// \brief save last_time
     private: common::Time last_time_;
-    private: math::Vector3 last_vpos_;
-    private: math::Vector3 last_veul_;
-    private: math::Vector3 apos_;
-    private: math::Vector3 aeul_;
+    private: ignition::math::Vector3d last_vpos_;
+    private: ignition::math::Vector3d last_veul_;
+    private: ignition::math::Vector3d apos_;
+    private: ignition::math::Vector3d aeul_;
 
     // rate control
     private: double update_rate_;
 
     /// \brief: keep initial pose to offset orientation in imu message
-    private: math::Pose initial_pose_;
+    private: ignition::math::Pose3d initial_pose_;
 
     /// \brief Gaussian noise
     private: double gaussian_noise_;

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_imu_sensor.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_imu_sensor.h
@@ -79,11 +79,11 @@ namespace gazebo
     /// \brief Pointer to the sdf config file.
     sdf::ElementPtr sdf;
     /// \brief Orientation data from the sensor.
-    gazebo::math::Quaternion orientation;
+    ignition::math::Quaterniond orientation;
     /// \brief Linear acceleration data from the sensor.
-    math::Vector3 accelerometer_data;
+    ignition::math::Vector3d accelerometer_data;
     /// \brief Angular velocity data from the sensor.
-    math::Vector3 gyroscope_data;
+    ignition::math::Vector3d gyroscope_data;
     
     /// \brief Seed for the Gaussian noise generator.
     unsigned int seed;
@@ -100,7 +100,7 @@ namespace gazebo
     /// \brief Gaussian noise.
     double gaussian_noise;
     /// \brief Offset parameter, position part is unused.
-    math::Pose offset;
+    ignition::math::Pose3d offset;
   };
 }
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_p3d.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_p3d.h
@@ -89,21 +89,21 @@ namespace gazebo
     private: std::string tf_frame_name_;
 
     /// \brief allow specifying constant xyz and rpy offsets
-    private: math::Pose offset_;
+    private: ignition::math::Pose3d offset_;
 
     /// \brief mutex to lock access to fields used in message callbacks
     private: boost::mutex lock;
 
     /// \brief save last_time
     private: common::Time last_time_;
-    private: math::Vector3 last_vpos_;
-    private: math::Vector3 last_veul_;
-    private: math::Vector3 apos_;
-    private: math::Vector3 aeul_;
-    private: math::Vector3 last_frame_vpos_;
-    private: math::Vector3 last_frame_veul_;
-    private: math::Vector3 frame_apos_;
-    private: math::Vector3 frame_aeul_;
+    private: ignition::math::Vector3d last_vpos_;
+    private: ignition::math::Vector3d last_veul_;
+    private: ignition::math::Vector3d apos_;
+    private: ignition::math::Vector3d aeul_;
+    private: ignition::math::Vector3d last_frame_vpos_;
+    private: ignition::math::Vector3d last_frame_veul_;
+    private: ignition::math::Vector3d frame_apos_;
+    private: ignition::math::Vector3d frame_aeul_;
 
     // rate control
     private: double update_rate_;

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_planar_move.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_planar_move.h
@@ -90,7 +90,7 @@ namespace gazebo {
       double rot_;
       bool alive_;
       common::Time last_odom_publish_time_;
-      math::Pose last_odom_pose_;
+      ignition::math::Pose3d last_odom_pose_;
 
   };
 

--- a/gazebo_plugins/src/gazebo_ros_imu.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu.cpp
@@ -102,18 +102,18 @@ void GazeboRosIMU::LoadThread()
   if (!this->sdf->HasElement("xyzOffset"))
   {
     ROS_INFO_NAMED("imu", "imu plugin missing <xyzOffset>, defaults to 0s");
-    this->offset_.pos = math::Vector3(0, 0, 0);
+    this->offset_.Pos() = ignition::math::Vector3d(0, 0, 0);
   }
   else
-    this->offset_.pos = this->sdf->Get<math::Vector3>("xyzOffset");
+    this->offset_.Pos() = this->sdf->Get<ignition::math::Vector3d>("xyzOffset");
 
   if (!this->sdf->HasElement("rpyOffset"))
   {
     ROS_INFO_NAMED("imu", "imu plugin missing <rpyOffset>, defaults to 0s");
-    this->offset_.rot = math::Vector3(0, 0, 0);
+    this->offset_.Rot() = ignition::math::Quaterniond(ignition::math::Vector3d(0, 0, 0));
   }
   else
-    this->offset_.rot = this->sdf->Get<math::Vector3>("rpyOffset");
+    this->offset_.Rot() = ignition::math::Quaterniond(this->sdf->Get<ignition::math::Vector3d>("rpyOffset"));
 
   if (!this->sdf->HasElement("updateRate"))
   {
@@ -174,8 +174,8 @@ void GazeboRosIMU::LoadThread()
   this->last_time_ = this->world_->GetSimTime();
 
   // this->initial_pose_ = this->link->GetPose();
-  this->last_vpos_ = this->link->GetWorldLinearVel();
-  this->last_veul_ = this->link->GetWorldAngularVel();
+  this->last_vpos_ = this->link->GetWorldLinearVel().Ign();
+  this->last_veul_ = this->link->GetWorldAngularVel().Ign();
   this->apos_ = 0;
   this->aeul_ = 0;
 
@@ -212,23 +212,23 @@ void GazeboRosIMU::UpdateChild()
 
   if ((this->pub_.getNumSubscribers() > 0 && this->topic_name_ != ""))
   {
-    math::Pose pose;
-    math::Quaternion rot;
-    math::Vector3 pos;
+    ignition::math::Pose3d pose;
+    ignition::math::Quaterniond rot;
+    ignition::math::Vector3d pos;
 
     // Get Pose/Orientation ///@todo: verify correctness
-    pose = this->link->GetWorldPose();
+    pose = this->link->GetWorldPose().Ign();
     // apply xyz offsets and get position and rotation components
-    pos = pose.pos + this->offset_.pos;
-    rot = pose.rot;
+    pos = pose.Pos() + this->offset_.Pos();
+    rot = pose.Rot();
 
     // apply rpy offsets
-    rot = this->offset_.rot*rot;
+    rot = this->offset_.Rot()*rot;
     rot.Normalize();
 
     // get Rates
-    math::Vector3 vpos = this->link->GetWorldLinearVel();
-    math::Vector3 veul = this->link->GetWorldAngularVel();
+    ignition::math::Vector3d vpos = this->link->GetWorldLinearVel().Ign();
+    ignition::math::Vector3d veul = this->link->GetWorldAngularVel().Ign();
 
     // differentiate to get accelerations
     double tmp_dt = this->last_time_.Double() - cur_time.Double();
@@ -250,37 +250,37 @@ void GazeboRosIMU::UpdateChild()
     // uncomment this if we are reporting orientation in the local frame
     // not the case for our imu definition
     // // apply fixed orientation offsets of initial pose
-    // rot = this->initial_pose_.rot*rot;
+    // rot = this->initial_pose_.Rot()*rot;
     // rot.Normalize();
 
-    this->imu_msg_.orientation.x = rot.x;
-    this->imu_msg_.orientation.y = rot.y;
-    this->imu_msg_.orientation.z = rot.z;
-    this->imu_msg_.orientation.w = rot.w;
+    this->imu_msg_.orientation.x = rot.X();
+    this->imu_msg_.orientation.y = rot.Y();
+    this->imu_msg_.orientation.z = rot.Z();
+    this->imu_msg_.orientation.w = rot.W();
 
     // pass euler angular rates
-    math::Vector3 linear_velocity(
-      veul.x + this->GaussianKernel(0, this->gaussian_noise_),
-      veul.y + this->GaussianKernel(0, this->gaussian_noise_),
-      veul.z + this->GaussianKernel(0, this->gaussian_noise_));
+    ignition::math::Vector3d linear_velocity(
+      veul.X() + this->GaussianKernel(0, this->gaussian_noise_),
+      veul.Y() + this->GaussianKernel(0, this->gaussian_noise_),
+      veul.Z() + this->GaussianKernel(0, this->gaussian_noise_));
     // rotate into local frame
     // @todo: deal with offsets!
     linear_velocity = rot.RotateVector(linear_velocity);
-    this->imu_msg_.angular_velocity.x    = linear_velocity.x;
-    this->imu_msg_.angular_velocity.y    = linear_velocity.y;
-    this->imu_msg_.angular_velocity.z    = linear_velocity.z;
+    this->imu_msg_.angular_velocity.x    = linear_velocity.X();
+    this->imu_msg_.angular_velocity.y    = linear_velocity.Y();
+    this->imu_msg_.angular_velocity.z    = linear_velocity.Z();
 
     // pass accelerations
-    math::Vector3 linear_acceleration(
-      apos_.x + this->GaussianKernel(0, this->gaussian_noise_),
-      apos_.y + this->GaussianKernel(0, this->gaussian_noise_),
-      apos_.z + this->GaussianKernel(0, this->gaussian_noise_));
+    ignition::math::Vector3d linear_acceleration(
+      apos_.X() + this->GaussianKernel(0, this->gaussian_noise_),
+      apos_.Y() + this->GaussianKernel(0, this->gaussian_noise_),
+      apos_.Z() + this->GaussianKernel(0, this->gaussian_noise_));
     // rotate into local frame
     // @todo: deal with offsets!
     linear_acceleration = rot.RotateVector(linear_acceleration);
-    this->imu_msg_.linear_acceleration.x    = linear_acceleration.x;
-    this->imu_msg_.linear_acceleration.y    = linear_acceleration.y;
-    this->imu_msg_.linear_acceleration.z    = linear_acceleration.z;
+    this->imu_msg_.linear_acceleration.x    = linear_acceleration.X();
+    this->imu_msg_.linear_acceleration.y    = linear_acceleration.Y();
+    this->imu_msg_.linear_acceleration.z    = linear_acceleration.Z();
 
     // fill in covariance matrix
     /// @todo: let user set separate linear and angular covariance values.

--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -61,35 +61,21 @@ void gazebo::GazeboRosImuSensor::Load(gazebo::sensors::SensorPtr sensor_, sdf::E
 
   connection = gazebo::event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboRosImuSensor::UpdateChild, this, _1));
 
-#if GAZEBO_MAJOR_VERSION >= 7
   last_time = sensor->LastUpdateTime();
-#else
-  last_time = sensor->GetLastUpdateTime();
-#endif
 }
 
 void gazebo::GazeboRosImuSensor::UpdateChild(const gazebo::common::UpdateInfo &/*_info*/)
 {
-#if GAZEBO_MAJOR_VERSION >= 7
   common::Time current_time = sensor->LastUpdateTime();
-#else
-  common::Time current_time = sensor->GetLastUpdateTime();
-#endif
 
   if(update_rate>0 && (current_time-last_time).Double() < 1.0/update_rate) //update rate check
     return;
 
   if(imu_data_publisher.getNumSubscribers() > 0)
   {
-#if GAZEBO_MAJOR_VERSION >= 6
     orientation = offset.rot*sensor->Orientation(); //applying offsets to the orientation measurement
     accelerometer_data = sensor->LinearAcceleration();
     gyroscope_data = sensor->AngularVelocity();
-#else
-    orientation = offset.rot*sensor->GetOrientation(); //applying offsets to the orientation measurement
-    accelerometer_data = sensor->GetLinearAcceleration();
-    gyroscope_data = sensor->GetAngularVelocity();
-#endif
 
     //Guassian noise is applied to all measurements
     imu_msg.orientation.x = orientation.x + GuassianKernel(0,gaussian_noise);
@@ -157,11 +143,7 @@ bool gazebo::GazeboRosImuSensor::LoadParameters()
   }
   else
   {
-#if GAZEBO_MAJOR_VERSION >= 7
     std::string scoped_name = sensor->ParentName();
-#else
-    std::string scoped_name = sensor->GetParentName(); //HACK to find the model name
-#endif
     std::size_t it = scoped_name.find("::");
 
     robot_namespace = "/" +scoped_name.substr(0,it)+"/";

--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -23,9 +23,9 @@ GZ_REGISTER_SENSOR_PLUGIN(gazebo::GazeboRosImuSensor)
 
 gazebo::GazeboRosImuSensor::GazeboRosImuSensor(): SensorPlugin()
 {
-  accelerometer_data = math::Vector3(0, 0, 0);
-  gyroscope_data = math::Vector3(0, 0, 0);
-  orientation = math::Quaternion(1,0,0,0);
+  accelerometer_data = ignition::math::Vector3d(0, 0, 0);
+  gyroscope_data = ignition::math::Vector3d(0, 0, 0);
+  orientation = ignition::math::Quaterniond(1,0,0,0);
   seed=0;
   sensor=NULL;
 }
@@ -73,23 +73,23 @@ void gazebo::GazeboRosImuSensor::UpdateChild(const gazebo::common::UpdateInfo &/
 
   if(imu_data_publisher.getNumSubscribers() > 0)
   {
-    orientation = offset.rot*sensor->Orientation(); //applying offsets to the orientation measurement
+    orientation = offset.Rot()*sensor->Orientation(); //applying offsets to the orientation measurement
     accelerometer_data = sensor->LinearAcceleration();
     gyroscope_data = sensor->AngularVelocity();
 
     //Guassian noise is applied to all measurements
-    imu_msg.orientation.x = orientation.x + GuassianKernel(0,gaussian_noise);
-    imu_msg.orientation.y = orientation.y + GuassianKernel(0,gaussian_noise);
-    imu_msg.orientation.z = orientation.z + GuassianKernel(0,gaussian_noise);
-    imu_msg.orientation.w = orientation.w + GuassianKernel(0,gaussian_noise);
+    imu_msg.orientation.x = orientation.X() + GuassianKernel(0,gaussian_noise);
+    imu_msg.orientation.y = orientation.Y() + GuassianKernel(0,gaussian_noise);
+    imu_msg.orientation.z = orientation.Z() + GuassianKernel(0,gaussian_noise);
+    imu_msg.orientation.w = orientation.W() + GuassianKernel(0,gaussian_noise);
 
-    imu_msg.linear_acceleration.x = accelerometer_data.x + GuassianKernel(0,gaussian_noise);
-    imu_msg.linear_acceleration.y = accelerometer_data.y + GuassianKernel(0,gaussian_noise);
-    imu_msg.linear_acceleration.z = accelerometer_data.z + GuassianKernel(0,gaussian_noise);
+    imu_msg.linear_acceleration.x = accelerometer_data.X() + GuassianKernel(0,gaussian_noise);
+    imu_msg.linear_acceleration.y = accelerometer_data.Y() + GuassianKernel(0,gaussian_noise);
+    imu_msg.linear_acceleration.z = accelerometer_data.Z() + GuassianKernel(0,gaussian_noise);
 
-    imu_msg.angular_velocity.x = gyroscope_data.x + GuassianKernel(0,gaussian_noise);
-    imu_msg.angular_velocity.y = gyroscope_data.y + GuassianKernel(0,gaussian_noise);
-    imu_msg.angular_velocity.z = gyroscope_data.z + GuassianKernel(0,gaussian_noise);
+    imu_msg.angular_velocity.x = gyroscope_data.X() + GuassianKernel(0,gaussian_noise);
+    imu_msg.angular_velocity.y = gyroscope_data.Y() + GuassianKernel(0,gaussian_noise);
+    imu_msg.angular_velocity.z = gyroscope_data.Z() + GuassianKernel(0,gaussian_noise);
 
     //covariance is related to the Gaussian noise
     double gn2 = gaussian_noise*gaussian_noise;
@@ -201,25 +201,25 @@ bool gazebo::GazeboRosImuSensor::LoadParameters()
   //POSITION OFFSET, UNUSED
   if (sdf->HasElement("xyzOffset"))
   {
-    offset.pos =  sdf->Get<math::Vector3>("xyzOffset");
-    ROS_INFO_STREAM("<xyzOffset> set to: " << offset.pos[0] << ' ' << offset.pos[1] << ' ' << offset.pos[2]);
+    offset.Pos() =  sdf->Get<ignition::math::Vector3d>("xyzOffset");
+    ROS_INFO_STREAM("<xyzOffset> set to: " << offset.Pos()[0] << ' ' << offset.Pos()[1] << ' ' << offset.Pos()[2]);
   }
   else
   {
-    offset.pos = math::Vector3(0, 0, 0);
-    ROS_WARN_STREAM("missing <xyzOffset>, set to default: " << offset.pos[0] << ' ' << offset.pos[1] << ' ' << offset.pos[2]);
+    offset.Pos() = ignition::math::Vector3d(0, 0, 0);
+    ROS_WARN_STREAM("missing <xyzOffset>, set to default: " << offset.Pos()[0] << ' ' << offset.Pos()[1] << ' ' << offset.Pos()[2]);
   }
 
   //ORIENTATION OFFSET
   if (sdf->HasElement("rpyOffset"))
   {
-    offset.rot =  sdf->Get<math::Vector3>("rpyOffset");
-    ROS_INFO_STREAM("<rpyOffset> set to: " << offset.rot.GetRoll() << ' ' << offset.rot.GetPitch() << ' ' << offset.rot.GetYaw());
+    offset.Rot() = ignition::math::Quaterniond(sdf->Get<ignition::math::Vector3d>("rpyOffset"));
+    ROS_INFO_STREAM("<rpyOffset> set to: " << offset.Rot().Roll() << ' ' << offset.Rot().Pitch() << ' ' << offset.Rot().Yaw());
   }
   else
   {
-    offset.rot = math::Vector3(0, 0, 0);
-    ROS_WARN_STREAM("missing <rpyOffset>, set to default: " << offset.rot.GetRoll() << ' ' << offset.rot.GetPitch() << ' ' << offset.rot.GetYaw());
+    offset.Rot() = ignition::math::Quaterniond::Identity;
+    ROS_WARN_STREAM("missing <rpyOffset>, set to default: " << offset.Rot().Roll() << ' ' << offset.Rot().Pitch() << ' ' << offset.Rot().Yaw());
   }
 
   return true;

--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -94,18 +94,18 @@ void GazeboRosP3D::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf)
   if (!_sdf->HasElement("xyzOffset"))
   {
     ROS_DEBUG_NAMED("p3d", "p3d plugin missing <xyzOffset>, defaults to 0s");
-    this->offset_.pos = math::Vector3(0, 0, 0);
+    this->offset_.Pos() = ignition::math::Vector3d(0, 0, 0);
   }
   else
-    this->offset_.pos = _sdf->GetElement("xyzOffset")->Get<math::Vector3>();
+    this->offset_.Pos() = _sdf->GetElement("xyzOffset")->Get<ignition::math::Vector3d>();
 
   if (!_sdf->HasElement("rpyOffset"))
   {
     ROS_DEBUG_NAMED("p3d", "p3d plugin missing <rpyOffset>, defaults to 0s");
-    this->offset_.rot = math::Vector3(0, 0, 0);
+    this->offset_.Rot() = ignition::math::Quaterniond(ignition::math::Vector3d(0, 0, 0));
   }
   else
-    this->offset_.rot = _sdf->GetElement("rpyOffset")->Get<math::Vector3>();
+    this->offset_.Rot() = ignition::math::Quaterniond(_sdf->GetElement("rpyOffset")->Get<ignition::math::Vector3d>());
 
   if (!_sdf->HasElement("gaussianNoise"))
   {
@@ -151,8 +151,8 @@ void GazeboRosP3D::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf)
 
   this->last_time_ = this->world_->GetSimTime();
   // initialize body
-  this->last_vpos_ = this->link_->GetWorldLinearVel();
-  this->last_veul_ = this->link_->GetWorldAngularVel();
+  this->last_vpos_ = this->link_->GetWorldLinearVel().Ign();
+  this->last_veul_ = this->link_->GetWorldAngularVel().Ign();
   this->apos_ = 0;
   this->aeul_ = 0;
 
@@ -178,8 +178,8 @@ void GazeboRosP3D::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf)
     ROS_DEBUG_NAMED("p3d", "got body %s", this->reference_link_->GetName().c_str());
     this->frame_apos_ = 0;
     this->frame_aeul_ = 0;
-    this->last_frame_vpos_ = this->reference_link_->GetWorldLinearVel();
-    this->last_frame_veul_ = this->reference_link_->GetWorldAngularVel();
+    this->last_frame_vpos_ = this->reference_link_->GetWorldLinearVel().Ign();
+    this->last_frame_veul_ = this->reference_link_->GetWorldAngularVel().Ign();
   }
 
 
@@ -225,38 +225,38 @@ void GazeboRosP3D::UpdateChild()
 
         this->pose_msg_.child_frame_id = this->link_name_;
 
-        math::Pose pose, frame_pose;
-        math::Vector3 frame_vpos;
-        math::Vector3 frame_veul;
+        ignition::math::Pose3d pose, frame_pose;
+        ignition::math::Vector3d frame_vpos;
+        ignition::math::Vector3d frame_veul;
 
         // get inertial Rates
-        math::Vector3 vpos = this->link_->GetWorldLinearVel();
-        math::Vector3 veul = this->link_->GetWorldAngularVel();
+        ignition::math::Vector3d vpos = this->link_->GetWorldLinearVel().Ign();
+        ignition::math::Vector3d veul = this->link_->GetWorldAngularVel().Ign();
 
         // Get Pose/Orientation
-        pose = this->link_->GetWorldPose();
+        pose = this->link_->GetWorldPose().Ign();
 
         // Apply Reference Frame
         if (this->reference_link_)
         {
           // convert to relative pose
-          frame_pose = this->reference_link_->GetWorldPose();
-          pose.pos = pose.pos - frame_pose.pos;
-          pose.pos = frame_pose.rot.RotateVectorReverse(pose.pos);
-          pose.rot *= frame_pose.rot.GetInverse();
+          frame_pose = this->reference_link_->GetWorldPose().Ign();
+          pose.Pos() = pose.Pos() - frame_pose.Pos();
+          pose.Pos() = frame_pose.Rot().RotateVectorReverse(pose.Pos());
+          pose.Rot() *= frame_pose.Rot().Inverse();
           // convert to relative rates
-          frame_vpos = this->reference_link_->GetWorldLinearVel();
-          frame_veul = this->reference_link_->GetWorldAngularVel();
-          vpos = frame_pose.rot.RotateVector(vpos - frame_vpos);
-          veul = frame_pose.rot.RotateVector(veul - frame_veul);
+          frame_vpos = this->reference_link_->GetWorldLinearVel().Ign();
+          frame_veul = this->reference_link_->GetWorldAngularVel().Ign();
+          vpos = frame_pose.Rot().RotateVector(vpos - frame_vpos);
+          veul = frame_pose.Rot().RotateVector(veul - frame_veul);
         }
 
         // Apply Constant Offsets
         // apply xyz offsets and get position and rotation components
-        pose.pos = pose.pos + this->offset_.pos;
+        pose.Pos() = pose.Pos() + this->offset_.Pos();
         // apply rpy offsets
-        pose.rot = this->offset_.rot*pose.rot;
-        pose.rot.Normalize();
+        pose.Rot() = this->offset_.Rot()*pose.Rot();
+        pose.Rot().Normalize();
 
         // compute accelerations (not used)
         this->apos_ = (this->last_vpos_ - vpos) / tmp_dt;
@@ -270,27 +270,27 @@ void GazeboRosP3D::UpdateChild()
         this->last_frame_veul_ = frame_veul;
 
         // Fill out messages
-        this->pose_msg_.pose.pose.position.x    = pose.pos.x;
-        this->pose_msg_.pose.pose.position.y    = pose.pos.y;
-        this->pose_msg_.pose.pose.position.z    = pose.pos.z;
+        this->pose_msg_.pose.pose.position.x    = pose.Pos().X();
+        this->pose_msg_.pose.pose.position.y    = pose.Pos().Y();
+        this->pose_msg_.pose.pose.position.z    = pose.Pos().Z();
 
-        this->pose_msg_.pose.pose.orientation.x = pose.rot.x;
-        this->pose_msg_.pose.pose.orientation.y = pose.rot.y;
-        this->pose_msg_.pose.pose.orientation.z = pose.rot.z;
-        this->pose_msg_.pose.pose.orientation.w = pose.rot.w;
+        this->pose_msg_.pose.pose.orientation.x = pose.Rot().X();
+        this->pose_msg_.pose.pose.orientation.y = pose.Rot().Y();
+        this->pose_msg_.pose.pose.orientation.z = pose.Rot().Z();
+        this->pose_msg_.pose.pose.orientation.w = pose.Rot().W();
 
-        this->pose_msg_.twist.twist.linear.x  = vpos.x +
+        this->pose_msg_.twist.twist.linear.x  = vpos.X() +
           this->GaussianKernel(0, this->gaussian_noise_);
-        this->pose_msg_.twist.twist.linear.y  = vpos.y +
+        this->pose_msg_.twist.twist.linear.y  = vpos.Y() +
           this->GaussianKernel(0, this->gaussian_noise_);
-        this->pose_msg_.twist.twist.linear.z  = vpos.z +
+        this->pose_msg_.twist.twist.linear.z  = vpos.Z() +
           this->GaussianKernel(0, this->gaussian_noise_);
         // pass euler angular rates
-        this->pose_msg_.twist.twist.angular.x = veul.x +
+        this->pose_msg_.twist.twist.angular.x = veul.X() +
           this->GaussianKernel(0, this->gaussian_noise_);
-        this->pose_msg_.twist.twist.angular.y = veul.y +
+        this->pose_msg_.twist.twist.angular.y = veul.Y() +
           this->GaussianKernel(0, this->gaussian_noise_);
-        this->pose_msg_.twist.twist.angular.z = veul.z +
+        this->pose_msg_.twist.twist.angular.z = veul.Z() +
           this->GaussianKernel(0, this->gaussian_noise_);
 
         // fill in covariance matrix

--- a/gazebo_plugins/src/gazebo_ros_planar_move.cpp
+++ b/gazebo_plugins/src/gazebo_ros_planar_move.cpp
@@ -113,7 +113,7 @@ namespace gazebo
     }
 
     last_odom_publish_time_ = parent_->GetWorld()->GetSimTime();
-    last_odom_pose_ = parent_->GetWorldPose();
+    last_odom_pose_ = parent_->GetWorldPose().Ign();
     x_ = 0;
     y_ = 0;
     rot_ = 0;
@@ -160,13 +160,13 @@ namespace gazebo
   void GazeboRosPlanarMove::UpdateChild()
   {
     boost::mutex::scoped_lock scoped_lock(lock);
-    math::Pose pose = parent_->GetWorldPose();
-    float yaw = pose.rot.GetYaw();
-    parent_->SetLinearVel(math::Vector3(
+    ignition::math::Pose3d pose = parent_->GetWorldPose().Ign();
+    float yaw = pose.Rot().Yaw();
+    parent_->SetLinearVel(ignition::math::Vector3d(
           x_ * cosf(yaw) - y_ * sinf(yaw),
           y_ * cosf(yaw) + x_ * sinf(yaw),
           0));
-    parent_->SetAngularVel(math::Vector3(0, 0, rot_));
+    parent_->SetAngularVel(ignition::math::Vector3d(0, 0, rot_));
     if (odometry_rate_ > 0.0) {
       common::Time current_time = parent_->GetWorld()->GetSimTime();
       double seconds_since_last_update =
@@ -214,10 +214,10 @@ namespace gazebo
       tf::resolve(tf_prefix_, robot_base_frame_);
 
     // getting data for base_footprint to odom transform
-    math::Pose pose = this->parent_->GetWorldPose();
+    ignition::math::Pose3d pose = this->parent_->GetWorldPose().Ign();
 
-    tf::Quaternion qt(pose.rot.x, pose.rot.y, pose.rot.z, pose.rot.w);
-    tf::Vector3 vt(pose.pos.x, pose.pos.y, pose.pos.z);
+    tf::Quaternion qt(pose.Rot().X(), pose.Rot().Y(), pose.Rot().Z(), pose.Rot().W());
+    tf::Vector3    vt(pose.Pos().X(), pose.Pos().Y(), pose.Pos().Z());
 
     tf::Transform base_footprint_to_odom(qt, vt);
     transform_broadcaster_->sendTransform(
@@ -225,13 +225,13 @@ namespace gazebo
             base_footprint_frame));
 
     // publish odom topic
-    odom_.pose.pose.position.x = pose.pos.x;
-    odom_.pose.pose.position.y = pose.pos.y;
+    odom_.pose.pose.position.x = pose.Pos().X();
+    odom_.pose.pose.position.y = pose.Pos().Y();
 
-    odom_.pose.pose.orientation.x = pose.rot.x;
-    odom_.pose.pose.orientation.y = pose.rot.y;
-    odom_.pose.pose.orientation.z = pose.rot.z;
-    odom_.pose.pose.orientation.w = pose.rot.w;
+    odom_.pose.pose.orientation.x = pose.Rot().X();
+    odom_.pose.pose.orientation.y = pose.Rot().Y();
+    odom_.pose.pose.orientation.z = pose.Rot().Z();
+    odom_.pose.pose.orientation.w = pose.Rot().W();
     odom_.pose.covariance[0] = 0.00001;
     odom_.pose.covariance[7] = 0.00001;
     odom_.pose.covariance[14] = 1000000000000.0;
@@ -240,9 +240,9 @@ namespace gazebo
     odom_.pose.covariance[35] = 0.001;
 
     // get velocity in /odom frame
-    math::Vector3 linear;
-    linear.x = (pose.pos.x - last_odom_pose_.pos.x) / step_time;
-    linear.y = (pose.pos.y - last_odom_pose_.pos.y) / step_time;
+    ignition::math::Vector3d linear;
+    linear.X() = (pose.Pos().X() - last_odom_pose_.Pos().X()) / step_time;
+    linear.Y() = (pose.Pos().Y() - last_odom_pose_.Pos().Y()) / step_time;
     if (rot_ > M_PI / step_time)
     {
       // we cannot calculate the angular velocity correctly
@@ -250,8 +250,8 @@ namespace gazebo
     }
     else
     {
-      float last_yaw = last_odom_pose_.rot.GetYaw();
-      float current_yaw = pose.rot.GetYaw();
+      float last_yaw = last_odom_pose_.Rot().Yaw();
+      float current_yaw = pose.Rot().Yaw();
       while (current_yaw < last_yaw - M_PI) current_yaw += 2 * M_PI;
       while (current_yaw > last_yaw + M_PI) current_yaw -= 2 * M_PI;
       float angular_diff = current_yaw - last_yaw;
@@ -260,9 +260,9 @@ namespace gazebo
     last_odom_pose_ = pose;
 
     // convert velocity to child_frame_id (aka base_footprint)
-    float yaw = pose.rot.GetYaw();
-    odom_.twist.twist.linear.x = cosf(yaw) * linear.x + sinf(yaw) * linear.y;
-    odom_.twist.twist.linear.y = cosf(yaw) * linear.y - sinf(yaw) * linear.x;
+    float yaw = pose.Rot().Yaw();
+    odom_.twist.twist.linear.x = cosf(yaw) * linear.X() + sinf(yaw) * linear.Y();
+    odom_.twist.twist.linear.y = cosf(yaw) * linear.Y() - sinf(yaw) * linear.X();
 
     odom_.header.stamp = current_time;
     odom_.header.frame_id = odom_frame;


### PR DESCRIPTION
{ port of pull request #628 }
The gazebo::math types are deprecated in gazebo8. This PR focuses on gazebo::math variables used as private member variables in `gazebo_plugins` header fiels and replaces them with ignition::math types. It also replaces local gazebo::math variables in those files. I also removed a few old compiler directive blocks.