### PR TITLE
Fix gazebo8 warnings part 8: ifdef's for GetWorldPose (lunar-devel)

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
@@ -194,7 +194,11 @@ void GazeboRosVacuumGripper::UpdateChild()
     }
     physics::Link_V links = models[i]->GetLinks();
     for (size_t j = 0; j < links.size(); j++) {
+#if GAZEBO_MAJOR_VERSION >= 8
+      ignition::math::Pose3d link_pose = links[j]->WorldPose();
+#else
       ignition::math::Pose3d link_pose = links[j]->GetWorldPose().Ign();
+#endif
       ignition::math::Pose3d diff = parent_pose - link_pose;
       double norm = diff.Pos().Length();
       if (norm < 0.05) {


### PR DESCRIPTION
{ port of pull request #650 }
The uses of GetWorldPose were organized such that I could use the following sed scripts to assist in adding ifdef's in 0691135.

~~~
sed -i -e 's@.*GetWorldPose.*@#if GAZEBO_MAJOR_VERSION >= 8\
__REPLACE__&\
\#else\
&\
\#endif
~~~

~~~
sed -i -e \
  's@^__REPLACE__\(.*\)GetWorldPose()\.Ign\(.*\)@\1WorldPose\2@' \
  $(grep -rlI GetWorldPose gazebo_* | grep -v vacuum)
~~~