### PR TITLE
Fix tests and compiler warnings on kinetic-devel

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
@@ -203,13 +203,9 @@ void GazeboRosVacuumGripper::UpdateChild()
       double norm = diff.Pos().Length();
       if (norm < 0.05) {
 #if GAZEBO_MAJOR_VERSION >= 8
-        links[j]->SetLinearAccel(link_->WorldLinearAccel());
-        links[j]->SetAngularAccel(link_->WorldAngularAccel());
         links[j]->SetLinearVel(link_->WorldLinearVel());
         links[j]->SetAngularVel(link_->WorldAngularVel());
 #else
-        links[j]->SetLinearAccel(link_->GetWorldLinearAccel());
-        links[j]->SetAngularAccel(link_->GetWorldAngularAccel());
         links[j]->SetLinearVel(link_->GetWorldLinearVel());
         links[j]->SetAngularVel(link_->GetWorldAngularVel());
 #endif

--- a/gazebo_plugins/test/camera/camera.test
+++ b/gazebo_plugins/test/camera/camera.test
@@ -6,7 +6,7 @@
 
   <node name="gazebo" pkg="gazebo_ros" type="gzserver"
       respawn="false" output="screen"
-      args="-r $(find gazebo_plugins)/test/camera/camera.world" />
+      args="--verbose $(find gazebo_plugins)/test/camera/camera.world" />
 
   <group if="$(arg gui)">
     <node name="gazebo_gui" pkg="gazebo_ros" type="gzclient" respawn="false" output="screen"/>

--- a/gazebo_plugins/test/camera/depth_camera.test
+++ b/gazebo_plugins/test/camera/depth_camera.test
@@ -6,7 +6,7 @@
 
   <node name="gazebo" pkg="gazebo_ros" type="gzserver"
       respawn="false" output="screen"
-      args="-r $(find gazebo_plugins)/test/camera/depth_camera.world" />
+      args="--verbose $(find gazebo_plugins)/test/camera/depth_camera.world" />
 
   <group if="$(arg gui)">
     <node name="gazebo_gui" pkg="gazebo_ros" type="gzclient" respawn="false" output="screen"/>

--- a/gazebo_plugins/test/camera/distortion_barrel.test
+++ b/gazebo_plugins/test/camera/distortion_barrel.test
@@ -5,7 +5,7 @@
   <node name="gazebo" pkg="gazebo_ros" type="gzserver"
       respawn="false"
       output="screen"
-      args="-r $(find gazebo_plugins)/test/camera/distortion_barrel.world" />
+      args="--verbose $(find gazebo_plugins)/test/camera/distortion_barrel.world" />
 
   <test test-name="distortion_barrel_test" pkg="gazebo_plugins"
       type="distortion_barrel_test" clear_params="true" time-limit="100.0" />

--- a/gazebo_plugins/test/camera/distortion_pincushion.test
+++ b/gazebo_plugins/test/camera/distortion_pincushion.test
@@ -5,7 +5,7 @@
   <node name="gazebo" pkg="gazebo_ros" type="gzserver"
       respawn="false"
       output="screen"
-      args="-r $(find gazebo_plugins)/test/camera/distortion_pincushion.world" />
+      args="--verbose $(find gazebo_plugins)/test/camera/distortion_pincushion.world" />
 
   <test test-name="distortion_pincushion_test" pkg="gazebo_plugins"
       type="distortion_pincushion_test" clear_params="true" time-limit="100.0" />

--- a/gazebo_plugins/test/camera/multicamera.test
+++ b/gazebo_plugins/test/camera/multicamera.test
@@ -4,7 +4,7 @@
 
   <node name="gazebo" pkg="gazebo_ros" type="gzserver"
       respawn="false" output="screen"
-      args="-r $(find gazebo_plugins)/test/camera/multicamera.world" />
+      args="--verbose $(find gazebo_plugins)/test/camera/multicamera.world" />
 
   <test test-name="multicamera" pkg="gazebo_plugins" type="multicamera-test"
       clear_params="true" time-limit="15.0" />

--- a/gazebo_plugins/test/set_model_state_test/set_model_state_test.test
+++ b/gazebo_plugins/test/set_model_state_test/set_model_state_test.test
@@ -5,7 +5,7 @@
     <param name="/use_sim_time" value="true" />
 
     <!-- gazebo server-->
-    <node name="gazebo" pkg="gazebo_ros" type="gzserver" respawn="false" output="screen" args="-r $(find gazebo_plugins)/test/set_model_state_test/set_model_state_test_p2dx.world" />
+    <node name="gazebo" pkg="gazebo_ros" type="gzserver" respawn="false" output="screen" args="--verbose $(find gazebo_plugins)/test/set_model_state_test/set_model_state_test_p2dx.world" />
 
     <test test-name="set_model_state_test" pkg="gazebo_plugins" type="set_model_state-test" clear_params="true" time-limit="100.0" />
 


### PR DESCRIPTION
Don't record state logs with `-r` in rostest's; add --verbose instead.

Fix gazebo9 deprecation warnings by removing Set.*Accel calls since they don't do anything