### PR TITLE
Fix gazebo8 warnings part 10: ifdefs for GetModel, GetEntity, Light

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_imu.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu.cpp
@@ -147,7 +147,11 @@ void GazeboRosIMU::LoadThread()
 
   // assert that the body by link_name_ exists
   this->link = boost::dynamic_pointer_cast<physics::Link>(
+#if GAZEBO_MAJOR_VERSION >= 8
+    this->world_->EntityByName(this->link_name_));
+#else
     this->world_->GetEntity(this->link_name_));
+#endif
   if (!this->link)
   {
     ROS_FATAL_NAMED("imu", "gazebo_ros_imu plugin error: bodyName: %s does not exist\n",

--- a/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
@@ -267,7 +267,11 @@ bool GazeboRosJointPoseTrajectory::SetTrajectory(
                 " inertially", this->reference_link_->GetName().c_str());
   }
 
+#if GAZEBO_MAJOR_VERSION >= 8
+  this->model_ =  this->world_->ModelByName(req.model_name);
+#else
   this->model_ =  this->world_->GetModel(req.model_name);
+#endif
   if (!this->model_)  // look for it by frame_id name
   {
     this->model_ = this->reference_link_->GetParentModel();

--- a/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
@@ -171,7 +171,11 @@ void GazeboRosJointPoseTrajectory::SetTrajectory(
       this->reference_link_name_ != "map")
   {
     physics::EntityPtr ent =
+#if GAZEBO_MAJOR_VERSION >= 8
+      this->world_->EntityByName(this->reference_link_name_);
+#else
       this->world_->GetEntity(this->reference_link_name_);
+#endif
     if (ent)
       this->reference_link_ = boost::dynamic_pointer_cast<physics::Link>(ent);
     if (!this->reference_link_)
@@ -250,7 +254,11 @@ bool GazeboRosJointPoseTrajectory::SetTrajectory(
       this->reference_link_name_ != "map")
   {
     physics::EntityPtr ent =
+#if GAZEBO_MAJOR_VERSION >= 8
+      this->world_->EntityByName(this->reference_link_name_);
+#else
       this->world_->GetEntity(this->reference_link_name_);
+#endif
     if (ent)
       this->reference_link_ = boost::dynamic_pointer_cast<physics::Link>(ent);
     if (!this->reference_link_)

--- a/gazebo_plugins/src/gazebo_ros_joint_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_trajectory.cpp
@@ -269,7 +269,11 @@ bool GazeboRosJointTrajectory::SetTrajectory(
                 " inertially", this->reference_link_->GetName().c_str());
   }
 
+#if GAZEBO_MAJOR_VERSION >= 8
+  this->model_ =  this->world_->ModelByName(req.model_name);
+#else
   this->model_ =  this->world_->GetModel(req.model_name);
+#endif
   if (!this->model_)  // look for it by frame_id name
   {
     this->model_ = this->reference_link_->GetParentModel();

--- a/gazebo_plugins/src/gazebo_ros_joint_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_trajectory.cpp
@@ -173,7 +173,11 @@ void GazeboRosJointTrajectory::SetTrajectory(
       this->reference_link_name_ != "map")
   {
     physics::EntityPtr ent =
+#if GAZEBO_MAJOR_VERSION >= 8
+      this->world_->EntityByName(this->reference_link_name_);
+#else
       this->world_->GetEntity(this->reference_link_name_);
+#endif
     if (ent)
       this->reference_link_ = boost::dynamic_pointer_cast<physics::Link>(ent);
     if (!this->reference_link_)
@@ -252,7 +256,11 @@ bool GazeboRosJointTrajectory::SetTrajectory(
       this->reference_link_name_ != "map")
   {
     physics::EntityPtr ent =
+#if GAZEBO_MAJOR_VERSION >= 8
+      this->world_->EntityByName(this->reference_link_name_);
+#else
       this->world_->GetEntity(this->reference_link_name_);
+#endif
     if (ent)
       this->reference_link_ = boost::shared_dynamic_cast<physics::Link>(ent);
     if (!this->reference_link_)

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -785,7 +785,11 @@ bool GazeboRosApiPlugin::deleteModel(gazebo_msgs::DeleteModel::Request &req,
 bool GazeboRosApiPlugin::deleteLight(gazebo_msgs::DeleteLight::Request &req,
                                      gazebo_msgs::DeleteLight::Response &res)
 {
+#if GAZEBO_MAJOR_VERSION >= 8
+  gazebo::physics::LightPtr phy_light = world_->LightByName(req.light_name);
+#else
   gazebo::physics::LightPtr phy_light = world_->Light(req.light_name);
+#endif
 
   if (phy_light == NULL)
   {
@@ -801,7 +805,11 @@ bool GazeboRosApiPlugin::deleteLight(gazebo_msgs::DeleteLight::Request &req,
 
     for (int i = 0; i < 100; i++)
     {
+#if GAZEBO_MAJOR_VERSION >= 8
+      phy_light = world_->LightByName(req.light_name);
+#else
       phy_light = world_->Light(req.light_name);
+#endif
       if (phy_light == NULL)
       {
         res.success = true;
@@ -1173,7 +1181,11 @@ bool GazeboRosApiPlugin::getLinkState(gazebo_msgs::GetLinkState::Request &req,
 bool GazeboRosApiPlugin::getLightProperties(gazebo_msgs::GetLightProperties::Request &req,
                                                gazebo_msgs::GetLightProperties::Response &res)
 {
+#if GAZEBO_MAJOR_VERSION >= 8
+  gazebo::physics::LightPtr phy_light = world_->LightByName(req.light_name);
+#else
   gazebo::physics::LightPtr phy_light = world_->Light(req.light_name);
+#endif
 
   if (phy_light == NULL)
   {
@@ -1203,7 +1215,11 @@ bool GazeboRosApiPlugin::getLightProperties(gazebo_msgs::GetLightProperties::Req
 bool GazeboRosApiPlugin::setLightProperties(gazebo_msgs::SetLightProperties::Request &req,
                                                gazebo_msgs::SetLightProperties::Response &res)
 {
+#if GAZEBO_MAJOR_VERSION >= 8
+  gazebo::physics::LightPtr phy_light = world_->LightByName(req.light_name);
+#else
   gazebo::physics::LightPtr phy_light = world_->Light(req.light_name);
+#endif
 
   if (phy_light == NULL)
   {
@@ -2451,7 +2467,11 @@ bool GazeboRosApiPlugin::spawnAndConform(TiXmlDocument &gazebo_model_xml, const 
   // todo: should wait for response response_sub_, check to see that if _msg->response == "nonexistant"
 
   gazebo::physics::ModelPtr model = world_->GetModel(model_name);
+#if GAZEBO_MAJOR_VERSION >= 8
+  gazebo::physics::LightPtr light = world_->LightByName(model_name);
+#else
   gazebo::physics::LightPtr light = world_->Light(model_name);
+#endif
   if ((isLight && light != NULL) || (model != NULL))
   {
     ROS_ERROR_NAMED("api_plugin", "SpawnModel: Failure - model name %s already exist.",model_name.c_str());
@@ -2493,7 +2513,11 @@ bool GazeboRosApiPlugin::spawnAndConform(TiXmlDocument &gazebo_model_xml, const 
 
     {
       //boost::recursive_mutex::scoped_lock lock(*world->GetMRMutex());
+#if GAZEBO_MAJOR_VERSION >= 8
+      if ((isLight && world_->LightByName(model_name) != NULL)
+#else
       if ((isLight && world_->Light(model_name) != NULL)
+#endif
           || (world_->GetModel(model_name) != NULL))
         break;
     }

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -844,12 +844,9 @@ bool GazeboRosApiPlugin::getModelState(gazebo_msgs::GetModelState::Request &req,
 {
 #if GAZEBO_MAJOR_VERSION >= 8
   gazebo::physics::ModelPtr model = world_->ModelByName(req.model_name);
-#else
-  gazebo::physics::ModelPtr model = world_->GetModel(req.model_name);
-#endif
-#if GAZEBO_MAJOR_VERSION >= 8
   gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->EntityByName(req.relative_entity_name));
 #else
+  gazebo::physics::ModelPtr model = world_->GetModel(req.model_name);
   gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.relative_entity_name));
 #endif
   if (!model)
@@ -1145,12 +1142,9 @@ bool GazeboRosApiPlugin::getLinkState(gazebo_msgs::GetLinkState::Request &req,
 {
 #if GAZEBO_MAJOR_VERSION >= 8
   gazebo::physics::LinkPtr body = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->EntityByName(req.link_name));
-#else
-  gazebo::physics::LinkPtr body = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.link_name));
-#endif
-#if GAZEBO_MAJOR_VERSION >= 8
   gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->EntityByName(req.reference_frame));
 #else
+  gazebo::physics::LinkPtr body = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.link_name));
   gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.reference_frame));
 #endif
 
@@ -1732,12 +1726,9 @@ bool GazeboRosApiPlugin::setLinkState(gazebo_msgs::SetLinkState::Request &req,
 {
 #if GAZEBO_MAJOR_VERSION >= 8
   gazebo::physics::LinkPtr body = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->EntityByName(req.link_state.link_name));
-#else
-  gazebo::physics::LinkPtr body = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.link_state.link_name));
-#endif
-#if GAZEBO_MAJOR_VERSION >= 8
   gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->EntityByName(req.link_state.reference_frame));
 #else
+  gazebo::physics::LinkPtr body = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.link_state.link_name));
   gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.link_state.reference_frame));
 #endif
   if (!body)
@@ -1835,12 +1826,9 @@ bool GazeboRosApiPlugin::applyBodyWrench(gazebo_msgs::ApplyBodyWrench::Request &
 {
 #if GAZEBO_MAJOR_VERSION >= 8
   gazebo::physics::LinkPtr body = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->EntityByName(req.body_name));
-#else
-  gazebo::physics::LinkPtr body = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.body_name));
-#endif
-#if GAZEBO_MAJOR_VERSION >= 8
   gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->EntityByName(req.reference_frame));
 #else
+  gazebo::physics::LinkPtr body = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.body_name));
   gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.reference_frame));
 #endif
   if (!body)

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -626,7 +626,11 @@ bool GazeboRosApiPlugin::spawnSDFModel(gazebo_msgs::SpawnModel::Request &req,
   ignition::math::Quaterniond initial_q(req.initial_pose.orientation.w,req.initial_pose.orientation.x,req.initial_pose.orientation.y,req.initial_pose.orientation.z);
 
   // refernce frame for initial pose definition, modify initial pose if defined
+#if GAZEBO_MAJOR_VERSION >= 8
+  gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->EntityByName(req.reference_frame));
+#else
   gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.reference_frame));
+#endif
   if (frame)
   {
     // convert to relative pose
@@ -843,7 +847,11 @@ bool GazeboRosApiPlugin::getModelState(gazebo_msgs::GetModelState::Request &req,
 #else
   gazebo::physics::ModelPtr model = world_->GetModel(req.model_name);
 #endif
+#if GAZEBO_MAJOR_VERSION >= 8
+  gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->EntityByName(req.relative_entity_name));
+#else
   gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.relative_entity_name));
