### PR TITLE
gazebo_plugins: unique names for distortion tests

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -386,11 +386,11 @@ if (CATKIN_ENABLE_TESTING)
     target_link_libraries(camera-test ${catkin_LIBRARIES})
     add_rostest_gtest(distortion_barrel_test
                       test/camera/distortion_barrel.test
-                      test/camera/distortion.cpp)
+                      test/camera/distortion_barrel.cpp)
     target_link_libraries(distortion_barrel_test ${catkin_LIBRARIES})
     add_rostest_gtest(distortion_pincushion_test
                       test/camera/distortion_pincushion.test
-                      test/camera/distortion.cpp)
+                      test/camera/distortion_pincushion.cpp)
     target_link_libraries(distortion_pincushion_test ${catkin_LIBRARIES})
   endif()
 endif()

--- a/gazebo_plugins/test/camera/distortion.h
+++ b/gazebo_plugins/test/camera/distortion.h
@@ -1,3 +1,6 @@
+#ifndef GAZEBO_PLUGINS_TEST_CAMERA_DISTORTION_H
+#define GAZEBO_PLUGINS_TEST_CAMERA_DISTORTION_H
+
 // OpenCV includes
 #include <opencv2/core/core.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
@@ -50,6 +53,8 @@ class DistortionTest : public testing::Test
   sensor_msgs::CameraInfoConstPtr cam_info_distorted_;
 
  public:
+  void cameraDistortionTest();
+
   void imageCallback(const sensor_msgs::ImageConstPtr& msg, int cam_index)
   {
     // for now, only support 2 cameras
@@ -69,7 +74,7 @@ class DistortionTest : public testing::Test
   }
 };
 
-TEST_F(DistortionTest, cameraDistortionTest)
+void DistortionTest::cameraDistortionTest()
 {
   ros::AsyncSpinner spinner(2);
   spinner.start();
@@ -175,9 +180,4 @@ TEST_F(DistortionTest, cameraDistortionTest)
   }
 }
 
-int main(int argc, char** argv)
-{
-  ros::init(argc, argv, "gazebo_camera_distortion_test");
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+#endif

--- a/gazebo_plugins/test/camera/distortion_barrel.cpp
+++ b/gazebo_plugins/test/camera/distortion_barrel.cpp
@@ -1,0 +1,13 @@
+#include "distortion.h"
+
+TEST_F(DistortionTest, barrelDistortion)
+{
+  cameraDistortionTest();
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "gazebo_camera_barrel_distortion_test");
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/gazebo_plugins/test/camera/distortion_pincushion.cpp
+++ b/gazebo_plugins/test/camera/distortion_pincushion.cpp
@@ -1,0 +1,13 @@
+#include "distortion.h"
+
+TEST_F(DistortionTest, pincushionDistortion)
+{
+  cameraDistortionTest();
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "gazebo_camera_pincushion_distortion_test");
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
The distortion tests have been using the same gtest code, but that gives them the same test name, which makes it hard to see which test failed in the results. This moves the gtest code to a function in a header file and uses distinct cpp files with different test names for each test case.