### PR TITLE
Fix gazebo8 warnings part 5: ignition math in gazebo_ros (lunar-devel)

### DIFF
--- a/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
+++ b/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
@@ -256,11 +256,11 @@ private:
 
   /// \brief Update the model name and pose of the SDF file before sending to Gazebo
   void updateSDFAttributes(TiXmlDocument &gazebo_model_xml, std::string model_name,
-                           gazebo::math::Vector3 initial_xyz, gazebo::math::Quaternion initial_q);
+                           ignition::math::Vector3d initial_xyz, ignition::math::Quaterniond initial_q);
 
   /// \brief Update the model pose of the URDF file before sending to Gazebo
   void updateURDFModelPose(TiXmlDocument &gazebo_model_xml,
-                           gazebo::math::Vector3 initial_xyz, gazebo::math::Quaternion initial_q);
+                           ignition::math::Vector3d initial_xyz, ignition::math::Quaterniond initial_q);
 
   /// \brief Update the model name of the URDF file before sending to Gazebo
   void updateURDFName(TiXmlDocument &gazebo_model_xml, std::string model_name);
@@ -274,9 +274,9 @@ private:
 
   /// \brief helper function for applyBodyWrench
   ///        shift wrench from reference frame to target frame
-  void transformWrench(gazebo::math::Vector3 &target_force, gazebo::math::Vector3 &target_torque,
-                       gazebo::math::Vector3 reference_force, gazebo::math::Vector3 reference_torque,
-                       gazebo::math::Pose target_to_reference );
+  void transformWrench(ignition::math::Vector3d &target_force, ignition::math::Vector3d &target_torque,
+                       ignition::math::Vector3d reference_force, ignition::math::Vector3d reference_torque,
+                       ignition::math::Pose3d target_to_reference );
 
   /// \brief Used for the dynamic reconfigure callback function template
   void physicsReconfigureCallback(gazebo_ros::PhysicsConfig &config, uint32_t level);
@@ -297,10 +297,10 @@ private:
   void loadGazeboRosApiPlugin(std::string world_name);
 
   /// \brief convert xml to Pose
-  gazebo::math::Pose parsePose(const std::string &str);
+  ignition::math::Pose3d parsePose(const std::string &str);
 
   /// \brief convert xml to Pose
-  gazebo::math::Vector3 parseVector3(const std::string &str);
+  ignition::math::Vector3d parseVector3(const std::string &str);
 
   // track if the desconstructor event needs to occur
   bool plugin_loaded_;
@@ -389,8 +389,8 @@ private:
   {
   public:
     gazebo::physics::LinkPtr body;
-    gazebo::math::Vector3 force;
-    gazebo::math::Vector3 torque;
+    ignition::math::Vector3d force;
+    ignition::math::Vector3d torque;
     ros::Time start_time;
     ros::Duration duration;
   };

--- a/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
+++ b/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
@@ -255,28 +255,32 @@ private:
   void stripXmlDeclaration(std::string &model_xml);
 
   /// \brief Update the model name and pose of the SDF file before sending to Gazebo
-  void updateSDFAttributes(TiXmlDocument &gazebo_model_xml, std::string model_name,
-                           ignition::math::Vector3d initial_xyz, ignition::math::Quaterniond initial_q);
+  void updateSDFAttributes(TiXmlDocument &gazebo_model_xml,
+                           const std::string &model_name,
+                           const ignition::math::Vector3d &initial_xyz,
+                           const ignition::math::Quaterniond &initial_q);
 
   /// \brief Update the model pose of the URDF file before sending to Gazebo
   void updateURDFModelPose(TiXmlDocument &gazebo_model_xml,
-                           ignition::math::Vector3d initial_xyz, ignition::math::Quaterniond initial_q);
+                           const ignition::math::Vector3d &initial_xyz,
+                           const ignition::math::Quaterniond &initial_q);
 
   /// \brief Update the model name of the URDF file before sending to Gazebo
-  void updateURDFName(TiXmlDocument &gazebo_model_xml, std::string model_name);
+  void updateURDFName(TiXmlDocument &gazebo_model_xml, const std::string &model_name);
 
   /// \brief
   void walkChildAddRobotNamespace(TiXmlNode* model_xml);
 
   /// \brief
-  bool spawnAndConform(TiXmlDocument &gazebo_model_xml, std::string model_name,
+  bool spawnAndConform(TiXmlDocument &gazebo_model_xml, const std::string &model_name,
                        gazebo_msgs::SpawnModel::Response &res);
 
   /// \brief helper function for applyBodyWrench
   ///        shift wrench from reference frame to target frame
   void transformWrench(ignition::math::Vector3d &target_force, ignition::math::Vector3d &target_torque,
-                       ignition::math::Vector3d reference_force, ignition::math::Vector3d reference_torque,
-                       ignition::math::Pose3d target_to_reference );
+                       const ignition::math::Vector3d &reference_force,
+                       const ignition::math::Vector3d &reference_torque,
+                       const ignition::math::Pose3d &target_to_reference );
 
   /// \brief Used for the dynamic reconfigure callback function template
   void physicsReconfigureCallback(gazebo_ros::PhysicsConfig &config, uint32_t level);

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -620,19 +620,19 @@ bool GazeboRosApiPlugin::spawnSDFModel(gazebo_msgs::SpawnModel::Request &req,
   robot_namespace_ = req.robot_namespace;
 
   // get initial pose of model
-  gazebo::math::Vector3 initial_xyz(req.initial_pose.position.x,req.initial_pose.position.y,req.initial_pose.position.z);
+  ignition::math::Vector3d initial_xyz(req.initial_pose.position.x,req.initial_pose.position.y,req.initial_pose.position.z);
   // get initial roll pitch yaw (fixed frame transform)
-  gazebo::math::Quaternion initial_q(req.initial_pose.orientation.w,req.initial_pose.orientation.x,req.initial_pose.orientation.y,req.initial_pose.orientation.z);
+  ignition::math::Quaterniond initial_q(req.initial_pose.orientation.w,req.initial_pose.orientation.x,req.initial_pose.orientation.y,req.initial_pose.orientation.z);
 
   // refernce frame for initial pose definition, modify initial pose if defined
   gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.reference_frame));
   if (frame)
   {
     // convert to relative pose
-    gazebo::math::Pose frame_pose = frame->GetWorldPose();
-    initial_xyz = frame_pose.rot.RotateVector(initial_xyz);
-    initial_xyz += frame_pose.pos;
-    initial_q *= frame_pose.rot;
+    ignition::math::Pose3d frame_pose = frame->GetWorldPose().Ign();
+    initial_xyz = frame_pose.Rot().RotateVector(initial_xyz);
+    initial_xyz += frame_pose.Pos();
+    initial_q *= frame_pose.Rot();
   }
 
   /// @todo: map is really wrong, need to use tf here somehow