+#endif
   if (!model)
   {
     ROS_ERROR_NAMED("api_plugin", "GetModelState: model [%s] does not exist",req.model_name.c_str());
@@ -1077,7 +1085,11 @@ bool GazeboRosApiPlugin::getJointProperties(gazebo_msgs::GetJointProperties::Req
 bool GazeboRosApiPlugin::getLinkProperties(gazebo_msgs::GetLinkProperties::Request &req,
                                            gazebo_msgs::GetLinkProperties::Response &res)
 {
+#if GAZEBO_MAJOR_VERSION >= 8
+  gazebo::physics::LinkPtr body = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->EntityByName(req.link_name));
+#else
   gazebo::physics::LinkPtr body = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.link_name));
+#endif
   if (!body)
   {
     res.success = false;
@@ -1131,8 +1143,16 @@ bool GazeboRosApiPlugin::getLinkProperties(gazebo_msgs::GetLinkProperties::Reque
 bool GazeboRosApiPlugin::getLinkState(gazebo_msgs::GetLinkState::Request &req,
                                       gazebo_msgs::GetLinkState::Response &res)
 {
+#if GAZEBO_MAJOR_VERSION >= 8
+  gazebo::physics::LinkPtr body = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->EntityByName(req.link_name));
+#else
   gazebo::physics::LinkPtr body = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.link_name));
