### PR TITLE
Fix gazebo8 warnings part 8: ifdef's for GetWorldPose

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
@@ -417,7 +417,11 @@ void GazeboRosDiffDrive::publishOdometry ( double step_time )
     }
     if ( odom_source_ == WORLD ) {
         // getting data form gazebo world
+#if GAZEBO_MAJOR_VERSION >= 8
+        ignition::math::Pose3d pose = parent->WorldPose();
+#else
         ignition::math::Pose3d pose = parent->GetWorldPose().Ign();
+#endif
         qt = tf::Quaternion ( pose.Rot().X(), pose.Rot().Y(), pose.Rot().Z(), pose.Rot().W() );
         vt = tf::Vector3 ( pose.Pos().X(), pose.Pos().Y(), pose.Pos().Z() );
 

--- a/gazebo_plugins/src/gazebo_ros_imu.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu.cpp
@@ -217,7 +217,11 @@ void GazeboRosIMU::UpdateChild()
     ignition::math::Vector3d pos;
 
     // Get Pose/Orientation ///@todo: verify correctness
+#if GAZEBO_MAJOR_VERSION >= 8
+    pose = this->link->WorldPose();
+#else
     pose = this->link->GetWorldPose().Ign();
+#endif
     // apply xyz offsets and get position and rotation components
     pos = pose.Pos() + this->offset_.Pos();
     rot = pose.Rot();

--- a/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
@@ -335,10 +335,18 @@ void GazeboRosJointPoseTrajectory::UpdateStates()
           cur_time.Double(), this->trajectory_index, this->points_.size());
 
         // get reference link pose before updates
+#if GAZEBO_MAJOR_VERSION >= 8
+        ignition::math::Pose3d reference_pose = this->model_->WorldPose();
+#else
         ignition::math::Pose3d reference_pose = this->model_->GetWorldPose().Ign();
+#endif
         if (this->reference_link_)
         {
+#if GAZEBO_MAJOR_VERSION >= 8
+          reference_pose = this->reference_link_->WorldPose();
+#else
           reference_pose = this->reference_link_->GetWorldPose().Ign();
+#endif
         }
 
         // trajectory roll-out based on time:

--- a/gazebo_plugins/src/gazebo_ros_joint_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_trajectory.cpp
@@ -337,10 +337,18 @@ void GazeboRosJointTrajectory::UpdateStates()
           cur_time.Double(), this->trajectory_index, this->points_.size());
 
         // get reference link pose before updates
+#if GAZEBO_MAJOR_VERSION >= 8
+        ignition::math::Pose3d reference_pose = this->model_->WorldPose();
+#else
         ignition::math::Pose3d reference_pose = this->model_->GetWorldPose().Ign();
+#endif
         if (this->reference_link_)
         {
+#if GAZEBO_MAJOR_VERSION >= 8
+          reference_pose = this->reference_link_->WorldPose();
+#else
           reference_pose = this->reference_link_->GetWorldPose().Ign();
+#endif
         }
 
         // trajectory roll-out based on time:

--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -234,13 +234,21 @@ void GazeboRosP3D::UpdateChild()
         ignition::math::Vector3d veul = this->link_->GetWorldAngularVel().Ign();
 
         // Get Pose/Orientation
+#if GAZEBO_MAJOR_VERSION >= 8
+        pose = this->link_->WorldPose();
+#else
         pose = this->link_->GetWorldPose().Ign();
+#endif
 
         // Apply Reference Frame
         if (this->reference_link_)
         {
           // convert to relative pose
+#if GAZEBO_MAJOR_VERSION >= 8
+          frame_pose = this->reference_link_->WorldPose();
+#else
           frame_pose = this->reference_link_->GetWorldPose().Ign();
+#endif
           pose.Pos() = pose.Pos() - frame_pose.Pos();
           pose.Pos() = frame_pose.Rot().RotateVectorReverse(pose.Pos());
           pose.Rot() *= frame_pose.Rot().Inverse();

--- a/gazebo_plugins/src/gazebo_ros_planar_move.cpp
+++ b/gazebo_plugins/src/gazebo_ros_planar_move.cpp
@@ -113,7 +113,11 @@ namespace gazebo
     }
 
     last_odom_publish_time_ = parent_->GetWorld()->GetSimTime();
+#if GAZEBO_MAJOR_VERSION >= 8
+    last_odom_pose_ = parent_->WorldPose();
+#else
     last_odom_pose_ = parent_->GetWorldPose().Ign();
+#endif
     x_ = 0;
     y_ = 0;
     rot_ = 0;
