### PR TITLE
Load the libgazebo_ros_api_plugin when starting gzclient

### DIFF
--- a/gazebo_ros/scripts/gzclient
+++ b/gazebo_ros/scripts/gzclient
@@ -17,6 +17,12 @@ then
     final="$final -g `catkin_find --first-only libgazebo_ros_paths_plugin.$EXT`"
 fi
 
+# add ros api plugin if it does not already exist in the passed in arguments
+if [ `expr "$final" : ".*libgazebo_ros_api_plugin\.$EXT.*"` -eq 0 ]
+then
+    final="$final -g `catkin_find --first-only libgazebo_ros_api_plugin.$EXT`"
+fi
+
 setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
 
 # source setup.sh, but keep local modifications to GAZEBO_MASTER_URI and GAZEBO_MODEL_DATABASE_URI


### PR DESCRIPTION
This change makes the ROS event loop turn over, which is required when you have a client-side Gazebo plugin that uses ROS. Otherwise if you use ROS in a gzclient plugin, ROS subscriptions and such will appear to work, but then nothing will happen because the event loop isn't turning over.