### PR TITLE
Fix issue #690 add physics type for dart with joint velocity interface (lunar-devel)

### DIFF
--- a/gazebo_ros_control/include/gazebo_ros_control/default_robot_hw_sim.h
+++ b/gazebo_ros_control/include/gazebo_ros_control/default_robot_hw_sim.h
@@ -134,6 +134,8 @@ protected:
 
   std::vector<gazebo::physics::JointPtr> sim_joints_;
 
+  std::string physics_type_;
+
   // e_stop_active_ is true if the emergency stop is active.
   bool e_stop_active_, last_e_stop_active_;
 };

--- a/gazebo_ros_control/src/default_robot_hw_sim.cpp
+++ b/gazebo_ros_control/src/default_robot_hw_sim.cpp
@@ -197,6 +197,18 @@ bool DefaultRobotHWSim::initSim(
     }
     sim_joints_.push_back(joint);
 
+    // get physics engine type
+#if GAZEBO_MAJOR_VERSION >= 8
+    gazebo::physics::PhysicsEnginePtr physics = gazebo::physics::get_world()->Physics();
+#else
+    gazebo::physics::PhysicsEnginePtr physics = gazebo::physics::get_world()->GetPhysicsEngine();
+#endif
+    physics_type_ = physics->GetType();
+    if (physics_type_.empty())
+    {
+      ROS_WARN_STREAM_NAMED("default_robot_hw_sim", "No physics type found.");
+    }
+
     registerJointLimits(joint_names_[j], joint_handle, joint_control_methods_[j],
                         joint_limit_nh, urdf_model,
                         &joint_types_[j], &joint_lower_limits_[j], &joint_upper_limits_[j],
@@ -342,7 +354,14 @@ void DefaultRobotHWSim::writeSim(ros::Time time, ros::Duration period)
 
       case VELOCITY:
 #if GAZEBO_MAJOR_VERSION > 2
-        sim_joints_[j]->SetParam("vel", 0, e_stop_active_ ? 0 : joint_velocity_command_[j]);
+        if (physics_type_.compare("dart") == 0)
+        {
+          sim_joints_[j]->SetVelocity(0, e_stop_active_ ? 0 : joint_velocity_command_[j]);
+        }
+        else 
+        {
+          sim_joints_[j]->SetParam("vel", 0, e_stop_active_ ? 0 : joint_velocity_command_[j]);
+        }
 #else
         sim_joints_[j]->SetVelocity(0, e_stop_active_ ? 0 : joint_velocity_command_[j]);
 #endif


### PR DESCRIPTION
{ port of pull request #693 }
Fix https://github.com/ros-simulation/gazebo_ros_pkgs/issues/690

- add physics type member
- change velocity API from `SetParam("vel")` to `SetVelocity()` for dart physics engine