@@ -160,7 +164,11 @@ namespace gazebo
   void GazeboRosPlanarMove::UpdateChild()
   {
     boost::mutex::scoped_lock scoped_lock(lock);
+#if GAZEBO_MAJOR_VERSION >= 8
+    ignition::math::Pose3d pose = parent_->WorldPose();
+#else
     ignition::math::Pose3d pose = parent_->GetWorldPose().Ign();
+#endif
     float yaw = pose.Rot().Yaw();
     parent_->SetLinearVel(ignition::math::Vector3d(
           x_ * cosf(yaw) - y_ * sinf(yaw),
@@ -214,7 +222,11 @@ namespace gazebo
       tf::resolve(tf_prefix_, robot_base_frame_);
 
     // getting data for base_footprint to odom transform
+#if GAZEBO_MAJOR_VERSION >= 8
+    ignition::math::Pose3d pose = this->parent_->WorldPose();
+#else
     ignition::math::Pose3d pose = this->parent_->GetWorldPose().Ign();
+#endif
 
     tf::Quaternion qt(pose.Rot().X(), pose.Rot().Y(), pose.Rot().Z(), pose.Rot().W());
     tf::Vector3    vt(pose.Pos().X(), pose.Pos().Y(), pose.Pos().Z());

--- a/gazebo_plugins/src/gazebo_ros_skid_steer_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_skid_steer_drive.cpp
@@ -405,7 +405,11 @@ namespace gazebo {
 
     // TODO create some non-perfect odometry!
     // getting data for base_footprint to odom transform
+#if GAZEBO_MAJOR_VERSION >= 8
+    ignition::math::Pose3d pose = this->parent->WorldPose();
+#else
     ignition::math::Pose3d pose = this->parent->GetWorldPose().Ign();
+#endif
 
     tf::Quaternion qt(pose.Rot().X(), pose.Rot().Y(), pose.Rot().Z(), pose.Rot().W());
     tf::Vector3 vt(pose.Pos().X(), pose.Pos().Y(), pose.Pos().Z());

--- a/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
@@ -405,7 +405,11 @@ void GazeboRosTricycleDrive::publishOdometry ( double step_time )
     }
     if ( odom_source_ == WORLD ) {
         // getting data form gazebo world
+#if GAZEBO_MAJOR_VERSION >= 8
+        ignition::math::Pose3d pose = parent->WorldPose();
+#else
         ignition::math::Pose3d pose = parent->GetWorldPose().Ign();
+#endif
         qt = tf::Quaternion ( pose.Rot().X(), pose.Rot().Y(), pose.Rot().Z(), pose.Rot().W() );
         vt = tf::Vector3 ( pose.Pos().X(), pose.Pos().Y(), pose.Pos().Z() );
 

--- a/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
@@ -194,7 +194,11 @@ void GazeboRosVacuumGripper::UpdateChild()
     }
     physics::Link_V links = models[i]->GetLinks();
     for (size_t j = 0; j < links.size(); j++) {
+#if GAZEBO_MAJOR_VERSION >= 8
+      ignition::math::Pose3d link_pose = links[j]->WorldPose();
+#else
       ignition::math::Pose3d link_pose = links[j]->GetWorldPose().Ign();
+#endif
       ignition::math::Pose3d diff = parent_pose - link_pose;
       double norm = diff.Pos().Length();
       if (norm < 0.05) {

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -1453,11 +1453,7 @@ bool GazeboRosApiPlugin::setModelState(gazebo_msgs::SetModelState::Request &req,
     world_->SetPaused(true);
     model->SetWorldPose(target_pose);
     world_->SetPaused(is_paused);
-#if GAZEBO_MAJOR_VERSION >= 8
     //ignition::math::Pose3d p3d = model->WorldPose();
-#else
-    //ignition::math::Pose3d p3d = model->GetWorldPose().Ign();
-#endif
     //ROS_ERROR_NAMED("api_plugin", "model updated state: %f %f %f",p3d.Pos().X(),p3d.Pos().Y(),p3d.Pos().Z());
 
     // set model velocity


### PR DESCRIPTION
The uses of GetWorldPose were organized such that I could use the following sed scripts to assist in adding ifdef's in 0691135.

~~~
sed -i -e 's@.*GetWorldPose.*@#if GAZEBO_MAJOR_VERSION >= 8\
__REPLACE__&\
\#else\
&\
\#endif
~~~

~~~
sed -i -e \
  's@^__REPLACE__\(.*\)GetWorldPose()\.Ign\(.*\)@\1WorldPose\2@' \
  $(grep -rlI GetWorldPose gazebo_* | grep -v vacuum)
~~~