### PR TITLE
Fix gazebo8 warnings part 3: more ign-math in plugins

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_imu_sensor.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_imu_sensor.h
@@ -19,8 +19,8 @@
 
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/common/UpdateInfo.hh>
-#include <gazebo/math/Vector3.hh>
-#include <gazebo/math/Pose.hh>
+#include <ignition/math/Vector3.hh>
+#include <ignition/math/Pose3.hh>
 #include <ros/ros.h>
 #include <sensor_msgs/Imu.h>
 #include <string>

--- a/gazebo_plugins/src/gazebo_ros_bumper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_bumper.cpp
@@ -177,9 +177,9 @@ void GazeboRosBumper::OnContact()
 */
   // get reference frame (body(link)) pose and subtract from it to get
   // relative force, torque, position and normal vectors
-  math::Pose pose, frame_pose;
-  math::Quaternion rot, frame_rot;
-  math::Vector3 pos, frame_pos;
+  ignition::math::Pose3d pose, frame_pose;
+  ignition::math::Quaterniond rot, frame_rot;
+  ignition::math::Vector3d pos, frame_pos;
   /*
   if (myFrame)
   {
@@ -192,9 +192,9 @@ void GazeboRosBumper::OnContact()
   {
     // no specific frames specified, use identity pose, keeping
     // relative frame at inertial origin
-    frame_pos = math::Vector3(0, 0, 0);
-    frame_rot = math::Quaternion(1, 0, 0, 0);  // gazebo u,x,y,z == identity
-    frame_pose = math::Pose(frame_pos, frame_rot);
+    frame_pos = ignition::math::Vector3d(0, 0, 0);
+    frame_rot = ignition::math::Quaterniond(1, 0, 0, 0);  // gazebo u,x,y,z == identity
+    frame_pose = ignition::math::Pose3d(frame_pos, frame_rot);
   }
 
 
@@ -253,23 +253,23 @@ void GazeboRosBumper::OnContact()
 
       // Get force, torque and rotate into user specified frame.
       // frame_rot is identity if world is used (default for now)
-      math::Vector3 force = frame_rot.RotateVectorReverse(math::Vector3(
+      ignition::math::Vector3d force = frame_rot.RotateVectorReverse(ignition::math::Vector3d(
                               contact.wrench(j).body_1_wrench().force().x(),
                             contact.wrench(j).body_1_wrench().force().y(),
                             contact.wrench(j).body_1_wrench().force().z()));
-      math::Vector3 torque = frame_rot.RotateVectorReverse(math::Vector3(
+      ignition::math::Vector3d torque = frame_rot.RotateVectorReverse(ignition::math::Vector3d(
                             contact.wrench(j).body_1_wrench().torque().x(),
                             contact.wrench(j).body_1_wrench().torque().y(),
                             contact.wrench(j).body_1_wrench().torque().z()));
 
       // set wrenches
       geometry_msgs::Wrench wrench;
-      wrench.force.x  = force.x;
-      wrench.force.y  = force.y;
-      wrench.force.z  = force.z;
-      wrench.torque.x = torque.x;
-      wrench.torque.y = torque.y;
-      wrench.torque.z = torque.z;
+      wrench.force.x  = force.X();
+      wrench.force.y  = force.Y();
+      wrench.force.z  = force.Z();
+      wrench.torque.x = torque.X();
+      wrench.torque.y = torque.Y();
+      wrench.torque.z = torque.Z();
       state.wrenches.push_back(wrench);
 
       total_wrench.force.x  += wrench.force.x;
@@ -281,27 +281,27 @@ void GazeboRosBumper::OnContact()
 
       // transform contact positions into relative frame
       // set contact positions
-      gazebo::math::Vector3 position = frame_rot.RotateVectorReverse(
-          math::Vector3(contact.position(j).x(),
-                        contact.position(j).y(),
-                        contact.position(j).z()) - frame_pos);
+      ignition::math::Vector3d position = frame_rot.RotateVectorReverse(
+          ignition::math::Vector3d(contact.position(j).x(),
+                                   contact.position(j).y(),
+                                   contact.position(j).z()) - frame_pos);
       geometry_msgs::Vector3 contact_position;
-      contact_position.x = position.x;
-      contact_position.y = position.y;
-      contact_position.z = position.z;
+      contact_position.x = position.X();
+      contact_position.y = position.Y();
+      contact_position.z = position.Z();
       state.contact_positions.push_back(contact_position);
 
       // rotate normal into user specified frame.
       // frame_rot is identity if world is used.
-      math::Vector3 normal = frame_rot.RotateVectorReverse(
-          math::Vector3(contact.normal(j).x(),
-                        contact.normal(j).y(),
-                        contact.normal(j).z()));
+      ignition::math::Vector3d normal = frame_rot.RotateVectorReverse(
+          ignition::math::Vector3d(contact.normal(j).x(),
+                                   contact.normal(j).y(),
+                                   contact.normal(j).z()));
       // set contact normals
       geometry_msgs::Vector3 contact_normal;
-      contact_normal.x = normal.x;
-      contact_normal.y = normal.y;
-      contact_normal.z = normal.z;
+      contact_normal.x = normal.X();
+      contact_normal.y = normal.Y();
+      contact_normal.z = normal.Z();
       state.contact_normals.push_back(contact_normal);
 
       // set contact depth, interpenetration

--- a/gazebo_plugins/src/gazebo_ros_bumper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_bumper.cpp
@@ -32,9 +32,9 @@
 #include <sdf/Param.hh>
 #include <gazebo/common/Exception.hh>
 #include <gazebo/sensors/SensorTypes.hh>
-#include <gazebo/math/Pose.hh>
-#include <gazebo/math/Quaternion.hh>
-#include <gazebo/math/Vector3.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Quaternion.hh>
+#include <ignition/math/Vector3.hh>
 
 #include <tf/tf.h>
 

--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -473,7 +473,7 @@ void GazeboRosCameraUtils::Init()
   else
   {
     // check against float precision
-    if (!gazebo::math::equal(this->focal_length_, computed_focal_length))
+    if (!ignition::math::equal(this->focal_length_, computed_focal_length))
     {
       ROS_WARN_NAMED("camera_utils", "The <focal_length>[%f] you have provided for camera_ [%s]"
                " is inconsistent with specified image_width [%d] and"

--- a/gazebo_plugins/src/gazebo_ros_hand_of_god.cpp
+++ b/gazebo_plugins/src/gazebo_ros_hand_of_god.cpp
@@ -149,22 +149,24 @@ namespace gazebo
     // Convert TF transform to Gazebo Pose
     const geometry_msgs::Vector3 &p = hog_desired_tform.transform.translation;
     const geometry_msgs::Quaternion &q = hog_desired_tform.transform.rotation;
-    gazebo::math::Pose hog_desired(
-        gazebo::math::Vector3(p.x, p.y, p.z),
-        gazebo::math::Quaternion(q.w, q.x, q.y, q.z));
+    ignition::math::Pose3d hog_desired(
+        ignition::math::Vector3d(p.x, p.y, p.z),
+        ignition::math::Quaterniond(q.w, q.x, q.y, q.z));
 
     // Relative transform from actual to desired pose
-    gazebo::math::Pose world_pose = floating_link_->GetDirtyPose();
-    gazebo::math::Vector3 err_pos = hog_desired.pos - world_pose.pos;
+    ignition::math::Pose3d world_pose = floating_link_->GetDirtyPose().Ign();
+    ignition::math::Vector3d err_pos = hog_desired.Pos() - world_pose.Pos();
     // Get exponential coordinates for rotation
-    gazebo::math::Quaternion err_rot =  (world_pose.rot.GetAsMatrix4().Inverse() * hog_desired.rot.GetAsMatrix4()).GetRotation();
-    gazebo::math::Quaternion not_a_quaternion = err_rot.GetLog();
+    ignition::math::Quaterniond err_rot =  (ignition::math::Matrix4d(world_pose.Rot()).Inverse()
+                                          * ignition::math::Matrix4d(hog_desired.Rot())).Rotation();
+    ignition::math::Quaterniond not_a_quaternion = err_rot.Log();
 
     floating_link_->AddForce(
-        kl_ * err_pos - cl_ * floating_link_->GetWorldLinearVel());
+        kl_ * err_pos - cl_ * floating_link_->GetWorldLinearVel().Ign());
 
     floating_link_->AddRelativeTorque(
-        ka_ * gazebo::math::Vector3(not_a_quaternion.x, not_a_quaternion.y, not_a_quaternion.z) - ca_ * floating_link_->GetRelativeAngularVel());
+        ka_ * ignition::math::Vector3d(not_a_quaternion.X(), not_a_quaternion.Y(), not_a_quaternion.Z())
+      - ca_ * floating_link_->GetRelativeAngularVel().Ign());
 
     // Convert actual pose to TransformStamped message
     geometry_msgs::TransformStamped hog_actual_tform;
@@ -174,14 +176,14 @@ namespace gazebo
 
     hog_actual_tform.child_frame_id = frame_id_ + "_actual";
 
-    hog_actual_tform.transform.translation.x = world_pose.pos.x;
-    hog_actual_tform.transform.translation.y = world_pose.pos.y;
-    hog_actual_tform.transform.translation.z = world_pose.pos.z;
+    hog_actual_tform.transform.translation.x = world_pose.Pos().X();
+    hog_actual_tform.transform.translation.y = world_pose.Pos().Y();
+    hog_actual_tform.transform.translation.z = world_pose.Pos().Z();
 
-    hog_actual_tform.transform.rotation.w = world_pose.rot.w;
-    hog_actual_tform.transform.rotation.x = world_pose.rot.x;
-    hog_actual_tform.transform.rotation.y = world_pose.rot.y;
-    hog_actual_tform.transform.rotation.z = world_pose.rot.z;
+    hog_actual_tform.transform.rotation.w = world_pose.Rot().W();
+    hog_actual_tform.transform.rotation.x = world_pose.Rot().X();
+    hog_actual_tform.transform.rotation.y = world_pose.Rot().Y();
+    hog_actual_tform.transform.rotation.z = world_pose.Rot().Z();
 
     tf_broadcaster_->sendTransform(hog_actual_tform);
   }

--- a/gazebo_plugins/src/gazebo_ros_skid_steer_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_skid_steer_drive.cpp
@@ -42,7 +42,8 @@
 
 #include <gazebo_plugins/gazebo_ros_skid_steer_drive.h>
 
-#include <gazebo/math/gzmath.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Vector3.hh>
 #include <sdf/sdf.hh>
 
 #include <ros/ros.h>
@@ -404,10 +405,10 @@ namespace gazebo {
 
     // TODO create some non-perfect odometry!
     // getting data for base_footprint to odom transform
-    math::Pose pose = this->parent->GetWorldPose();
+    ignition::math::Pose3d pose = this->parent->GetWorldPose().Ign();
 
-    tf::Quaternion qt(pose.rot.x, pose.rot.y, pose.rot.z, pose.rot.w);
-    tf::Vector3 vt(pose.pos.x, pose.pos.y, pose.pos.z);
+    tf::Quaternion qt(pose.Rot().X(), pose.Rot().Y(), pose.Rot().Z(), pose.Rot().W());
+    tf::Vector3 vt(pose.Pos().X(), pose.Pos().Y(), pose.Pos().Z());
 
     tf::Transform base_footprint_to_odom(qt, vt);
     if (this->broadcast_tf_) {
@@ -419,13 +420,13 @@ namespace gazebo {
     }
 
     // publish odom topic
-    odom_.pose.pose.position.x = pose.pos.x;
-    odom_.pose.pose.position.y = pose.pos.y;
+    odom_.pose.pose.position.x = pose.Pos().X();
+    odom_.pose.pose.position.y = pose.Pos().Y();
 
-    odom_.pose.pose.orientation.x = pose.rot.x;
-    odom_.pose.pose.orientation.y = pose.rot.y;
-    odom_.pose.pose.orientation.z = pose.rot.z;
-    odom_.pose.pose.orientation.w = pose.rot.w;
+    odom_.pose.pose.orientation.x = pose.Rot().X();
+    odom_.pose.pose.orientation.y = pose.Rot().Y();
+    odom_.pose.pose.orientation.z = pose.Rot().Z();
+    odom_.pose.pose.orientation.w = pose.Rot().W();
     odom_.pose.covariance[0] = this->covariance_x_;
     odom_.pose.covariance[7] = this->covariance_y_;
     odom_.pose.covariance[14] = 1000000000000.0;
@@ -434,14 +435,14 @@ namespace gazebo {
     odom_.pose.covariance[35] = this->covariance_yaw_;
 
     // get velocity in /odom frame
-    math::Vector3 linear;
-    linear = this->parent->GetWorldLinearVel();
-    odom_.twist.twist.angular.z = this->parent->GetWorldAngularVel().z;
+    ignition::math::Vector3d linear;
+    linear = this->parent->GetWorldLinearVel().Ign();
+    odom_.twist.twist.angular.z = this->parent->GetWorldAngularVel().Ign().Z();
 
     // convert velocity to child_frame_id (aka base_footprint)
-    float yaw = pose.rot.GetYaw();
-    odom_.twist.twist.linear.x = cosf(yaw) * linear.x + sinf(yaw) * linear.y;
-    odom_.twist.twist.linear.y = cosf(yaw) * linear.y - sinf(yaw) * linear.x;
+    float yaw = pose.Rot().Yaw();
+    odom_.twist.twist.linear.x = cosf(yaw) * linear.X() + sinf(yaw) * linear.Y();
+    odom_.twist.twist.linear.y = cosf(yaw) * linear.Y() - sinf(yaw) * linear.X();
     odom_.twist.covariance[0] = this->covariance_x_;
     odom_.twist.covariance[7] = this->covariance_y_;
     odom_.twist.covariance[14] = 1000000000000.0;

--- a/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
@@ -44,7 +44,8 @@
 
 #include <gazebo_plugins/gazebo_ros_tricycle_drive.h>
 
-#include <gazebo/math/gzmath.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Vector3.hh>
 #include <sdf/sdf.hh>
 
 #include <ros/ros.h>
@@ -108,13 +109,8 @@ void GazeboRosTricycleDrive::Load ( physics::ModelPtr _parent, sdf::ElementPtr _
     odomOptions["world"] = WORLD;
     gazebo_ros_->getParameter<OdomSource> ( odom_source_, "odometrySource", odomOptions, WORLD );
 
-#if GAZEBO_MAJOR_VERSION > 2
     joint_wheel_actuated_->SetParam ( "fmax", 0, wheel_torque_ );
     joint_steering_->SetParam ( "fmax", 0, wheel_torque_ );
-#else
-    joint_wheel_actuated_->SetMaxForce ( 0, wheel_torque_ );
-    joint_steering_->SetMaxForce ( 0, wheel_torque_ );
-#endif
 
 
     // Initialize update rate stuff
@@ -189,10 +185,10 @@ void GazeboRosTricycleDrive::publishWheelTF()
         std::string frame = gazebo_ros_->resolveTF ( joints[i]->GetName() );
         std::string parent_frame = gazebo_ros_->resolveTF ( joints[i]->GetParent()->GetName() );
 
-        math::Pose pose = joints[i]->GetChild()->GetRelativePose();
+        ignition::math::Pose3d pose = joints[i]->GetChild()->GetRelativePose().Ign();
 
-        tf::Quaternion qt ( pose.rot.x, pose.rot.y, pose.rot.z, pose.rot.w );
-        tf::Vector3 vt ( pose.pos.x, pose.pos.y, pose.pos.z );
+        tf::Quaternion qt ( pose.Rot().X(), pose.Rot().Y(), pose.Rot().Z(), pose.Rot().W() );
+        tf::Vector3 vt ( pose.Pos().X(), pose.Pos().Y(), pose.Pos().Z() );
 
         tf::Transform transform ( qt, vt );
         transform_broadcaster_->sendTransform ( tf::StampedTransform ( transform, current_time, parent_frame, frame ) );
@@ -248,11 +244,7 @@ void GazeboRosTricycleDrive::motorController ( double target_speed, double targe
         }
       }
     }
-#if GAZEBO_MAJOR_VERSION > 2
     joint_wheel_actuated_->SetParam ( "vel", 0, applied_speed );
-#else
-    joint_wheel_actuated_->SetVelocity ( 0, applied_speed );
-#endif
 
     double current_angle = joint_steering_->GetAngle ( 0 ).Radian();
 
@@ -284,11 +276,7 @@ void GazeboRosTricycleDrive::motorController ( double target_speed, double targe
       }
 
       // use speed control, not recommended, for better dynamics use force control
-#if GAZEBO_MAJOR_VERSION > 2
       joint_steering_->SetParam ( "vel", 0, applied_steering_speed );
-#else
-      joint_steering_->SetVelocity ( 0, applied_steering_speed );
-#endif
     }
     else {
       // steering_speed_ is zero, use position control.
@@ -309,11 +297,7 @@ void GazeboRosTricycleDrive::motorController ( double target_speed, double targe
       {
         applied_angle = target_angle;
       }
-#if GAZEBO_MAJOR_VERSION >= 4
       joint_steering_->SetPosition(0, applied_angle);
-#else
-      joint_steering_->SetAngle(0, math::Angle(applied_angle));
-#endif
     }
     //ROS_INFO_NAMED("tricycle_drive", "target: [%3.2f, %3.2f], current: [%3.2f, %3.2f], applied: [%3.2f, %3.2f/%3.2f] ",
     //            target_speed, target_angle, current_speed, current_angle, applied_speed, applied_angle, applied_steering_speed );
@@ -409,9 +393,9 @@ void GazeboRosTricycleDrive::publishOdometry ( double step_time )
     }
     if ( odom_source_ == WORLD ) {
         // getting data form gazebo world
-        math::Pose pose = parent->GetWorldPose();
-        qt = tf::Quaternion ( pose.rot.x, pose.rot.y, pose.rot.z, pose.rot.w );
-        vt = tf::Vector3 ( pose.pos.x, pose.pos.y, pose.pos.z );
+        ignition::math::Pose3d pose = parent->GetWorldPose().Ign();
+        qt = tf::Quaternion ( pose.Rot().X(), pose.Rot().Y(), pose.Rot().Z(), pose.Rot().W() );
+        vt = tf::Vector3 ( pose.Pos().X(), pose.Pos().Y(), pose.Pos().Z() );
 
         odom_.pose.pose.position.x = vt.x();
         odom_.pose.pose.position.y = vt.y();
@@ -423,14 +407,14 @@ void GazeboRosTricycleDrive::publishOdometry ( double step_time )
         odom_.pose.pose.orientation.w = qt.w();
 
         // get velocity in /odom frame
-        math::Vector3 linear;
-        linear = parent->GetWorldLinearVel();
-        odom_.twist.twist.angular.z = parent->GetWorldAngularVel().z;
+        ignition::math::Vector3d linear;
+        linear = parent->GetWorldLinearVel().Ign();
+        odom_.twist.twist.angular.z = parent->GetWorldAngularVel().Ign().Z();
 
         // convert velocity to child_frame_id (aka base_footprint)
-        float yaw = pose.rot.GetYaw();
-        odom_.twist.twist.linear.x = cosf ( yaw ) * linear.x + sinf ( yaw ) * linear.y;
-        odom_.twist.twist.linear.y = cosf ( yaw ) * linear.y - sinf ( yaw ) * linear.x;
+        float yaw = pose.Rot().Yaw();
+        odom_.twist.twist.linear.x = cosf ( yaw ) * linear.X() + sinf ( yaw ) * linear.Y();
+        odom_.twist.twist.linear.y = cosf ( yaw ) * linear.Y() - sinf ( yaw ) * linear.X();
     }
 
     tf::Transform base_footprint_to_odom ( qt, vt );

--- a/gazebo_plugins/test/pub_joint_trajectory_test.cpp
+++ b/gazebo_plugins/test/pub_joint_trajectory_test.cpp
@@ -1,7 +1,7 @@
 #include <ros/ros.h>
 #include <trajectory_msgs/JointTrajectory.h>
 #include <gazebo_msgs/SetJointTrajectory.h>
-#include <gazebo/math/Quaternion.hh>
+#include <ignition/math/Quaternion.hh>
 #include <math.h>
 
 int main(int argc, char** argv)
@@ -62,15 +62,15 @@ int main(int argc, char** argv)
   sjt.request.joint_trajectory = jt;
   sjt.request.disable_physics_updates = false;
 
-  gazebo::math::Quaternion r(0, 0, M_PI);
+  ignition::math::Quaterniond r(0, 0, M_PI);
   geometry_msgs::Pose p;
   p.position.x = 0;
   p.position.y = 0;
   p.position.z = 0;
-  p.orientation.x = r.x;
-  p.orientation.y = r.y;
-  p.orientation.z = r.z;
-  p.orientation.w = r.w;
+  p.orientation.x = r.X();
+  p.orientation.y = r.Y();
+  p.orientation.z = r.Z();
+  p.orientation.w = r.W();
   sjt.request.model_pose = p;
   sjt.request.set_model_pose = true;
 


### PR DESCRIPTION
Convert local more local variables in gazebo_plugins to use ignition math and remove a few outdated header guards in tricycle plugin.