@@ -849,28 +849,28 @@ bool GazeboRosApiPlugin::getModelState(gazebo_msgs::GetModelState::Request &req,
       res.header.frame_id = req.relative_entity_name; /// @brief this is a redundant information
     }
     // get model pose
-    gazebo::math::Pose       model_pose = model->GetWorldPose();
-    gazebo::math::Vector3    model_pos = model_pose.pos;
-    gazebo::math::Quaternion model_rot = model_pose.rot;
+    ignition::math::Pose3d      model_pose = model->GetWorldPose().Ign();
+    ignition::math::Vector3d    model_pos = model_pose.Pos();
+    ignition::math::Quaterniond model_rot = model_pose.Rot();
 
     // get model twist
-    gazebo::math::Vector3 model_linear_vel  = model->GetWorldLinearVel();
-    gazebo::math::Vector3 model_angular_vel = model->GetWorldAngularVel();
+    ignition::math::Vector3d model_linear_vel  = model->GetWorldLinearVel().Ign();
+    ignition::math::Vector3d model_angular_vel = model->GetWorldAngularVel().Ign();
 
 
     if (frame)
     {
       // convert to relative pose
-      gazebo::math::Pose frame_pose = frame->GetWorldPose();
-      model_pos = model_pos - frame_pose.pos;
-      model_pos = frame_pose.rot.RotateVectorReverse(model_pos);
-      model_rot *= frame_pose.rot.GetInverse();
+      ignition::math::Pose3d frame_pose = frame->GetWorldPose().Ign();
+      model_pos = model_pos - frame_pose.Pos();
+      model_pos = frame_pose.Rot().RotateVectorReverse(model_pos);
+      model_rot *= frame_pose.Rot().Inverse();
 
       // convert to relative rates
-      gazebo::math::Vector3 frame_vpos = frame->GetWorldLinearVel(); // get velocity in gazebo frame
-      gazebo::math::Vector3 frame_veul = frame->GetWorldAngularVel(); // get velocity in gazebo frame
-      model_linear_vel = frame_pose.rot.RotateVector(model_linear_vel - frame_vpos);
-      model_angular_vel = frame_pose.rot.RotateVector(model_angular_vel - frame_veul);
+      ignition::math::Vector3d frame_vpos = frame->GetWorldLinearVel().Ign(); // get velocity in gazebo frame
+      ignition::math::Vector3d frame_veul = frame->GetWorldAngularVel().Ign(); // get velocity in gazebo frame
+      model_linear_vel = frame_pose.Rot().RotateVector(model_linear_vel - frame_vpos);
+      model_angular_vel = frame_pose.Rot().RotateVector(model_angular_vel - frame_veul);
     }
     /// @todo: FIXME map is really wrong, need to use tf here somehow
     else if (req.relative_entity_name == "" || req.relative_entity_name == "world" || req.relative_entity_name == "map" || req.relative_entity_name == "/map")
@@ -885,20 +885,20 @@ bool GazeboRosApiPlugin::getModelState(gazebo_msgs::GetModelState::Request &req,
     }
 
     // fill in response
-    res.pose.position.x = model_pos.x;
-    res.pose.position.y = model_pos.y;
-    res.pose.position.z = model_pos.z;
-    res.pose.orientation.w = model_rot.w;
-    res.pose.orientation.x = model_rot.x;
-    res.pose.orientation.y = model_rot.y;
-    res.pose.orientation.z = model_rot.z;
+    res.pose.position.x = model_pos.X();
+    res.pose.position.y = model_pos.Y();
+    res.pose.position.z = model_pos.Z();
+    res.pose.orientation.w = model_rot.W();
+    res.pose.orientation.x = model_rot.X();
+    res.pose.orientation.y = model_rot.Y();
+    res.pose.orientation.z = model_rot.Z();
 
-    res.twist.linear.x = model_linear_vel.x;
-    res.twist.linear.y = model_linear_vel.y;
-    res.twist.linear.z = model_linear_vel.z;
-    res.twist.angular.x = model_angular_vel.x;
-    res.twist.angular.y = model_angular_vel.y;
-    res.twist.angular.z = model_angular_vel.z;
+    res.twist.linear.x = model_linear_vel.X();
+    res.twist.linear.y = model_linear_vel.Y();
+    res.twist.linear.z = model_linear_vel.Z();
+    res.twist.angular.x = model_angular_vel.X();
+    res.twist.angular.y = model_angular_vel.Y();
+    res.twist.angular.z = model_angular_vel.Z();
 
     res.success = true;
     res.status_message = "GetModelState: got properties";
