### PR TITLE
Fix gazebo8 warnings part 9: ifdef's for Get.*Vel (lunar-devel)

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
@@ -412,7 +412,7 @@ void GazeboRosDiffDrive::publishOdometry ( double step_time )
 
     }
     if ( odom_source_ == WORLD ) {
-        // getting data form gazebo world
+        // getting data from gazebo world
 #if GAZEBO_MAJOR_VERSION >= 8
         ignition::math::Pose3d pose = parent->WorldPose();
 #else
@@ -432,8 +432,13 @@ void GazeboRosDiffDrive::publishOdometry ( double step_time )
 
         // get velocity in /odom frame
         ignition::math::Vector3d linear;
+#if GAZEBO_MAJOR_VERSION >= 8
+        linear = parent->WorldLinearVel();
+        odom_.twist.twist.angular.z = parent->WorldAngularVel().Z();
+#else
         linear = parent->GetWorldLinearVel().Ign();
         odom_.twist.twist.angular.z = parent->GetWorldAngularVel().Ign().Z();
+#endif
 
         // convert velocity to child_frame_id (aka base_footprint)
         float yaw = pose.Rot().Yaw();

--- a/gazebo_plugins/src/gazebo_ros_imu.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu.cpp
@@ -174,8 +174,13 @@ void GazeboRosIMU::LoadThread()
   this->last_time_ = this->world_->GetSimTime();
 
   // this->initial_pose_ = this->link->GetPose();
+#if GAZEBO_MAJOR_VERSION >= 8
+  this->last_vpos_ = this->link->WorldLinearVel();
+  this->last_veul_ = this->link->WorldAngularVel();
+#else
   this->last_vpos_ = this->link->GetWorldLinearVel().Ign();
   this->last_veul_ = this->link->GetWorldAngularVel().Ign();
+#endif
   this->apos_ = 0;
   this->aeul_ = 0;
 
@@ -231,8 +236,13 @@ void GazeboRosIMU::UpdateChild()
     rot.Normalize();
 
     // get Rates
+#if GAZEBO_MAJOR_VERSION >= 8
+    ignition::math::Vector3d vpos = this->link->WorldLinearVel();
+    ignition::math::Vector3d veul = this->link->WorldAngularVel();
+#else
     ignition::math::Vector3d vpos = this->link->GetWorldLinearVel().Ign();
     ignition::math::Vector3d veul = this->link->GetWorldAngularVel().Ign();
+#endif
 
     // differentiate to get accelerations
     double tmp_dt = this->last_time_.Double() - cur_time.Double();

--- a/gazebo_plugins/src/gazebo_ros_skid_steer_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_skid_steer_drive.cpp
@@ -440,8 +440,13 @@ namespace gazebo {
 
     // get velocity in /odom frame
     ignition::math::Vector3d linear;
+#if GAZEBO_MAJOR_VERSION >= 8
+    linear = this->parent->WorldLinearVel();
+    odom_.twist.twist.angular.z = this->parent->WorldAngularVel().Z();
+#else
     linear = this->parent->GetWorldLinearVel().Ign();
     odom_.twist.twist.angular.z = this->parent->GetWorldAngularVel().Ign().Z();
+#endif
 
     // convert velocity to child_frame_id (aka base_footprint)
     float yaw = pose.Rot().Yaw();

--- a/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
@@ -416,8 +416,13 @@ void GazeboRosTricycleDrive::publishOdometry ( double step_time )
 
         // get velocity in /odom frame
         ignition::math::Vector3d linear;
+#if GAZEBO_MAJOR_VERSION >= 8
+        linear = parent->WorldLinearVel();
+        odom_.twist.twist.angular.z = parent->WorldAngularVel().Z();
+#else
         linear = parent->GetWorldLinearVel().Ign();
         odom_.twist.twist.angular.z = parent->GetWorldAngularVel().Ign().Z();
+#endif
 
         // convert velocity to child_frame_id (aka base_footprint)
         float yaw = pose.Rot().Yaw();


### PR DESCRIPTION
{ port of pull request #653 }
A lot of this was done manually. Some of it was adding new ifdef's, and some of it was moving variable declarations to existing ifdef blocks for GetWorldPose calls.