+#endif
+#if GAZEBO_MAJOR_VERSION >= 8
+  gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->EntityByName(req.reference_frame));
+#else
   gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.reference_frame));
+#endif
 
   if (!body)
   {
@@ -1279,7 +1299,11 @@ bool GazeboRosApiPlugin::setLightProperties(gazebo_msgs::SetLightProperties::Req
 bool GazeboRosApiPlugin::setLinkProperties(gazebo_msgs::SetLinkProperties::Request &req,
                                            gazebo_msgs::SetLinkProperties::Response &res)
 {
+#if GAZEBO_MAJOR_VERSION >= 8
+  gazebo::physics::LinkPtr body = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->EntityByName(req.link_name));
+#else
   gazebo::physics::LinkPtr body = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.link_name));
+#endif
   if (!body)
   {
     res.success = false;
@@ -1468,7 +1492,11 @@ bool GazeboRosApiPlugin::setModelState(gazebo_msgs::SetModelState::Request &req,
   }
   else
   {
+#if GAZEBO_MAJOR_VERSION >= 8
+    gazebo::physics::LinkPtr relative_entity = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->EntityByName(req.model_state.reference_frame));
+#else
     gazebo::physics::LinkPtr relative_entity = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.model_state.reference_frame));
+#endif
     if (relative_entity)
     {
 #if GAZEBO_MAJOR_VERSION >= 8
@@ -1702,8 +1730,16 @@ bool GazeboRosApiPlugin::setModelConfiguration(gazebo_msgs::SetModelConfiguratio
 bool GazeboRosApiPlugin::setLinkState(gazebo_msgs::SetLinkState::Request &req,
                                       gazebo_msgs::SetLinkState::Response &res)
 {
+#if GAZEBO_MAJOR_VERSION >= 8
+  gazebo::physics::LinkPtr body = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->EntityByName(req.link_state.link_name));
+#else
   gazebo::physics::LinkPtr body = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.link_state.link_name));
