### PR TITLE
Fix gazebo8 warnings part 4: convert remaining local variables in plugins to ign-math (lunar-devel)

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_block_laser.cpp
+++ b/gazebo_plugins/src/gazebo_ros_block_laser.cpp
@@ -232,13 +232,8 @@ void GazeboRosBlockLaser::PutLaserData(common::Time &_updateTime)
 
   this->parent_ray_sensor_->SetActive(false);
 
-#if GAZEBO_MAJOR_VERSION >= 6
   auto maxAngle = this->parent_ray_sensor_->AngleMax();
   auto minAngle = this->parent_ray_sensor_->AngleMin();
-#else
-  math::Angle maxAngle = this->parent_ray_sensor_->GetAngleMax();
-  math::Angle minAngle = this->parent_ray_sensor_->GetAngleMin();
-#endif
 
   double maxRange = this->parent_ray_sensor_->RangeMax();
   double minRange = this->parent_ray_sensor_->RangeMin();
@@ -247,13 +242,8 @@ void GazeboRosBlockLaser::PutLaserData(common::Time &_updateTime)
 
   int verticalRayCount = this->parent_ray_sensor_->VerticalRayCount();
   int verticalRangeCount = this->parent_ray_sensor_->VerticalRangeCount();
-#if GAZEBO_MAJOR_VERSION >= 6
   auto verticalMaxAngle = this->parent_ray_sensor_->VerticalAngleMax();
   auto verticalMinAngle = this->parent_ray_sensor_->VerticalAngleMin();
-#else
-  math::Angle verticalMaxAngle = this->parent_ray_sensor_->GetVerticalAngleMax();
-  math::Angle verticalMinAngle = this->parent_ray_sensor_->GetVerticalAngleMin();
-#endif
 
   double yDiff = maxAngle.Radian() - minAngle.Radian();
   double pDiff = verticalMaxAngle.Radian() - verticalMinAngle.Radian();