@@ -1044,10 +1044,10 @@ bool GazeboRosApiPlugin::getLinkProperties(gazebo_msgs::GetLinkProperties::Reque
     res.ixz = inertia->GetIXZ();
     res.iyz = inertia->GetIYZ();
 
-    gazebo::math::Vector3 com = body->GetInertial()->GetCoG();
-    res.com.position.x = com.x;
-    res.com.position.y = com.y;
-    res.com.position.z = com.z;
+    ignition::math::Vector3d com = body->GetInertial()->GetCoG().Ign();
+    res.com.position.x = com.X();
+    res.com.position.y = com.Y();
+    res.com.position.z = com.Z();
     res.com.orientation.x = 0; // @todo: gazebo do not support rotated inertia yet
     res.com.orientation.y = 0;
     res.com.orientation.z = 0;
@@ -1073,24 +1073,24 @@ bool GazeboRosApiPlugin::getLinkState(gazebo_msgs::GetLinkState::Request &req,
   }
 
   // get body pose
-  gazebo::math::Pose body_pose = body->GetWorldPose();
+  ignition::math::Pose3d body_pose = body->GetWorldPose().Ign();
   // Get inertial rates
-  gazebo::math::Vector3 body_vpos = body->GetWorldLinearVel(); // get velocity in gazebo frame
-  gazebo::math::Vector3 body_veul = body->GetWorldAngularVel(); // get velocity in gazebo frame
+  ignition::math::Vector3d body_vpos = body->GetWorldLinearVel().Ign(); // get velocity in gazebo frame
+  ignition::math::Vector3d body_veul = body->GetWorldAngularVel().Ign(); // get velocity in gazebo frame
 
   if (frame)
   {
     // convert to relative pose
-    gazebo::math::Pose frame_pose = frame->GetWorldPose();
-    body_pose.pos = body_pose.pos - frame_pose.pos;
-    body_pose.pos = frame_pose.rot.RotateVectorReverse(body_pose.pos);
-    body_pose.rot *= frame_pose.rot.GetInverse();
+    ignition::math::Pose3d frame_pose = frame->GetWorldPose().Ign();
+    body_pose.Pos() = body_pose.Pos() - frame_pose.Pos();
+    body_pose.Pos() = frame_pose.Rot().RotateVectorReverse(body_pose.Pos());
+    body_pose.Rot() *= frame_pose.Rot().Inverse();
 
     // convert to relative rates
-    gazebo::math::Vector3 frame_vpos = frame->GetWorldLinearVel(); // get velocity in gazebo frame
-    gazebo::math::Vector3 frame_veul = frame->GetWorldAngularVel(); // get velocity in gazebo frame
-    body_vpos = frame_pose.rot.RotateVector(body_vpos - frame_vpos);
-    body_veul = frame_pose.rot.RotateVector(body_veul - frame_veul);
+    ignition::math::Vector3d frame_vpos = frame->GetWorldLinearVel().Ign(); // get velocity in gazebo frame
+    ignition::math::Vector3d frame_veul = frame->GetWorldAngularVel().Ign(); // get velocity in gazebo frame
+    body_vpos = frame_pose.Rot().RotateVector(body_vpos - frame_vpos);
+    body_veul = frame_pose.Rot().RotateVector(body_veul - frame_veul);
   }
   /// @todo: FIXME map is really wrong, need to use tf here somehow
   else if (req.reference_frame == "" || req.reference_frame == "world" || req.reference_frame == "map" || req.reference_frame == "/map")
@@ -1105,19 +1105,19 @@ bool GazeboRosApiPlugin::getLinkState(gazebo_msgs::GetLinkState::Request &req,
   }
 
   res.link_state.link_name = req.link_name;
-  res.link_state.pose.position.x = body_pose.pos.x;
-  res.link_state.pose.position.y = body_pose.pos.y;
-  res.link_state.pose.position.z = body_pose.pos.z;
-  res.link_state.pose.orientation.x = body_pose.rot.x;
-  res.link_state.pose.orientation.y = body_pose.rot.y;
-  res.link_state.pose.orientation.z = body_pose.rot.z;
-  res.link_state.pose.orientation.w = body_pose.rot.w;
-  res.link_state.twist.linear.x = body_vpos.x;
-  res.link_state.twist.linear.y = body_vpos.y;
-  res.link_state.twist.linear.z = body_vpos.z;
-  res.link_state.twist.angular.x = body_veul.x;
-  res.link_state.twist.angular.y = body_veul.y;
-  res.link_state.twist.angular.z = body_veul.z;
+  res.link_state.pose.position.x = body_pose.Pos().X();
+  res.link_state.pose.position.y = body_pose.Pos().Y();
+  res.link_state.pose.position.z = body_pose.Pos().Z();
+  res.link_state.pose.orientation.x = body_pose.Rot().X();
+  res.link_state.pose.orientation.y = body_pose.Rot().Y();
+  res.link_state.pose.orientation.z = body_pose.Rot().Z();
+  res.link_state.pose.orientation.w = body_pose.Rot().W();
+  res.link_state.twist.linear.x = body_vpos.X();
+  res.link_state.twist.linear.y = body_vpos.Y();
+  res.link_state.twist.linear.z = body_vpos.Z();
+  res.link_state.twist.angular.x = body_veul.X();
+  res.link_state.twist.angular.y = body_veul.Y();
+  res.link_state.twist.angular.z = body_veul.Z();
   res.link_state.reference_frame = req.reference_frame;
 
   res.success = true;
@@ -1202,8 +1202,8 @@ bool GazeboRosApiPlugin::setLinkProperties(gazebo_msgs::SetLinkProperties::Reque
   {
     gazebo::physics::InertialPtr mass = body->GetInertial();
     // @todo: FIXME: add inertia matrix rotation to Gazebo
-    // mass.SetInertiaRotation(gazebo::math::Quaternionion(req.com.orientation.w,res.com.orientation.x,req.com.orientation.y req.com.orientation.z));
-    mass->SetCoG(gazebo::math::Vector3(req.com.position.x,req.com.position.y,req.com.position.z));
+    // mass.SetInertiaRotation(ignition::math::Quaterniondion(req.com.orientation.w,res.com.orientation.x,req.com.orientation.y req.com.orientation.z));
+    mass->SetCoG(ignition::math::Vector3d(req.com.position.x,req.com.position.y,req.com.position.z));
     mass->SetInertiaMatrix(req.ixx,req.iyy,req.izz,req.ixy,req.ixz,req.iyz);
     mass->SetMass(req.mass);
     body->SetGravityMode(req.gravity_mode);
@@ -1353,12 +1353,12 @@ bool GazeboRosApiPlugin::setJointProperties(gazebo_msgs::SetJointProperties::Req
 bool GazeboRosApiPlugin::setModelState(gazebo_msgs::SetModelState::Request &req,
                                        gazebo_msgs::SetModelState::Response &res)
 {
-  gazebo::math::Vector3 target_pos(req.model_state.pose.position.x,req.model_state.pose.position.y,req.model_state.pose.position.z);
-  gazebo::math::Quaternion target_rot(req.model_state.pose.orientation.w,req.model_state.pose.orientation.x,req.model_state.pose.orientation.y,req.model_state.pose.orientation.z);
+  ignition::math::Vector3d target_pos(req.model_state.pose.position.x,req.model_state.pose.position.y,req.model_state.pose.position.z);
+  ignition::math::Quaterniond target_rot(req.model_state.pose.orientation.w,req.model_state.pose.orientation.x,req.model_state.pose.orientation.y,req.model_state.pose.orientation.z);
   target_rot.Normalize(); // eliminates invalid rotation (0, 0, 0, 0)
-  gazebo::math::Pose target_pose(target_pos,target_rot);
-  gazebo::math::Vector3 target_pos_dot(req.model_state.twist.linear.x,req.model_state.twist.linear.y,req.model_state.twist.linear.z);
-  gazebo::math::Vector3 target_rot_dot(req.model_state.twist.angular.x,req.model_state.twist.angular.y,req.model_state.twist.angular.z);
+  ignition::math::Pose3d target_pose(target_pos,target_rot);
+  ignition::math::Vector3d target_pos_dot(req.model_state.twist.linear.x,req.model_state.twist.linear.y,req.model_state.twist.linear.z);
+  ignition::math::Vector3d target_rot_dot(req.model_state.twist.angular.x,req.model_state.twist.angular.y,req.model_state.twist.angular.z);
 
   gazebo::physics::ModelPtr model = world_->GetModel(req.model_state.model_name);
   if (!model)
@@ -1373,14 +1373,14 @@ bool GazeboRosApiPlugin::setModelState(gazebo_msgs::SetModelState::Request &req,
     gazebo::physics::LinkPtr relative_entity = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.model_state.reference_frame));
     if (relative_entity)
     {
-      gazebo::math::Pose  frame_pose = relative_entity->GetWorldPose(); // - myBody->GetCoMPose();
-      gazebo::math::Vector3 frame_pos = frame_pose.pos;
-      gazebo::math::Quaternion frame_rot = frame_pose.rot;
+      ignition::math::Pose3d  frame_pose = relative_entity->GetWorldPose().Ign(); // - myBody->GetCoMPose();
+      ignition::math::Vector3d frame_pos = frame_pose.Pos();
+      ignition::math::Quaterniond frame_rot = frame_pose.Rot();
 
       //std::cout << " debug : " << relative_entity->GetName() << " : " << frame_pose << " : " << target_pose << std::endl;
       //target_pose = frame_pose + target_pose; // seems buggy, use my own
-      target_pose.pos = model->GetWorldPose().pos + frame_rot.RotateVector(target_pos);
-      target_pose.rot = frame_rot * target_pose.rot;
+      target_pose.Pos() = model->GetWorldPose().Ign().Pos() + frame_rot.RotateVector(target_pos);
+      target_pose.Rot() = frame_rot * target_pose.Rot();
 
       // Velocities should be commanded in the requested reference
       // frame, so we need to translate them to the world frame
@@ -1401,13 +1401,13 @@ bool GazeboRosApiPlugin::setModelState(gazebo_msgs::SetModelState::Request &req,
       return true;
     }
 
-    //ROS_ERROR_NAMED("api_plugin", "target state: %f %f %f",target_pose.pos.x,target_pose.pos.y,target_pose.pos.z);
+    //ROS_ERROR_NAMED("api_plugin", "target state: %f %f %f",target_pose.Pos().X(),target_pose.Pos().Y(),target_pose.Pos().Z());
     bool is_paused = world_->IsPaused();
     world_->SetPaused(true);
     model->SetWorldPose(target_pose);
     world_->SetPaused(is_paused);
-    //gazebo::math::Pose p3d = model->GetWorldPose();
-    //ROS_ERROR_NAMED("api_plugin", "model updated state: %f %f %f",p3d.pos.x,p3d.pos.y,p3d.pos.z);
+    //ignition::math::Pose3d p3d = model->GetWorldPose().Ign();
+    //ROS_ERROR_NAMED("api_plugin", "model updated state: %f %f %f",p3d.Pos().X(),p3d.Pos().Y(),p3d.Pos().Z());
 
     // set model velocity
     model->SetLinearVel(target_pos_dot);
@@ -1599,25 +1599,25 @@ bool GazeboRosApiPlugin::setLinkState(gazebo_msgs::SetLinkState::Request &req,
   /// @todo: FIXME map is really wrong, unless using tf here somehow
   // get reference frame (body/model(link)) pose and
   // transform target pose to absolute world frame
-  gazebo::math::Vector3 target_pos(req.link_state.pose.position.x,req.link_state.pose.position.y,req.link_state.pose.position.z);
-  gazebo::math::Quaternion target_rot(req.link_state.pose.orientation.w,req.link_state.pose.orientation.x,req.link_state.pose.orientation.y,req.link_state.pose.orientation.z);
-  gazebo::math::Pose target_pose(target_pos,target_rot);
-  gazebo::math::Vector3 target_linear_vel(req.link_state.twist.linear.x,req.link_state.twist.linear.y,req.link_state.twist.linear.z);
-  gazebo::math::Vector3 target_angular_vel(req.link_state.twist.angular.x,req.link_state.twist.angular.y,req.link_state.twist.angular.z);
+  ignition::math::Vector3d target_pos(req.link_state.pose.position.x,req.link_state.pose.position.y,req.link_state.pose.position.z);
+  ignition::math::Quaterniond target_rot(req.link_state.pose.orientation.w,req.link_state.pose.orientation.x,req.link_state.pose.orientation.y,req.link_state.pose.orientation.z);
+  ignition::math::Pose3d target_pose(target_pos,target_rot);
+  ignition::math::Vector3d target_linear_vel(req.link_state.twist.linear.x,req.link_state.twist.linear.y,req.link_state.twist.linear.z);
+  ignition::math::Vector3d target_angular_vel(req.link_state.twist.angular.x,req.link_state.twist.angular.y,req.link_state.twist.angular.z);
 
   if (frame)
   {
-    gazebo::math::Pose  frame_pose = frame->GetWorldPose(); // - myBody->GetCoMPose();
-    gazebo::math::Vector3 frame_pos = frame_pose.pos;
-    gazebo::math::Quaternion frame_rot = frame_pose.rot;
+    ignition::math::Pose3d  frame_pose = frame->GetWorldPose().Ign(); // - myBody->GetCoMPose();
+    ignition::math::Vector3d frame_pos = frame_pose.Pos();
+    ignition::math::Quaterniond frame_rot = frame_pose.Rot();
 
     //std::cout << " debug : " << frame->GetName() << " : " << frame_pose << " : " << target_pose << std::endl;
     //target_pose = frame_pose + target_pose; // seems buggy, use my own
-    target_pose.pos = frame_pos + frame_rot.RotateVector(target_pos);
-    target_pose.rot = frame_rot * target_pose.rot;
+    target_pose.Pos() = frame_pos + frame_rot.RotateVector(target_pos);
+    target_pose.Rot() = frame_rot * target_pose.Rot();
 
-    gazebo::math::Vector3 frame_linear_vel = frame->GetWorldLinearVel();
-    gazebo::math::Vector3 frame_angular_vel = frame->GetWorldAngularVel();
+    ignition::math::Vector3d frame_linear_vel = frame->GetWorldLinearVel().Ign();
+    ignition::math::Vector3d frame_angular_vel = frame->GetWorldAngularVel().Ign();
     target_linear_vel -= frame_linear_vel;
     target_angular_vel -= frame_angular_vel;
   }
@@ -1658,17 +1658,17 @@ void GazeboRosApiPlugin::updateLinkState(const gazebo_msgs::LinkState::ConstPtr&
   /*bool success = */ setLinkState(req,res);
 }
 
-void GazeboRosApiPlugin::transformWrench( gazebo::math::Vector3 &target_force, gazebo::math::Vector3 &target_torque,
-                                          gazebo::math::Vector3 reference_force, gazebo::math::Vector3 reference_torque,
-                                          gazebo::math::Pose target_to_reference )
+void GazeboRosApiPlugin::transformWrench( ignition::math::Vector3d &target_force, ignition::math::Vector3d &target_torque,
+                                          ignition::math::Vector3d reference_force, ignition::math::Vector3d reference_torque,
+                                          ignition::math::Pose3d target_to_reference )
 {
   // rotate force into target frame
-  target_force = target_to_reference.rot.RotateVector(reference_force);
+  target_force = target_to_reference.Rot().RotateVector(reference_force);
   // rotate torque into target frame
-  target_torque = target_to_reference.rot.RotateVector(reference_torque);
+  target_torque = target_to_reference.Rot().RotateVector(reference_torque);
 
   // target force is the refence force rotated by the target->reference transform
-  target_torque = target_torque + target_to_reference.pos.Cross(target_force);
+  target_torque = target_torque + target_to_reference.Pos().Cross(target_force);
 }
 
 bool GazeboRosApiPlugin::applyBodyWrench(gazebo_msgs::ApplyBodyWrench::Request &req,
@@ -1685,12 +1685,12 @@ bool GazeboRosApiPlugin::applyBodyWrench(gazebo_msgs::ApplyBodyWrench::Request &
   }
 
   // target wrench
-  gazebo::math::Vector3 reference_force(req.wrench.force.x,req.wrench.force.y,req.wrench.force.z);
-  gazebo::math::Vector3 reference_torque(req.wrench.torque.x,req.wrench.torque.y,req.wrench.torque.z);
-  gazebo::math::Vector3 reference_point(req.reference_point.x,req.reference_point.y,req.reference_point.z);
+  ignition::math::Vector3d reference_force(req.wrench.force.x,req.wrench.force.y,req.wrench.force.z);
+  ignition::math::Vector3d reference_torque(req.wrench.torque.x,req.wrench.torque.y,req.wrench.torque.z);
+  ignition::math::Vector3d reference_point(req.reference_point.x,req.reference_point.y,req.reference_point.z);
 
-  gazebo::math::Vector3 target_force;
-  gazebo::math::Vector3 target_torque;
+  ignition::math::Vector3d target_force;
+  ignition::math::Vector3d target_torque;
 
   /// shift wrench to body frame if a non-zero reference point is given
   ///   @todo: to be more general, should we make the reference point a reference pose?
@@ -1705,43 +1705,43 @@ bool GazeboRosApiPlugin::applyBodyWrench(gazebo_msgs::ApplyBodyWrench::Request &
     //        transform wrench from reference_point in reference_frame
     //        into the reference frame of the body
     //        first, translate by reference point to the body frame
-    gazebo::math::Pose target_to_reference = frame->GetWorldPose() - body->GetWorldPose();
+    ignition::math::Pose3d target_to_reference = frame->GetWorldPose().Ign() - body->GetWorldPose().Ign();
     ROS_DEBUG_NAMED("api_plugin", "reference frame for applied wrench: [%f %f %f, %f %f %f]-[%f %f %f, %f %f %f]=[%f %f %f, %f %f %f]",
-              body->GetWorldPose().pos.x,
-              body->GetWorldPose().pos.y,
-              body->GetWorldPose().pos.z,
-              body->GetWorldPose().rot.GetAsEuler().x,
-              body->GetWorldPose().rot.GetAsEuler().y,
-              body->GetWorldPose().rot.GetAsEuler().z,
-              frame->GetWorldPose().pos.x,
-              frame->GetWorldPose().pos.y,
-              frame->GetWorldPose().pos.z,
-              frame->GetWorldPose().rot.GetAsEuler().x,
-              frame->GetWorldPose().rot.GetAsEuler().y,
-              frame->GetWorldPose().rot.GetAsEuler().z,
-              target_to_reference.pos.x,
-              target_to_reference.pos.y,
-              target_to_reference.pos.z,
-              target_to_reference.rot.GetAsEuler().x,
-              target_to_reference.rot.GetAsEuler().y,
-              target_to_reference.rot.GetAsEuler().z
+              body->GetWorldPose().Ign().Pos().X(),
+              body->GetWorldPose().Ign().Pos().Y(),
+              body->GetWorldPose().Ign().Pos().Z(),
+              body->GetWorldPose().Ign().Rot().Euler().X(),
+              body->GetWorldPose().Ign().Rot().Euler().Y(),
+              body->GetWorldPose().Ign().Rot().Euler().Z(),
+              frame->GetWorldPose().Ign().Pos().X(),
+              frame->GetWorldPose().Ign().Pos().Y(),
+              frame->GetWorldPose().Ign().Pos().Z(),
+              frame->GetWorldPose().Ign().Rot().Euler().X(),
+              frame->GetWorldPose().Ign().Rot().Euler().Y(),
+              frame->GetWorldPose().Ign().Rot().Euler().Z(),
+              target_to_reference.Pos().X(),
+              target_to_reference.Pos().Y(),
+              target_to_reference.Pos().Z(),
+              target_to_reference.Rot().Euler().X(),
+              target_to_reference.Rot().Euler().Y(),
+              target_to_reference.Rot().Euler().Z()
               );
     transformWrench(target_force, target_torque, reference_force, reference_torque, target_to_reference);
     ROS_ERROR_NAMED("api_plugin", "wrench defined as [%s]:[%f %f %f, %f %f %f] --> applied as [%s]:[%f %f %f, %f %f %f]",
               frame->GetName().c_str(),
-              reference_force.x,
-              reference_force.y,
-              reference_force.z,
-              reference_torque.x,
-              reference_torque.y,
-              reference_torque.z,
+              reference_force.X(),
+              reference_force.Y(),
+              reference_force.Z(),
+              reference_torque.X(),
+              reference_torque.Y(),
+              reference_torque.Z(),
               body->GetName().c_str(),
-              target_force.x,
-              target_force.y,
-              target_force.z,
-              target_torque.x,
-              target_torque.y,
-              target_torque.z
+              target_force.X(),
+              target_force.Y(),
+              target_force.Z(),
+              target_torque.X(),
+              target_torque.Y(),
+              target_torque.Z()
               );
 
   }
@@ -1749,7 +1749,7 @@ bool GazeboRosApiPlugin::applyBodyWrench(gazebo_msgs::ApplyBodyWrench::Request &
   {
     ROS_INFO_NAMED("api_plugin", "ApplyBodyWrench: reference_frame is empty/world/map, using inertial frame, transferring from body relative to inertial frame");
     // FIXME: transfer to inertial frame
-    gazebo::math::Pose target_to_reference = body->GetWorldPose();
+    ignition::math::Pose3d target_to_reference = body->GetWorldPose().Ign();
     target_force = reference_force;
     target_torque = reference_torque;
 
@@ -1914,26 +1914,26 @@ void GazeboRosApiPlugin::publishLinkStates()
       {
         link_states.name.push_back(body->GetScopedName());
         geometry_msgs::Pose pose;
-        gazebo::math::Pose  body_pose = body->GetWorldPose(); // - myBody->GetCoMPose();
-        gazebo::math::Vector3 pos = body_pose.pos;
-        gazebo::math::Quaternion rot = body_pose.rot;
-        pose.position.x = pos.x;
-        pose.position.y = pos.y;
-        pose.position.z = pos.z;
-        pose.orientation.w = rot.w;
-        pose.orientation.x = rot.x;
-        pose.orientation.y = rot.y;
-        pose.orientation.z = rot.z;
+        ignition::math::Pose3d  body_pose = body->GetWorldPose().Ign(); // - myBody->GetCoMPose();
+        ignition::math::Vector3d pos = body_pose.Pos();
+        ignition::math::Quaterniond rot = body_pose.Rot();
+        pose.position.x = pos.X();
+        pose.position.y = pos.Y();
+        pose.position.z = pos.Z();
+        pose.orientation.w = rot.W();
+        pose.orientation.x = rot.X();
+        pose.orientation.y = rot.Y();
+        pose.orientation.z = rot.Z();
         link_states.pose.push_back(pose);
-        gazebo::math::Vector3 linear_vel  = body->GetWorldLinearVel();
-        gazebo::math::Vector3 angular_vel = body->GetWorldAngularVel();
+        ignition::math::Vector3d linear_vel  = body->GetWorldLinearVel().Ign();
+        ignition::math::Vector3d angular_vel = body->GetWorldAngularVel().Ign();
         geometry_msgs::Twist twist;
-        twist.linear.x = linear_vel.x;
-        twist.linear.y = linear_vel.y;
-        twist.linear.z = linear_vel.z;
-        twist.angular.x = angular_vel.x;
-        twist.angular.y = angular_vel.y;
-        twist.angular.z = angular_vel.z;
+        twist.linear.x = linear_vel.X();
+        twist.linear.y = linear_vel.Y();
+        twist.linear.z = linear_vel.Z();
+        twist.angular.x = angular_vel.X();
+        twist.angular.y = angular_vel.Y();
+        twist.angular.z = angular_vel.Z();
         link_states.twist.push_back(twist);
       }
     }
@@ -1952,26 +1952,26 @@ void GazeboRosApiPlugin::publishModelStates()
     gazebo::physics::ModelPtr model = world_->GetModel(i);
     model_states.name.push_back(model->GetName());
     geometry_msgs::Pose pose;
-    gazebo::math::Pose  model_pose = model->GetWorldPose(); // - myBody->GetCoMPose();
-    gazebo::math::Vector3 pos = model_pose.pos;
-    gazebo::math::Quaternion rot = model_pose.rot;
-    pose.position.x = pos.x;
-    pose.position.y = pos.y;
-    pose.position.z = pos.z;
-    pose.orientation.w = rot.w;
-    pose.orientation.x = rot.x;
-    pose.orientation.y = rot.y;
-    pose.orientation.z = rot.z;
+    ignition::math::Pose3d  model_pose = model->GetWorldPose().Ign(); // - myBody->GetCoMPose();
+    ignition::math::Vector3d pos = model_pose.Pos();
+    ignition::math::Quaterniond rot = model_pose.Rot();
+    pose.position.x = pos.X();
+    pose.position.y = pos.Y();
+    pose.position.z = pos.Z();
+    pose.orientation.w = rot.W();
+    pose.orientation.x = rot.X();
+    pose.orientation.y = rot.Y();
+    pose.orientation.z = rot.Z();
     model_states.pose.push_back(pose);
-    gazebo::math::Vector3 linear_vel  = model->GetWorldLinearVel();
-    gazebo::math::Vector3 angular_vel = model->GetWorldAngularVel();
+    ignition::math::Vector3d linear_vel  = model->GetWorldLinearVel().Ign();
+    ignition::math::Vector3d angular_vel = model->GetWorldAngularVel().Ign();
     geometry_msgs::Twist twist;
-    twist.linear.x = linear_vel.x;
-    twist.linear.y = linear_vel.y;
-    twist.linear.z = linear_vel.z;
-    twist.angular.x = angular_vel.x;
-    twist.angular.y = angular_vel.y;
-    twist.angular.z = angular_vel.z;
+    twist.linear.x = linear_vel.X();
+    twist.linear.y = linear_vel.Y();
+    twist.linear.z = linear_vel.Z();
+    twist.angular.x = angular_vel.X();
+    twist.angular.y = angular_vel.Y();
+    twist.angular.z = angular_vel.Z();
     model_states.twist.push_back(twist);
   }
   pub_model_states_.publish(model_states);
@@ -2083,8 +2083,8 @@ void GazeboRosApiPlugin::stripXmlDeclaration(std::string &model_xml)
 
 void GazeboRosApiPlugin::updateSDFAttributes(TiXmlDocument &gazebo_model_xml,
                                              std::string model_name,
-                                             gazebo::math::Vector3 initial_xyz,
-                                             gazebo::math::Quaternion initial_q)
+                                             ignition::math::Vector3d initial_xyz,
+                                             ignition::math::Quaterniond initial_q)
 {
   // This function can handle both regular SDF files and <include> SDFs that are used with the
   // Gazebo Model Database
@@ -2146,13 +2146,13 @@ void GazeboRosApiPlugin::updateSDFAttributes(TiXmlDocument &gazebo_model_xml,
 
   // Check for the pose element
   pose_element = model_tixml->FirstChildElement("pose");
-  gazebo::math::Pose model_pose;
+  ignition::math::Pose3d model_pose;
 
   // Create the pose element if it doesn't exist
   // Remove it if it exists, since we are inserting a new one
   if (pose_element)
   {
-    // save pose_element in math::Pose and remove child
+    // save pose_element in ignition::math::Pose3d and remove child
     model_pose = this->parsePose(pose_element->GetText());
     model_tixml->RemoveChild(pose_element);
   }
@@ -2160,13 +2160,13 @@ void GazeboRosApiPlugin::updateSDFAttributes(TiXmlDocument &gazebo_model_xml,
   // Set and link the pose element after adding initial pose
   {
     // add pose_element Pose to initial pose
-    gazebo::math::Pose new_model_pose = model_pose + gazebo::math::Pose(initial_xyz, initial_q);
+    ignition::math::Pose3d new_model_pose = model_pose + ignition::math::Pose3d(initial_xyz, initial_q);
 
     // Create the string of 6 numbers
     std::ostringstream pose_stream;
-    gazebo::math::Vector3 model_rpy = new_model_pose.rot.GetAsEuler(); // convert to Euler angles for Gazebo XML
-    pose_stream << new_model_pose.pos.x << " " << new_model_pose.pos.y << " " << new_model_pose.pos.z << " "
-                << model_rpy.x << " " << model_rpy.y << " " << model_rpy.z;
+    ignition::math::Vector3d model_rpy = new_model_pose.Rot().Euler(); // convert to Euler angles for Gazebo XML
+    pose_stream << new_model_pose.Pos().X() << " " << new_model_pose.Pos().Y() << " " << new_model_pose.Pos().Z() << " "
+                << model_rpy.X() << " " << model_rpy.Y() << " " << model_rpy.Z();
 
     // Add value to pose element
     TiXmlText* text = new TiXmlText(pose_stream.str());
@@ -2176,7 +2176,7 @@ void GazeboRosApiPlugin::updateSDFAttributes(TiXmlDocument &gazebo_model_xml,
   }
 }
 
-gazebo::math::Pose GazeboRosApiPlugin::parsePose(const std::string &str)
+ignition::math::Pose3d GazeboRosApiPlugin::parsePose(const std::string &str)
 {
   std::vector<std::string> pieces;
   std::vector<double> vals;
@@ -2195,21 +2195,21 @@ gazebo::math::Pose GazeboRosApiPlugin::parsePose(const std::string &str)
         sdferr << "xml key [" << str
           << "][" << i << "] value [" << pieces[i]
           << "] is not a valid double from a 3-tuple\n";
-        return gazebo::math::Pose();
+        return ignition::math::Pose3d();
       }
     }
   }
 
   if (vals.size() == 6)
-    return gazebo::math::Pose(vals[0], vals[1], vals[2], vals[3], vals[4], vals[5]);
+    return ignition::math::Pose3d(vals[0], vals[1], vals[2], vals[3], vals[4], vals[5]);
   else
   {
-    ROS_ERROR_NAMED("api_plugin", "Beware: failed to parse string [%s] as gazebo::math::Pose, returning zeros.", str.c_str());
-    return gazebo::math::Pose();
+    ROS_ERROR_NAMED("api_plugin", "Beware: failed to parse string [%s] as ignition::math::Pose3d, returning zeros.", str.c_str());
+    return ignition::math::Pose3d();
   }
 }
 
-gazebo::math::Vector3 GazeboRosApiPlugin::parseVector3(const std::string &str)
+ignition::math::Vector3d GazeboRosApiPlugin::parseVector3(const std::string &str)
 {
   std::vector<std::string> pieces;
   std::vector<double> vals;
@@ -2228,21 +2228,21 @@ gazebo::math::Vector3 GazeboRosApiPlugin::parseVector3(const std::string &str)
         sdferr << "xml key [" << str
           << "][" << i << "] value [" << pieces[i]
           << "] is not a valid double from a 3-tuple\n";
-        return gazebo::math::Vector3();
+        return ignition::math::Vector3d();
       }
     }
   }
 
   if (vals.size() == 3)
-    return gazebo::math::Vector3(vals[0], vals[1], vals[2]);
+    return ignition::math::Vector3d(vals[0], vals[1], vals[2]);
   else
   {
-    ROS_ERROR_NAMED("api_plugin", "Beware: failed to parse string [%s] as gazebo::math::Vector3, returning zeros.", str.c_str());
-    return gazebo::math::Vector3();
+    ROS_ERROR_NAMED("api_plugin", "Beware: failed to parse string [%s] as ignition::math::Vector3d, returning zeros.", str.c_str());
+    return ignition::math::Vector3d();
   }
 }
 
-void GazeboRosApiPlugin::updateURDFModelPose(TiXmlDocument &gazebo_model_xml, gazebo::math::Vector3 initial_xyz, gazebo::math::Quaternion initial_q)
+void GazeboRosApiPlugin::updateURDFModelPose(TiXmlDocument &gazebo_model_xml, ignition::math::Vector3d initial_xyz, ignition::math::Quaterniond initial_q)
 {
   TiXmlElement* model_tixml = (gazebo_model_xml.FirstChildElement("robot"));
   if (model_tixml)
@@ -2257,8 +2257,8 @@ void GazeboRosApiPlugin::updateURDFModelPose(TiXmlDocument &gazebo_model_xml, ga
       model_tixml->LinkEndChild(origin_key);
     }
 
-    gazebo::math::Vector3 xyz;
-    gazebo::math::Vector3 rpy;
+    ignition::math::Vector3d xyz;
+    ignition::math::Vector3d rpy;
     if (origin_key->Attribute("xyz"))
     {
       xyz = this->parseVector3(origin_key->Attribute("xyz"));
@@ -2271,14 +2271,15 @@ void GazeboRosApiPlugin::updateURDFModelPose(TiXmlDocument &gazebo_model_xml, ga
     }
 
     // add xyz, rpy to initial pose
-    gazebo::math::Pose model_pose = gazebo::math::Pose(xyz, rpy) + gazebo::math::Pose(initial_xyz, initial_q);
+    ignition::math::Pose3d model_pose = ignition::math::Pose3d(xyz, ignition::math::Quaterniond(rpy))
+                                      + ignition::math::Pose3d(initial_xyz, initial_q);
 
     std::ostringstream xyz_stream;
-    xyz_stream << model_pose.pos.x << " " << model_pose.pos.y << " " << model_pose.pos.z;
+    xyz_stream << model_pose.Pos().X() << " " << model_pose.Pos().Y() << " " << model_pose.Pos().Z();
 
     std::ostringstream rpy_stream;
-    gazebo::math::Vector3 model_rpy = model_pose.rot.GetAsEuler(); // convert to Euler angles for Gazebo XML
-    rpy_stream << model_rpy.x << " " << model_rpy.y << " " << model_rpy.z;
+    ignition::math::Vector3d model_rpy = model_pose.Rot().Euler(); // convert to Euler angles for Gazebo XML
+    rpy_stream << model_rpy.X() << " " << model_rpy.Y() << " " << model_rpy.Z();
 
     origin_key->SetAttribute("xyz",xyz_stream.str());
     origin_key->SetAttribute("rpy",rpy_stream.str());

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -1659,8 +1659,9 @@ void GazeboRosApiPlugin::updateLinkState(const gazebo_msgs::LinkState::ConstPtr&
 }
 
 void GazeboRosApiPlugin::transformWrench( ignition::math::Vector3d &target_force, ignition::math::Vector3d &target_torque,
-                                          ignition::math::Vector3d reference_force, ignition::math::Vector3d reference_torque,
-                                          ignition::math::Pose3d target_to_reference )
+                                          const ignition::math::Vector3d &reference_force,
+                                          const ignition::math::Vector3d &reference_torque,
+                                          const ignition::math::Pose3d &target_to_reference )
 {
   // rotate force into target frame
   target_force = target_to_reference.Rot().RotateVector(reference_force);
@@ -2082,9 +2083,9 @@ void GazeboRosApiPlugin::stripXmlDeclaration(std::string &model_xml)
 }
 
 void GazeboRosApiPlugin::updateSDFAttributes(TiXmlDocument &gazebo_model_xml,
-                                             std::string model_name,
-                                             ignition::math::Vector3d initial_xyz,
-                                             ignition::math::Quaterniond initial_q)
+                                             const std::string &model_name,
+                                             const ignition::math::Vector3d &initial_xyz,
+                                             const ignition::math::Quaterniond &initial_q)
 {
   // This function can handle both regular SDF files and <include> SDFs that are used with the
   // Gazebo Model Database
@@ -2242,7 +2243,9 @@ ignition::math::Vector3d GazeboRosApiPlugin::parseVector3(const std::string &str
   }
 }
 
-void GazeboRosApiPlugin::updateURDFModelPose(TiXmlDocument &gazebo_model_xml, ignition::math::Vector3d initial_xyz, ignition::math::Quaterniond initial_q)
+void GazeboRosApiPlugin::updateURDFModelPose(TiXmlDocument &gazebo_model_xml,
+                                             const ignition::math::Vector3d &initial_xyz,
+                                             const ignition::math::Quaterniond &initial_q)
 {
   TiXmlElement* model_tixml = (gazebo_model_xml.FirstChildElement("robot"));
   if (model_tixml)
@@ -2288,7 +2291,7 @@ void GazeboRosApiPlugin::updateURDFModelPose(TiXmlDocument &gazebo_model_xml, ig
     ROS_WARN_NAMED("api_plugin", "Could not find <model> element in sdf, so name and initial position is not applied");
 }
 
-void GazeboRosApiPlugin::updateURDFName(TiXmlDocument &gazebo_model_xml, std::string model_name)
+void GazeboRosApiPlugin::updateURDFName(TiXmlDocument &gazebo_model_xml, const std::string &model_name)
 {
   TiXmlElement* model_tixml = gazebo_model_xml.FirstChildElement("robot");
   // replace model name if one is specified by the user
@@ -2333,7 +2336,7 @@ void GazeboRosApiPlugin::walkChildAddRobotNamespace(TiXmlNode* model_xml)
   }
 }
 
-bool GazeboRosApiPlugin::spawnAndConform(TiXmlDocument &gazebo_model_xml, std::string model_name,
+bool GazeboRosApiPlugin::spawnAndConform(TiXmlDocument &gazebo_model_xml, const std::string &model_name,
                                          gazebo_msgs::SpawnModel::Response &res)
 {
   std::string entity_type = gazebo_model_xml.RootElement()->FirstChild()->Value();


### PR DESCRIPTION
{ port of pull request #635 }
Replace gazebo::math variables with ignition::math in several places in the private section of gazebo_ros_api_plugin.h and all local variables in the cpp file. Also, change some of the API's to pass const references to objects instead of copying them.