+#endif
+#if GAZEBO_MAJOR_VERSION >= 8
+  gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->EntityByName(req.link_state.reference_frame));
+#else
   gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.link_state.reference_frame));
+#endif
   if (!body)
   {
     ROS_ERROR_NAMED("api_plugin", "Updating LinkState: link [%s] does not exist",req.link_state.link_name.c_str());
@@ -1797,8 +1833,16 @@ void GazeboRosApiPlugin::transformWrench( ignition::math::Vector3d &target_force
 bool GazeboRosApiPlugin::applyBodyWrench(gazebo_msgs::ApplyBodyWrench::Request &req,
                                          gazebo_msgs::ApplyBodyWrench::Response &res)
 {
+#if GAZEBO_MAJOR_VERSION >= 8
+  gazebo::physics::LinkPtr body = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->EntityByName(req.body_name));
+#else
   gazebo::physics::LinkPtr body = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.body_name));
+#endif
+#if GAZEBO_MAJOR_VERSION >= 8
+  gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->EntityByName(req.reference_frame));
+#else
   gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.reference_frame));
+#endif
   if (!body)
   {
     ROS_ERROR_NAMED("api_plugin", "ApplyBodyWrench: body [%s] does not exist",req.body_name.c_str());

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -998,8 +998,13 @@ bool GazeboRosApiPlugin::getWorldProperties(gazebo_msgs::GetWorldProperties::Req
 {
   res.sim_time = world_->GetSimTime().Double();
   res.model_names.clear();
+#if GAZEBO_MAJOR_VERSION >= 8
+  for (unsigned int i = 0; i < world_->ModelCount(); i ++)
+    res.model_names.push_back(world_->ModelByIndex(i)->GetName());
+#else
   for (unsigned int i = 0; i < world_->GetModelCount(); i ++)
     res.model_names.push_back(world_->GetModel(i)->GetName());
+#endif
   gzerr << "disablign rendering has not been implemented, rendering is always enabled\n";
   res.rendering_enabled = true; //world->GetRenderEngineEnabled();
   res.success = true;
@@ -1011,9 +1016,15 @@ bool GazeboRosApiPlugin::getJointProperties(gazebo_msgs::GetJointProperties::Req
                                             gazebo_msgs::GetJointProperties::Response &res)
 {
   gazebo::physics::JointPtr joint;
+#if GAZEBO_MAJOR_VERSION >= 8
+  for (unsigned int i = 0; i < world_->ModelCount(); i ++)
+  {
+    joint = world_->ModelByIndex(i)->GetJoint(req.joint_name);
+#else
   for (unsigned int i = 0; i < world_->GetModelCount(); i ++)
   {
     joint = world_->GetModel(i)->GetJoint(req.joint_name);
+#endif
     if (joint) break;
   }
 
@@ -1370,9 +1381,15 @@ bool GazeboRosApiPlugin::setJointProperties(gazebo_msgs::SetJointProperties::Req
 {
   /// @todo: current settings only allows for setting of 1DOF joints (e.g. HingeJoint and SliderJoint) correctly.
   gazebo::physics::JointPtr joint;
+#if GAZEBO_MAJOR_VERSION >= 8
+  for (unsigned int i = 0; i < world_->ModelCount(); i ++)
+  {
+    joint = world_->ModelByIndex(i)->GetJoint(req.joint_name);
+#else
   for (unsigned int i = 0; i < world_->GetModelCount(); i ++)
   {
     joint = world_->GetModel(i)->GetJoint(req.joint_name);
+#endif
     if (joint) break;
   }
 
@@ -1500,9 +1517,15 @@ bool GazeboRosApiPlugin::applyJointEffort(gazebo_msgs::ApplyJointEffort::Request
                                           gazebo_msgs::ApplyJointEffort::Response &res)
 {
   gazebo::physics::JointPtr joint;
+#if GAZEBO_MAJOR_VERSION >= 8
+  for (unsigned int i = 0; i < world_->ModelCount(); i ++)
+  {
+    joint = world_->ModelByIndex(i)->GetJoint(req.joint_name);
+#else
   for (unsigned int i = 0; i < world_->GetModelCount(); i ++)
   {
     joint = world_->GetModel(i)->GetJoint(req.joint_name);
+#endif
     if (joint)
     {
       GazeboRosApiPlugin::ForceJointJob* fjj = new GazeboRosApiPlugin::ForceJointJob;
@@ -1992,9 +2015,15 @@ void GazeboRosApiPlugin::publishLinkStates()
   gazebo_msgs::LinkStates link_states;
 
   // fill link_states
+#if GAZEBO_MAJOR_VERSION >= 8
+  for (unsigned int i = 0; i < world_->ModelCount(); i ++)
+  {
+    gazebo::physics::ModelPtr model = world_->ModelByIndex(i);
+#else
   for (unsigned int i = 0; i < world_->GetModelCount(); i ++)
   {
     gazebo::physics::ModelPtr model = world_->GetModel(i);
+#endif
 
     for (unsigned int j = 0 ; j < model->GetChildCount(); j ++)
     {
@@ -2043,22 +2072,24 @@ void GazeboRosApiPlugin::publishModelStates()
   gazebo_msgs::ModelStates model_states;
 
   // fill model_states
-  for (unsigned int i = 0; i < world_->GetModelCount(); i ++)
-  {
-    gazebo::physics::ModelPtr model = world_->GetModel(i);
-    model_states.name.push_back(model->GetName());
-    geometry_msgs::Pose pose;
 #if GAZEBO_MAJOR_VERSION >= 8
+  for (unsigned int i = 0; i < world_->ModelCount(); i ++)
+  {
+    gazebo::physics::ModelPtr model = world_->ModelByIndex(i);
     ignition::math::Pose3d  model_pose = model->WorldPose(); // - myBody->GetCoMPose();
     ignition::math::Vector3d linear_vel  = model->WorldLinearVel();
     ignition::math::Vector3d angular_vel = model->WorldAngularVel();
 #else
+  for (unsigned int i = 0; i < world_->GetModelCount(); i ++)
+  {
+    gazebo::physics::ModelPtr model = world_->GetModel(i);
     ignition::math::Pose3d  model_pose = model->GetWorldPose().Ign(); // - myBody->GetCoMPose();
     ignition::math::Vector3d linear_vel  = model->GetWorldLinearVel().Ign();
     ignition::math::Vector3d angular_vel = model->GetWorldAngularVel().Ign();
 #endif
     ignition::math::Vector3d pos = model_pose.Pos();
     ignition::math::Quaterniond rot = model_pose.Rot();
+    geometry_msgs::Pose pose;
     pose.position.x = pos.X();
     pose.position.y = pos.Y();
     pose.position.z = pos.Z();
@@ -2067,6 +2098,7 @@ void GazeboRosApiPlugin::publishModelStates()
     pose.orientation.y = rot.Y();
     pose.orientation.z = rot.Z();
     model_states.pose.push_back(pose);
+    model_states.name.push_back(model->GetName());
     geometry_msgs::Twist twist;
     twist.linear.x = linear_vel.X();
     twist.linear.y = linear_vel.Y();

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -725,7 +725,11 @@ bool GazeboRosApiPlugin::deleteModel(gazebo_msgs::DeleteModel::Request &req,
                                      gazebo_msgs::DeleteModel::Response &res)
 {
   // clear forces, etc for the body in question
+#if GAZEBO_MAJOR_VERSION >= 8
+  gazebo::physics::ModelPtr model = world_->ModelByName(req.model_name);
+#else
   gazebo::physics::ModelPtr model = world_->GetModel(req.model_name);
+#endif
   if (!model)
   {
     ROS_ERROR_NAMED("api_plugin", "DeleteModel: model [%s] does not exist",req.model_name.c_str());
@@ -770,7 +774,11 @@ bool GazeboRosApiPlugin::deleteModel(gazebo_msgs::DeleteModel::Request &req,
     }
     {
       //boost::recursive_mutex::scoped_lock lock(*world->GetMRMutex());
+#if GAZEBO_MAJOR_VERSION >= 8
+      if (!world_->ModelByName(req.model_name)) break;
+#else
       if (!world_->GetModel(req.model_name)) break;
+#endif
     }
     ROS_DEBUG_NAMED("api_plugin", "Waiting for model deletion (%s)",req.model_name.c_str());
     usleep(1000);
@@ -830,7 +838,11 @@ bool GazeboRosApiPlugin::deleteLight(gazebo_msgs::DeleteLight::Request &req,
 bool GazeboRosApiPlugin::getModelState(gazebo_msgs::GetModelState::Request &req,
                                        gazebo_msgs::GetModelState::Response &res)
 {
+#if GAZEBO_MAJOR_VERSION >= 8
+  gazebo::physics::ModelPtr model = world_->ModelByName(req.model_name);
+#else
   gazebo::physics::ModelPtr model = world_->GetModel(req.model_name);
+#endif
   gazebo::physics::LinkPtr frame = boost::dynamic_pointer_cast<gazebo::physics::Link>(world_->GetEntity(req.relative_entity_name));
   if (!model)
   {
@@ -934,7 +946,11 @@ bool GazeboRosApiPlugin::getModelState(gazebo_msgs::GetModelState::Request &req,
 bool GazeboRosApiPlugin::getModelProperties(gazebo_msgs::GetModelProperties::Request &req,
                                             gazebo_msgs::GetModelProperties::Response &res)
 {
+#if GAZEBO_MAJOR_VERSION >= 8
+  gazebo::physics::ModelPtr model = world_->ModelByName(req.model_name);
+#else
   gazebo::physics::ModelPtr model = world_->GetModel(req.model_name);
+#endif
   if (!model)
   {
     ROS_ERROR_NAMED("api_plugin", "GetModelProperties: model [%s] does not exist",req.model_name.c_str());
@@ -1438,7 +1454,11 @@ bool GazeboRosApiPlugin::setModelState(gazebo_msgs::SetModelState::Request &req,
   ignition::math::Vector3d target_pos_dot(req.model_state.twist.linear.x,req.model_state.twist.linear.y,req.model_state.twist.linear.z);
   ignition::math::Vector3d target_rot_dot(req.model_state.twist.angular.x,req.model_state.twist.angular.y,req.model_state.twist.angular.z);
 
+#if GAZEBO_MAJOR_VERSION >= 8
+  gazebo::physics::ModelPtr model = world_->ModelByName(req.model_state.model_name);
+#else
   gazebo::physics::ModelPtr model = world_->GetModel(req.model_state.model_name);
+#endif
   if (!model)
   {
     ROS_ERROR_NAMED("api_plugin", "Updating ModelState: model [%s] does not exist",req.model_state.model_name.c_str());
@@ -1637,7 +1657,11 @@ bool GazeboRosApiPlugin::setModelConfiguration(gazebo_msgs::SetModelConfiguratio
   std::string gazebo_model_name = req.model_name;
 
   // search for model with name
+#if GAZEBO_MAJOR_VERSION >= 8
+  gazebo::physics::ModelPtr gazebo_model = world_->ModelByName(req.model_name);
+#else
   gazebo::physics::ModelPtr gazebo_model = world_->GetModel(req.model_name);
+#endif
   if (!gazebo_model)
   {
     ROS_ERROR_NAMED("api_plugin", "SetModelConfiguration: model [%s] does not exist",gazebo_model_name.c_str());
@@ -2498,10 +2522,11 @@ bool GazeboRosApiPlugin::spawnAndConform(TiXmlDocument &gazebo_model_xml, const 
   request_pub_->Publish(*entity_info_msg,true);
   // todo: should wait for response response_sub_, check to see that if _msg->response == "nonexistant"
 
-  gazebo::physics::ModelPtr model = world_->GetModel(model_name);
 #if GAZEBO_MAJOR_VERSION >= 8
+  gazebo::physics::ModelPtr model = world_->ModelByName(model_name);
   gazebo::physics::LightPtr light = world_->LightByName(model_name);
 #else
+  gazebo::physics::ModelPtr model = world_->GetModel(model_name);
   gazebo::physics::LightPtr light = world_->Light(model_name);
 #endif
   if ((isLight && light != NULL) || (model != NULL))
@@ -2547,10 +2572,11 @@ bool GazeboRosApiPlugin::spawnAndConform(TiXmlDocument &gazebo_model_xml, const 
       //boost::recursive_mutex::scoped_lock lock(*world->GetMRMutex());
 #if GAZEBO_MAJOR_VERSION >= 8
       if ((isLight && world_->LightByName(model_name) != NULL)
+          || (world_->ModelByName(model_name) != NULL))
 #else
       if ((isLight && world_->Light(model_name) != NULL)
-#endif
           || (world_->GetModel(model_name) != NULL))
+#endif
         break;
     }
 


### PR DESCRIPTION
This adds more ifdefs for functions that let you get pointers to physics objects, like Model, Entity, and Light. The only remaining warnings are from `World::GetSimTime` and `World::GetPhysicsEngine`.