### PR TITLE
Fix gazebo8 warnings part 9: ifdef's for Get.*Vel

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
@@ -416,7 +416,7 @@ void GazeboRosDiffDrive::publishOdometry ( double step_time )
 
     }
     if ( odom_source_ == WORLD ) {
-        // getting data form gazebo world
+        // getting data from gazebo world
 #if GAZEBO_MAJOR_VERSION >= 8
         ignition::math::Pose3d pose = parent->WorldPose();
 #else
@@ -436,8 +436,13 @@ void GazeboRosDiffDrive::publishOdometry ( double step_time )
 
         // get velocity in /odom frame
         ignition::math::Vector3d linear;
+#if GAZEBO_MAJOR_VERSION >= 8
+        linear = parent->WorldLinearVel();
+        odom_.twist.twist.angular.z = parent->WorldAngularVel().Z();
+#else
         linear = parent->GetWorldLinearVel().Ign();
         odom_.twist.twist.angular.z = parent->GetWorldAngularVel().Ign().Z();
+#endif
 
         // convert velocity to child_frame_id (aka base_footprint)
         float yaw = pose.Rot().Yaw();

--- a/gazebo_plugins/src/gazebo_ros_imu.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu.cpp
@@ -174,8 +174,13 @@ void GazeboRosIMU::LoadThread()
   this->last_time_ = this->world_->GetSimTime();
 
   // this->initial_pose_ = this->link->GetPose();
+#if GAZEBO_MAJOR_VERSION >= 8
+  this->last_vpos_ = this->link->WorldLinearVel();
+  this->last_veul_ = this->link->WorldAngularVel();
+#else
   this->last_vpos_ = this->link->GetWorldLinearVel().Ign();
   this->last_veul_ = this->link->GetWorldAngularVel().Ign();
+#endif
   this->apos_ = 0;
   this->aeul_ = 0;
 
@@ -231,8 +236,13 @@ void GazeboRosIMU::UpdateChild()
     rot.Normalize();
 
     // get Rates
+#if GAZEBO_MAJOR_VERSION >= 8
+    ignition::math::Vector3d vpos = this->link->WorldLinearVel();
+    ignition::math::Vector3d veul = this->link->WorldAngularVel();
+#else
     ignition::math::Vector3d vpos = this->link->GetWorldLinearVel().Ign();
     ignition::math::Vector3d veul = this->link->GetWorldAngularVel().Ign();
+#endif
 
     // differentiate to get accelerations
     double tmp_dt = this->last_time_.Double() - cur_time.Double();

--- a/gazebo_plugins/src/gazebo_ros_skid_steer_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_skid_steer_drive.cpp
@@ -440,8 +440,13 @@ namespace gazebo {
 
     // get velocity in /odom frame
     ignition::math::Vector3d linear;
+#if GAZEBO_MAJOR_VERSION >= 8
+    linear = this->parent->WorldLinearVel();
+    odom_.twist.twist.angular.z = this->parent->WorldAngularVel().Z();
+#else
     linear = this->parent->GetWorldLinearVel().Ign();
     odom_.twist.twist.angular.z = this->parent->GetWorldAngularVel().Ign().Z();
+#endif
 
     // convert velocity to child_frame_id (aka base_footprint)
     float yaw = pose.Rot().Yaw();

--- a/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
@@ -424,8 +424,13 @@ void GazeboRosTricycleDrive::publishOdometry ( double step_time )
 
         // get velocity in /odom frame
         ignition::math::Vector3d linear;
+#if GAZEBO_MAJOR_VERSION >= 8
+        linear = parent->WorldLinearVel();
+        odom_.twist.twist.angular.z = parent->WorldAngularVel().Z();
+#else
         linear = parent->GetWorldLinearVel().Ign();
         odom_.twist.twist.angular.z = parent->GetWorldAngularVel().Ign().Z();
+#endif
 
         // convert velocity to child_frame_id (aka base_footprint)
         float yaw = pose.Rot().Yaw();

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -854,34 +854,37 @@ bool GazeboRosApiPlugin::getModelState(gazebo_msgs::GetModelState::Request &req,
       res.header.frame_id = req.relative_entity_name; /// @brief this is a redundant information
     }
     // get model pose
+    // get model twist
 #if GAZEBO_MAJOR_VERSION >= 8
     ignition::math::Pose3d      model_pose = model->WorldPose();
+    ignition::math::Vector3d model_linear_vel  = model->WorldLinearVel();
+    ignition::math::Vector3d model_angular_vel = model->WorldAngularVel();
 #else
     ignition::math::Pose3d      model_pose = model->GetWorldPose().Ign();
+    ignition::math::Vector3d model_linear_vel  = model->GetWorldLinearVel().Ign();
+    ignition::math::Vector3d model_angular_vel = model->GetWorldAngularVel().Ign();
 #endif
     ignition::math::Vector3d    model_pos = model_pose.Pos();
     ignition::math::Quaterniond model_rot = model_pose.Rot();
 
-    // get model twist
-    ignition::math::Vector3d model_linear_vel  = model->GetWorldLinearVel().Ign();
-    ignition::math::Vector3d model_angular_vel = model->GetWorldAngularVel().Ign();
 
 
     if (frame)
     {
-      // convert to relative pose
+      // convert to relative pose, rates
 #if GAZEBO_MAJOR_VERSION >= 8
       ignition::math::Pose3d frame_pose = frame->WorldPose();
+      ignition::math::Vector3d frame_vpos = frame->WorldLinearVel(); // get velocity in gazebo frame
+      ignition::math::Vector3d frame_veul = frame->WorldAngularVel(); // get velocity in gazebo frame
 #else
       ignition::math::Pose3d frame_pose = frame->GetWorldPose().Ign();
+      ignition::math::Vector3d frame_vpos = frame->GetWorldLinearVel().Ign(); // get velocity in gazebo frame
+      ignition::math::Vector3d frame_veul = frame->GetWorldAngularVel().Ign(); // get velocity in gazebo frame
 #endif
       model_pos = model_pos - frame_pose.Pos();
       model_pos = frame_pose.Rot().RotateVectorReverse(model_pos);
       model_rot *= frame_pose.Rot().Inverse();
 
-      // convert to relative rates
-      ignition::math::Vector3d frame_vpos = frame->GetWorldLinearVel().Ign(); // get velocity in gazebo frame
-      ignition::math::Vector3d frame_veul = frame->GetWorldAngularVel().Ign(); // get velocity in gazebo frame
       model_linear_vel = frame_pose.Rot().RotateVector(model_linear_vel - frame_vpos);
       model_angular_vel = frame_pose.Rot().RotateVector(model_angular_vel - frame_veul);
     }
@@ -1104,30 +1107,33 @@ bool GazeboRosApiPlugin::getLinkState(gazebo_msgs::GetLinkState::Request &req,
   }
 
   // get body pose
+  // Get inertial rates
 #if GAZEBO_MAJOR_VERSION >= 8
   ignition::math::Pose3d body_pose = body->WorldPose();
+  ignition::math::Vector3d body_vpos = body->WorldLinearVel(); // get velocity in gazebo frame
+  ignition::math::Vector3d body_veul = body->WorldAngularVel(); // get velocity in gazebo frame
 #else
   ignition::math::Pose3d body_pose = body->GetWorldPose().Ign();
-#endif
-  // Get inertial rates
   ignition::math::Vector3d body_vpos = body->GetWorldLinearVel().Ign(); // get velocity in gazebo frame
   ignition::math::Vector3d body_veul = body->GetWorldAngularVel().Ign(); // get velocity in gazebo frame
+#endif
 
   if (frame)
   {
-    // convert to relative pose
+    // convert to relative pose, rates
 #if GAZEBO_MAJOR_VERSION >= 8
     ignition::math::Pose3d frame_pose = frame->WorldPose();
+    ignition::math::Vector3d frame_vpos = frame->WorldLinearVel(); // get velocity in gazebo frame
+    ignition::math::Vector3d frame_veul = frame->WorldAngularVel(); // get velocity in gazebo frame
 #else
     ignition::math::Pose3d frame_pose = frame->GetWorldPose().Ign();
+    ignition::math::Vector3d frame_vpos = frame->GetWorldLinearVel().Ign(); // get velocity in gazebo frame
+    ignition::math::Vector3d frame_veul = frame->GetWorldAngularVel().Ign(); // get velocity in gazebo frame
 #endif
     body_pose.Pos() = body_pose.Pos() - frame_pose.Pos();
     body_pose.Pos() = frame_pose.Rot().RotateVectorReverse(body_pose.Pos());
     body_pose.Rot() *= frame_pose.Rot().Inverse();
 
-    // convert to relative rates
-    ignition::math::Vector3d frame_vpos = frame->GetWorldLinearVel().Ign(); // get velocity in gazebo frame
-    ignition::math::Vector3d frame_veul = frame->GetWorldAngularVel().Ign(); // get velocity in gazebo frame
     body_vpos = frame_pose.Rot().RotateVector(body_vpos - frame_vpos);
     body_veul = frame_pose.Rot().RotateVector(body_veul - frame_veul);
   }
@@ -1656,8 +1662,12 @@ bool GazeboRosApiPlugin::setLinkState(gazebo_msgs::SetLinkState::Request &req,
   {
 #if GAZEBO_MAJOR_VERSION >= 8
     ignition::math::Pose3d  frame_pose = frame->WorldPose(); // - myBody->GetCoMPose();
+    ignition::math::Vector3d frame_linear_vel = frame->WorldLinearVel();
+    ignition::math::Vector3d frame_angular_vel = frame->WorldAngularVel();
 #else
     ignition::math::Pose3d  frame_pose = frame->GetWorldPose().Ign(); // - myBody->GetCoMPose();
+    ignition::math::Vector3d frame_linear_vel = frame->GetWorldLinearVel().Ign();
+    ignition::math::Vector3d frame_angular_vel = frame->GetWorldAngularVel().Ign();
 #endif
     ignition::math::Vector3d frame_pos = frame_pose.Pos();
     ignition::math::Quaterniond frame_rot = frame_pose.Rot();
@@ -1667,8 +1677,6 @@ bool GazeboRosApiPlugin::setLinkState(gazebo_msgs::SetLinkState::Request &req,
     target_pose.Pos() = frame_pos + frame_rot.RotateVector(target_pos);
     target_pose.Rot() = frame_rot * target_pose.Rot();
 
-    ignition::math::Vector3d frame_linear_vel = frame->GetWorldLinearVel().Ign();
-    ignition::math::Vector3d frame_angular_vel = frame->GetWorldAngularVel().Ign();
     target_linear_vel -= frame_linear_vel;
     target_angular_vel -= frame_angular_vel;
   }
@@ -1982,8 +1990,12 @@ void GazeboRosApiPlugin::publishLinkStates()
         geometry_msgs::Pose pose;
 #if GAZEBO_MAJOR_VERSION >= 8
         ignition::math::Pose3d  body_pose = body->WorldPose(); // - myBody->GetCoMPose();
+        ignition::math::Vector3d linear_vel  = body->WorldLinearVel();
+        ignition::math::Vector3d angular_vel = body->WorldAngularVel();
 #else
         ignition::math::Pose3d  body_pose = body->GetWorldPose().Ign(); // - myBody->GetCoMPose();
+        ignition::math::Vector3d linear_vel  = body->GetWorldLinearVel().Ign();
+        ignition::math::Vector3d angular_vel = body->GetWorldAngularVel().Ign();
 #endif
         ignition::math::Vector3d pos = body_pose.Pos();
         ignition::math::Quaterniond rot = body_pose.Rot();
@@ -1995,8 +2007,6 @@ void GazeboRosApiPlugin::publishLinkStates()
         pose.orientation.y = rot.Y();
         pose.orientation.z = rot.Z();
         link_states.pose.push_back(pose);
-        ignition::math::Vector3d linear_vel  = body->GetWorldLinearVel().Ign();
-        ignition::math::Vector3d angular_vel = body->GetWorldAngularVel().Ign();
         geometry_msgs::Twist twist;
         twist.linear.x = linear_vel.X();
         twist.linear.y = linear_vel.Y();
@@ -2024,8 +2034,12 @@ void GazeboRosApiPlugin::publishModelStates()
     geometry_msgs::Pose pose;
 #if GAZEBO_MAJOR_VERSION >= 8
     ignition::math::Pose3d  model_pose = model->WorldPose(); // - myBody->GetCoMPose();
+    ignition::math::Vector3d linear_vel  = model->WorldLinearVel();
+    ignition::math::Vector3d angular_vel = model->WorldAngularVel();
 #else
     ignition::math::Pose3d  model_pose = model->GetWorldPose().Ign(); // - myBody->GetCoMPose();
+    ignition::math::Vector3d linear_vel  = model->GetWorldLinearVel().Ign();
+    ignition::math::Vector3d angular_vel = model->GetWorldAngularVel().Ign();
 #endif
     ignition::math::Vector3d pos = model_pose.Pos();
     ignition::math::Quaterniond rot = model_pose.Rot();
@@ -2037,8 +2051,6 @@ void GazeboRosApiPlugin::publishModelStates()
     pose.orientation.y = rot.Y();
     pose.orientation.z = rot.Z();
     model_states.pose.push_back(pose);
-    ignition::math::Vector3d linear_vel  = model->GetWorldLinearVel().Ign();
-    ignition::math::Vector3d angular_vel = model->GetWorldAngularVel().Ign();
     geometry_msgs::Twist twist;
     twist.linear.x = linear_vel.X();
     twist.linear.y = linear_vel.Y();


### PR DESCRIPTION
A lot of this was done manually. Some of it was adding new ifdef's, and some of it was moving variable declarations to existing ifdef blocks for GetWorldPose calls.