@@ -405,9 +395,9 @@ void GazeboRosBlockLaser::OnStats( const boost::shared_ptr<msgs::WorldStatistics
 {
   this->sim_time_  = msgs::Convert( _msg->sim_time() );
 
-  math::Pose pose;
-  pose.pos.x = 0.5*sin(0.01*this->sim_time_.Double());
-  gzdbg << "plugin simTime [" << this->sim_time_.Double() << "] update pose [" << pose.pos.x << "]\n";
+  ignition::math::Pose3d pose;
+  pose.Pos().X() = 0.5*sin(0.01*this->sim_time_.Double());
+  gzdbg << "plugin simTime [" << this->sim_time_.Double() << "] update pose [" << pose.Pos().X() << "]\n";
 }
 
 

--- a/gazebo_plugins/src/gazebo_ros_f3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_f3d.cpp
@@ -149,14 +149,14 @@ void GazeboRosF3D::UpdateChild()
   if (this->f3d_connect_count_ == 0)
     return;
 
-  math::Vector3 torque;
-  math::Vector3 force;
+  ignition::math::Vector3d torque;
+  ignition::math::Vector3d force;
 
   // get force on body
-  force = this->link_->GetWorldForce();
+  force = this->link_->GetWorldForce().Ign();
 
   // get torque on body
-  torque = this->link_->GetWorldTorque();
+  torque = this->link_->GetWorldTorque().Ign();
 
   this->lock_.lock();
   // copy data into wrench message
@@ -164,12 +164,12 @@ void GazeboRosF3D::UpdateChild()
   this->wrench_msg_.header.stamp.sec = (this->world_->GetSimTime()).sec;
   this->wrench_msg_.header.stamp.nsec = (this->world_->GetSimTime()).nsec;
 
-  this->wrench_msg_.wrench.force.x    = force.x;
-  this->wrench_msg_.wrench.force.y    = force.y;
-  this->wrench_msg_.wrench.force.z    = force.z;
-  this->wrench_msg_.wrench.torque.x   = torque.x;
-  this->wrench_msg_.wrench.torque.y   = torque.y;
-  this->wrench_msg_.wrench.torque.z   = torque.z;
+  this->wrench_msg_.wrench.force.x    = force.X();
+  this->wrench_msg_.wrench.force.y    = force.Y();
+  this->wrench_msg_.wrench.force.z    = force.Z();
+  this->wrench_msg_.wrench.torque.x   = torque.X();
+  this->wrench_msg_.wrench.torque.y   = torque.Y();
+  this->wrench_msg_.wrench.torque.z   = torque.Z();
 
   this->pub_.publish(this->wrench_msg_);
   this->lock_.unlock();

--- a/gazebo_plugins/src/gazebo_ros_force.cpp
+++ b/gazebo_plugins/src/gazebo_ros_force.cpp
@@ -137,8 +137,8 @@ void GazeboRosForce::UpdateObjectForce(const geometry_msgs::Wrench::ConstPtr& _m
 void GazeboRosForce::UpdateChild()
 {
   this->lock_.lock();
-  math::Vector3 force(this->wrench_msg_.force.x,this->wrench_msg_.force.y,this->wrench_msg_.force.z);
-  math::Vector3 torque(this->wrench_msg_.torque.x,this->wrench_msg_.torque.y,this->wrench_msg_.torque.z);
+  ignition::math::Vector3d force(this->wrench_msg_.force.x,this->wrench_msg_.force.y,this->wrench_msg_.force.z);
+  ignition::math::Vector3d torque(this->wrench_msg_.torque.x,this->wrench_msg_.torque.y,this->wrench_msg_.torque.z);
   this->link_->AddForce(force);
   this->link_->AddTorque(torque);
   this->lock_.unlock();

--- a/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
@@ -177,8 +177,13 @@ void GazeboRosFT::UpdateChild()
   // The wrench is reported in the CHILD <frame>
   // The <measure_direction> is child_to_parent
   wrench = this->joint_->GetForceTorque(0);
+#if GAZEBO_MAJOR_VERSION >= 8
   force = wrench.body2Force;
   torque = wrench.body2Torque;
+#else
+  force = wrench.body2Force.Ign();
+  torque = wrench.body2Torque.Ign();
+#endif
 
 
   this->lock_.lock();

--- a/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
@@ -168,8 +168,8 @@ void GazeboRosFT::UpdateChild()
     return;
 
   physics::JointWrench wrench;
-  math::Vector3 torque;
-  math::Vector3 force;
+  ignition::math::Vector3d torque;
+  ignition::math::Vector3d force;
 
   // FIXME: Should include options for diferent frames and measure directions
   // E.g: https://bitbucket.org/osrf/gazebo/raw/default/gazebo/sensors/ForceTorqueSensor.hh
@@ -187,12 +187,12 @@ void GazeboRosFT::UpdateChild()
   this->wrench_msg_.header.stamp.sec = (this->world_->GetSimTime()).sec;
   this->wrench_msg_.header.stamp.nsec = (this->world_->GetSimTime()).nsec;
 
-  this->wrench_msg_.wrench.force.x = force.x + this->GaussianKernel(0, this->gaussian_noise_);
-  this->wrench_msg_.wrench.force.y = force.y + this->GaussianKernel(0, this->gaussian_noise_);
-  this->wrench_msg_.wrench.force.z = force.z + this->GaussianKernel(0, this->gaussian_noise_);
-  this->wrench_msg_.wrench.torque.x = torque.x + this->GaussianKernel(0, this->gaussian_noise_);
-  this->wrench_msg_.wrench.torque.y = torque.y + this->GaussianKernel(0, this->gaussian_noise_);
-  this->wrench_msg_.wrench.torque.z = torque.z + this->GaussianKernel(0, this->gaussian_noise_);
+  this->wrench_msg_.wrench.force.x = force.X() + this->GaussianKernel(0, this->gaussian_noise_);
+  this->wrench_msg_.wrench.force.y = force.Y() + this->GaussianKernel(0, this->gaussian_noise_);
+  this->wrench_msg_.wrench.force.z = force.Z() + this->GaussianKernel(0, this->gaussian_noise_);
+  this->wrench_msg_.wrench.torque.x = torque.X() + this->GaussianKernel(0, this->gaussian_noise_);
+  this->wrench_msg_.wrench.torque.y = torque.Y() + this->GaussianKernel(0, this->gaussian_noise_);
+  this->wrench_msg_.wrench.torque.z = torque.Z() + this->GaussianKernel(0, this->gaussian_noise_);
 
   this->pub_.publish(this->wrench_msg_);
   this->lock_.unlock();

--- a/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
@@ -66,7 +66,7 @@ void GazeboRosJointPoseTrajectory::Load(physics::ModelPtr _model,
   this->sdf = _sdf;
   this->world_ = this->model_->GetWorld();
 
-  // this->world_->GetPhysicsEngine()->SetGravity(ignition::math::Vector3d(0, 0, 0));
+  // this->world_->SetGravity(ignition::math::Vector3d(0, 0, 0));
 
   // load parameters
   this->robot_namespace_ = "";

--- a/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
@@ -66,7 +66,7 @@ void GazeboRosJointPoseTrajectory::Load(physics::ModelPtr _model,
   this->sdf = _sdf;
   this->world_ = this->model_->GetWorld();
 
-  // this->world_->GetPhysicsEngine()->SetGravity(math::Vector3(0, 0, 0));
+  // this->world_->GetPhysicsEngine()->SetGravity(ignition::math::Vector3d(0, 0, 0));
 
   // load parameters
   this->robot_namespace_ = "";
@@ -325,10 +325,10 @@ void GazeboRosJointPoseTrajectory::UpdateStates()
           cur_time.Double(), this->trajectory_index, this->points_.size());
 
         // get reference link pose before updates
-        math::Pose reference_pose = this->model_->GetWorldPose();
+        ignition::math::Pose3d reference_pose = this->model_->GetWorldPose().Ign();
         if (this->reference_link_)
         {
-          reference_pose = this->reference_link_->GetWorldPose();
+          reference_pose = this->reference_link_->GetWorldPose().Ign();
         }
 
         // trajectory roll-out based on time:
@@ -342,11 +342,7 @@ void GazeboRosJointPoseTrajectory::UpdateStates()
             // this is not the most efficient way to set things
             if (this->joints_[i])
             {
-#if GAZEBO_MAJOR_VERSION >= 4
               this->joints_[i]->SetPosition(0,
-#else
-              this->joints_[i]->SetAngle(0,
-#endif
                 this->points_[this->trajectory_index].positions[i]);
             }
           }

--- a/gazebo_plugins/src/gazebo_ros_joint_state_publisher.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_state_publisher.cpp
@@ -124,7 +124,7 @@ void GazeboRosJointStatePublisher::publishJointStates() {
 
     for ( int i = 0; i < joints_.size(); i++ ) {
         physics::JointPtr joint = joints_[i];
-        math::Angle angle = joint->GetAngle ( 0 );
+        ignition::math::Angle angle = joint->GetAngle ( 0 ).Ign();
         joint_state_.name[i] = joint->GetName();
         joint_state_.position[i] = angle.Radian () ;
     }

--- a/gazebo_plugins/src/gazebo_ros_joint_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_trajectory.cpp
@@ -67,7 +67,7 @@ void GazeboRosJointTrajectory::Load(physics::ModelPtr _model,
   this->sdf = _sdf;
   this->world_ = this->model_->GetWorld();
 
-  // this->world_->GetPhysicsEngine()->SetGravity(math::Vector3(0, 0, 0));
+  // this->world_->GetPhysicsEngine()->SetGravity(ignition::math::Vector3d(0, 0, 0));
 
   // load parameters
   this->robot_namespace_ = "";
@@ -327,10 +327,10 @@ void GazeboRosJointTrajectory::UpdateStates()
           cur_time.Double(), this->trajectory_index, this->points_.size());
 
         // get reference link pose before updates
-        math::Pose reference_pose = this->model_->GetWorldPose();
+        ignition::math::Pose3d reference_pose = this->model_->GetWorldPose().Ign();
         if (this->reference_link_)
         {
-          reference_pose = this->reference_link_->GetWorldPose();
+          reference_pose = this->reference_link_->GetWorldPose().Ign();
         }
 
         // trajectory roll-out based on time:
@@ -344,11 +344,7 @@ void GazeboRosJointTrajectory::UpdateStates()
             // this is not the most efficient way to set things
             if (this->joints_[i])
             {
-#if GAZEBO_MAJOR_VERSION >= 4
               this->joints_[i]->SetPosition(0,
-#else
-              this->joints_[i]->SetAngle(0,
-#endif
                 this->points_[this->trajectory_index].positions[i]);
             }
           }

--- a/gazebo_plugins/src/gazebo_ros_joint_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_trajectory.cpp
@@ -67,7 +67,7 @@ void GazeboRosJointTrajectory::Load(physics::ModelPtr _model,
   this->sdf = _sdf;
   this->world_ = this->model_->GetWorld();
 
-  // this->world_->GetPhysicsEngine()->SetGravity(ignition::math::Vector3d(0, 0, 0));
+  // this->world_->SetGravity(ignition::math::Vector3d(0, 0, 0));
 
   // load parameters
   this->robot_namespace_ = "";

--- a/gazebo_plugins/src/gazebo_ros_prosilica.cpp
+++ b/gazebo_plugins/src/gazebo_ros_prosilica.cpp
@@ -333,9 +333,9 @@ void GazeboRosProsilica::OnStats( const boost::shared_ptr<msgs::WorldStatistics 
 {
   this->simTime  = msgs::Convert( _msg->sim_time() );
 
-  math::Pose pose;
-  pose.pos.x = 0.5*sin(0.01*this->simTime.Double());
-  gzdbg << "plugin simTime [" << this->simTime.Double() << "] update pose [" << pose.pos.x << "]\n";
+  ignition::math::Pose3d pose;
+  pose.Pos().X() = 0.5*sin(0.01*this->simTime.Double());
+  gzdbg << "plugin simTime [" << this->simTime.Double() << "] update pose [" << pose.Pos().X() << "]\n";
 }
 */
 

--- a/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
@@ -179,7 +179,7 @@ void GazeboRosVacuumGripper::UpdateChild()
   }
   // apply force
   lock_.lock();
-  math::Pose parent_pose = link_->GetWorldPose();
+  ignition::math::Pose3d parent_pose = link_->GetWorldPose().Ign();
   physics::Model_V models = world_->GetModels();
   for (size_t i = 0; i < models.size(); i++) {
     if (models[i]->GetName() == link_->GetName() ||
@@ -189,9 +189,9 @@ void GazeboRosVacuumGripper::UpdateChild()
     }
     physics::Link_V links = models[i]->GetLinks();
     for (size_t j = 0; j < links.size(); j++) {
-      math::Pose link_pose = links[j]->GetWorldPose();
-      math::Pose diff = parent_pose - link_pose;
-      double norm = diff.pos.GetLength();
+      ignition::math::Pose3d link_pose = links[j]->GetWorldPose().Ign();
+      ignition::math::Pose3d diff = parent_pose - link_pose;
+      double norm = diff.Pos().Length();
       if (norm < 0.05) {
         links[j]->SetLinearAccel(link_->GetWorldLinearAccel());
         links[j]->SetAngularAccel(link_->GetWorldAngularAccel());
@@ -201,13 +201,13 @@ void GazeboRosVacuumGripper::UpdateChild()
         if (norm < 0.01) {
           // apply friction like force
           // TODO(unknown): should apply friction actually
-          link_pose.Set(parent_pose.pos, link_pose.rot);
+          link_pose.Set(parent_pose.Pos(), link_pose.Rot());
           links[j]->SetWorldPose(link_pose);
         }
         if (norm_force > 20) {
           norm_force = 20;  // max_force
         }
-        math::Vector3 force = norm_force * diff.pos.Normalize();
+        ignition::math::Vector3d force = norm_force * diff.Pos().Normalize();
         links[j]->AddForce(force);
         grasping_msg.data = true;
       }

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -1265,9 +1265,9 @@ bool GazeboRosApiPlugin::getPhysicsProperties(gazebo_msgs::GetPhysicsProperties:
   res.pause = world_->IsPaused();
   res.max_update_rate = world_->GetPhysicsEngine()->GetRealTimeUpdateRate();
   ignition::math::Vector3d gravity = world_->Gravity();
-  res.gravity.x = gravity.x;
-  res.gravity.y = gravity.y;
-  res.gravity.z = gravity.z;
+  res.gravity.x = gravity.X();
+  res.gravity.y = gravity.Y();
+  res.gravity.z = gravity.Z();
 
   // stuff only works in ODE right now
   if (world_->GetPhysicsEngine()->GetType() == "ode")

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -1220,18 +1220,17 @@ bool GazeboRosApiPlugin::setPhysicsProperties(gazebo_msgs::SetPhysicsProperties:
   // pause simulation if requested
   bool is_paused = world_->IsPaused();
   world_->SetPaused(true);
+  world_->SetGravity(ignition::math::Vector3d(req.gravity.x,req.gravity.y,req.gravity.z));
 
   // supported updates
   gazebo::physics::PhysicsEnginePtr pe = (world_->GetPhysicsEngine());
   pe->SetMaxStepSize(req.time_step);
   pe->SetRealTimeUpdateRate(req.max_update_rate);
-  pe->SetGravity(gazebo::math::Vector3(req.gravity.x,req.gravity.y,req.gravity.z));
 
   if (world_->GetPhysicsEngine()->GetType() == "ode")
   {
     // stuff only works in ODE right now
     pe->SetAutoDisableFlag(req.ode_config.auto_disable_bodies);
-#if GAZEBO_MAJOR_VERSION >= 3
     pe->SetParam("precon_iters", req.ode_config.sor_pgs_precon_iters);
     pe->SetParam("iters", req.ode_config.sor_pgs_iters);
     pe->SetParam("sor", req.ode_config.sor_pgs_w);
@@ -1242,16 +1241,6 @@ bool GazeboRosApiPlugin::setPhysicsProperties(gazebo_msgs::SetPhysicsProperties:
     pe->SetParam("contact_max_correcting_vel",
         req.ode_config.contact_max_correcting_vel);
     pe->SetParam("max_contacts", req.ode_config.max_contacts);
-#else
-    pe->SetSORPGSPreconIters(req.ode_config.sor_pgs_precon_iters);
-    pe->SetSORPGSIters(req.ode_config.sor_pgs_iters);
-    pe->SetSORPGSW(req.ode_config.sor_pgs_w);
-    pe->SetWorldCFM(req.ode_config.cfm);
-    pe->SetWorldERP(req.ode_config.erp);
-    pe->SetContactSurfaceLayer(req.ode_config.contact_surface_layer);
-    pe->SetContactMaxCorrectingVel(req.ode_config.contact_max_correcting_vel);
-    pe->SetMaxContacts(req.ode_config.max_contacts);
-#endif
 
     world_->SetPaused(is_paused);
 
@@ -1275,7 +1264,7 @@ bool GazeboRosApiPlugin::getPhysicsProperties(gazebo_msgs::GetPhysicsProperties:
   res.time_step = world_->GetPhysicsEngine()->GetMaxStepSize();
   res.pause = world_->IsPaused();
   res.max_update_rate = world_->GetPhysicsEngine()->GetRealTimeUpdateRate();
-  gazebo::math::Vector3 gravity = world_->GetPhysicsEngine()->GetGravity();
+  ignition::math::Vector3d gravity = world_->Gravity();
   res.gravity.x = gravity.x;
   res.gravity.y = gravity.y;
   res.gravity.z = gravity.z;
@@ -1285,7 +1274,6 @@ bool GazeboRosApiPlugin::getPhysicsProperties(gazebo_msgs::GetPhysicsProperties:
   {
     res.ode_config.auto_disable_bodies =
       world_->GetPhysicsEngine()->GetAutoDisableFlag();
-#if GAZEBO_MAJOR_VERSION >= 3
     res.ode_config.sor_pgs_precon_iters = boost::any_cast<int>(
       world_->GetPhysicsEngine()->GetParam("precon_iters"));
     res.ode_config.sor_pgs_iters = boost::any_cast<int>(
@@ -1302,16 +1290,6 @@ bool GazeboRosApiPlugin::getPhysicsProperties(gazebo_msgs::GetPhysicsProperties:
         world_->GetPhysicsEngine()->GetParam("erp"));
     res.ode_config.max_contacts = boost::any_cast<int>(
       world_->GetPhysicsEngine()->GetParam("max_contacts"));
-#else
-    res.ode_config.sor_pgs_precon_iters = world_->GetPhysicsEngine()->GetSORPGSPreconIters();
-    res.ode_config.sor_pgs_iters = world_->GetPhysicsEngine()->GetSORPGSIters();
-    res.ode_config.sor_pgs_w = world_->GetPhysicsEngine()->GetSORPGSW();
-    res.ode_config.contact_surface_layer = world_->GetPhysicsEngine()->GetContactSurfaceLayer();
-    res.ode_config.contact_max_correcting_vel = world_->GetPhysicsEngine()->GetContactMaxCorrectingVel();
-    res.ode_config.cfm = world_->GetPhysicsEngine()->GetWorldCFM();
-    res.ode_config.erp = world_->GetPhysicsEngine()->GetWorldERP();
-    res.ode_config.max_contacts = world_->GetPhysicsEngine()->GetMaxContacts();
-#endif
 
     res.success = true;
     res.status_message = "GetPhysicsProperties: got properties";
@@ -1347,7 +1325,6 @@ bool GazeboRosApiPlugin::setJointProperties(gazebo_msgs::SetJointProperties::Req
   {
     for(unsigned int i=0;i< req.ode_joint_config.damping.size();i++)
       joint->SetDamping(i,req.ode_joint_config.damping[i]);
-#if GAZEBO_MAJOR_VERSION >= 4
     for(unsigned int i=0;i< req.ode_joint_config.hiStop.size();i++)
       joint->SetParam("hi_stop",i,req.ode_joint_config.hiStop[i]);
     for(unsigned int i=0;i< req.ode_joint_config.loStop.size();i++)
@@ -1366,26 +1343,6 @@ bool GazeboRosApiPlugin::setJointProperties(gazebo_msgs::SetJointProperties::Req
       joint->SetParam("fmax",i,req.ode_joint_config.fmax[i]);
     for(unsigned int i=0;i< req.ode_joint_config.vel.size();i++)
       joint->SetParam("vel",i,req.ode_joint_config.vel[i]);
-#else
-    for(unsigned int i=0;i< req.ode_joint_config.hiStop.size();i++)
-      joint->SetAttribute("hi_stop",i,req.ode_joint_config.hiStop[i]);
-    for(unsigned int i=0;i< req.ode_joint_config.loStop.size();i++)
-      joint->SetAttribute("lo_stop",i,req.ode_joint_config.loStop[i]);
-    for(unsigned int i=0;i< req.ode_joint_config.erp.size();i++)
-      joint->SetAttribute("erp",i,req.ode_joint_config.erp[i]);
-    for(unsigned int i=0;i< req.ode_joint_config.cfm.size();i++)
-      joint->SetAttribute("cfm",i,req.ode_joint_config.cfm[i]);
-    for(unsigned int i=0;i< req.ode_joint_config.stop_erp.size();i++)
-      joint->SetAttribute("stop_erp",i,req.ode_joint_config.stop_erp[i]);
-    for(unsigned int i=0;i< req.ode_joint_config.stop_cfm.size();i++)
-      joint->SetAttribute("stop_cfm",i,req.ode_joint_config.stop_cfm[i]);
-    for(unsigned int i=0;i< req.ode_joint_config.fudge_factor.size();i++)
-      joint->SetAttribute("fudge_factor",i,req.ode_joint_config.fudge_factor[i]);
-    for(unsigned int i=0;i< req.ode_joint_config.fmax.size();i++)
-      joint->SetAttribute("fmax",i,req.ode_joint_config.fmax[i]);
-    for(unsigned int i=0;i< req.ode_joint_config.vel.size();i++)
-      joint->SetAttribute("vel",i,req.ode_joint_config.vel[i]);
-#endif
 
     res.success = true;
     res.status_message = "SetJointProperties: properties set";


### PR DESCRIPTION
{ port of pull request #633 }
Also remove some outdated compiler directives.