### PR TITLE
Parameter to disable ROS network interaction from/to Gazebo (lunar-devel)

### DIFF
--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -81,6 +81,10 @@ set_target_properties(gazebo_ros_paths_plugin PROPERTIES COMPILE_FLAGS "${cxx_fl
 set_target_properties(gazebo_ros_paths_plugin PROPERTIES LINK_FLAGS "${ld_flags}")
 target_link_libraries(gazebo_ros_paths_plugin ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
+## Tests
+
+add_subdirectory(test)
+
 # Install Gazebo System Plugins
 install(TARGETS gazebo_ros_api_plugin gazebo_ros_paths_plugin
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
+++ b/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
@@ -413,6 +413,9 @@ private:
 
   /// \brief index counters to count the accesses on models via GetModelState
   std::map<std::string, unsigned int> access_count_get_model_state_;
+
+  /// \brief enable the communication of gazebo information using ROS service/topics
+  bool enable_ros_network_;
 };
 }
 #endif

--- a/gazebo_ros/launch/empty_world.launch
+++ b/gazebo_ros/launch/empty_world.launch
@@ -17,6 +17,7 @@
   <arg name="respawn_gazebo" default="false"/>
   <arg name="use_clock_frequency" default="false"/>
   <arg name="pub_clock_frequency" default="100"/>
+  <arg name="enable_ros_network" default="true" />
 
   <!-- set use_sim_time flag -->
   <param name="/use_sim_time" value="$(arg use_sim_time)"/>
@@ -34,6 +35,9 @@
   <!-- start gazebo server-->
   <group if="$(arg use_clock_frequency)">
     <param name="gazebo/pub_clock_frequency" value="$(arg pub_clock_frequency)" />
+  </group>
+  <group>
+    <param name="gazebo/enable_ros_network" value="$(arg enable_ros_network)" />
   </group>
   <node name="gazebo" pkg="gazebo_ros" type="$(arg script_type)" respawn="$(arg respawn_gazebo)" output="screen"
 	args="$(arg command_arg1) $(arg command_arg2) $(arg command_arg3) -e $(arg physics) $(arg extra_gazebo_args) $(arg world_name)" />

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -215,9 +215,7 @@ void GazeboRosApiPlugin::loadGazeboRosApiPlugin(std::string world_name)
   // hooks for applying forces, publishing simtime on /clock
   wrench_update_event_ = gazebo::event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboRosApiPlugin::wrenchBodySchedulerSlot,this));
   force_update_event_  = gazebo::event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboRosApiPlugin::forceJointSchedulerSlot,this));
-
-  if (enable_ros_network_)
-    time_update_event_   = gazebo::event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboRosApiPlugin::publishSimTime,this));
+  time_update_event_   = gazebo::event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboRosApiPlugin::publishSimTime,this));
 }
 
 void GazeboRosApiPlugin::onResponse(ConstResponsePtr &response)

--- a/gazebo_ros/test/CMakeLists.txt
+++ b/gazebo_ros/test/CMakeLists.txt
@@ -1,0 +1,22 @@
+set (rostests_python
+  ros_network/ros_network_default.test
+  ros_network/ros_network_disabled.test
+)
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+    foreach (rostest ${rostests_python})
+      # We don't set a timeout here because we trust rostest to enforce the
+      # timeout specified in each .test file.
+      add_rostest(${rostest} rostest ${CMAKE_CURRENT_SOURCE_DIR}/${rostest})
+      # Check for test result file and create one if needed.  rostest can fail to
+      # generate a file if it throws an exception.
+      add_test(check_${rostest} rosrun rosunit check_test_ran.py 
+               --rostest ${ROS_PACKAGE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${rostest})
+  endforeach()
+endif()
+
+install(PROGRAMS
+  ros_network/ros_api_checker
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/test
+)

--- a/gazebo_ros/test/ros_network/gazebo_network_api.yaml
+++ b/gazebo_ros/test/ros_network/gazebo_network_api.yaml
@@ -1,0 +1,140 @@
+strict: true
+
+##########################################################
+# Published topics
+topics:
+  # System
+  - topic: /clock
+    type: rosgraph_msgs/Clock
+    num_publishers: 1
+    num_subscribers: -1
+
+  - topic: /rosout
+    type: rosgraph_msgs/Log
+    num_publishers: -1
+    num_subscribers: -1
+
+  # Gazebo
+  - topic: /gazebo/set_model_state
+    type: gazebo_msgs/ModelState
+    num_publishers: 0
+    num_subscribers: -1
+
+  - topic: /gazebo/set_link_state
+    type: gazebo_msgs/LinkState
+    num_publishers: 0
+    num_subscribers: -1
+
+  - topic: /gazebo/link_states
+    type: gazebo_msgs/LinkStates
+    num_publishers: 1
+    num_subscribers: -1
+
+  - topic: /gazebo/model_states
+    type: gazebo_msgs/ModelStates
+    num_publishers: 1
+    num_subscribers: -1
+
+  - topic: /gazebo/parameter_descriptions
+    type: dynamic_reconfigure/ConfigDescription
+    num_publishers: 1
+    num_subscribers: -1
+
+  - topic: /gazebo/parameter_updates
+    type: dynamic_reconfigure/Config
+    num_publishers: 1
+    num_subscribers: -1
+
+##########################################################
+# Published services
+services:
+  # Gazebo
+  - service: /gazebo/apply_joint_effort
+    type: gazebo_msgs/ApplyJointEffort
+
+  - service: /gazebo/get_physics_properties
+    type: gazebo_msgs/GetPhysicsProperties
+
+  - service: /gazebo/set_link_state
+    type: gazebo_msgs/SetLinkState
+
+  - service: /gazebo/set_joint_properties
+    type: gazebo_msgs/SetJointProperties
+
+  - service: /gazebo/reset_world
+    type: std_srvs/Empty
+
+  - service: /gazebo/set_model_configuration
+    type: gazebo_msgs/SetModelConfiguration
+
+  - service: /gazebo/get_world_properties
+    type: gazebo_msgs/GetWorldProperties
+
+  - service: /gazebo/delete_light
+    type: gazebo_msgs/DeleteLight
+
+  - service: /gazebo/set_parameters
+    type: dynamic_reconfigure/Reconfigure
+
+  - service: /gazebo/spawn_sdf_model
+    type: gazebo_msgs/SpawnModel
+
+  - service: /gazebo/unpause_physics
+    type: std_srvs/Empty
+
+  - service: /gazebo/pause_physics
+    type: std_srvs/Empty
+
+  - service: /gazebo/get_joint_properties
+    type: gazebo_msgs/GetJointProperties
+
+  - service: /gazebo/set_logger_level
+    type: roscpp/SetLoggerLevel
+
+  - service: /gazebo/get_light_properties
+    type: gazebo_msgs/GetLightProperties
+
+  - service: /gazebo/clear_body_wrenches
+    type: gazebo_msgs/BodyRequest
+
+  - service: /gazebo/clear_joint_forces
+    type: gazebo_msgs/JointRequest
+
+  - service: /gazebo/set_physics_properties
+    type: gazebo_msgs/SetPhysicsProperties
+
+  - service: /gazebo/get_model_state
+    type: gazebo_msgs/GetModelState
+
+  - service: /gazebo/reset_simulation
+    type: std_srvs/Empty
+
+  - service: /gazebo/delete_model
+    type: gazebo_msgs/DeleteModel
+
+  - service: /gazebo/spawn_urdf_model
+    type: gazebo_msgs/SpawnModel
+
+  - service: /gazebo/set_link_properties
+    type: gazebo_msgs/SetLinkProperties
+
+  - service: /gazebo/set_model_state
+    type: gazebo_msgs/SetModelState
+
+  - service: /gazebo/apply_body_wrench
+    type: gazebo_msgs/ApplyBodyWrench
+
+  - service: /gazebo/get_link_state
+    type: gazebo_msgs/GetLinkState
+
+  - service: /gazebo/get_loggers
+    type: roscpp/GetLoggers
+
+  - service: /gazebo/get_model_properties
+    type: gazebo_msgs/GetModelProperties
+
+  - service: /gazebo/set_light_properties
+    type: gazebo_msgs/SetLightProperties
+  
+  - service: /gazebo/get_link_properties
+    type: gazebo_msgs/GetLinkProperties

--- a/gazebo_ros/test/ros_network/no_gazebo_network_api.yaml
+++ b/gazebo_ros/test/ros_network/no_gazebo_network_api.yaml
@@ -1,0 +1,25 @@
+strict: true
+
+##########################################################
+# Published topics
+topics:
+  # System
+  - topic: /clock
+    type: rosgraph_msgs/Clock
+    num_publishers: 1
+    num_subscribers: -1
+
+  - topic: /rosout
+    type: rosgraph_msgs/Log
+    num_publishers: -1
+    num_subscribers: -1
+
+##########################################################
+# Published services
+services:
+  # System
+  - service: /gazebo/set_logger_level
+    type: roscpp/SetLoggerLevel
+
+  - service: /gazebo/get_loggers
+    type: roscpp/GetLoggers

--- a/gazebo_ros/test/ros_network/ros_api_checker
+++ b/gazebo_ros/test/ros_network/ros_api_checker
@@ -1,0 +1,196 @@
+#!/usr/bin/env python
+
+# The script was originally written by Brian Gerkey under
+# the works of the Virtual Robotics Challenge
+#
+# Copyright Open Source Robotics Foundation
+#
+
+from __future__ import print_function
+import unittest
+import rostest
+import subprocess
+import sys
+import time
+import re
+import rospy
+
+class Tester(unittest.TestCase):
+
+    def _test_extra_topics(self, topics):
+        cmd = ['rostopic', 'list']
+        po = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = po.communicate()
+        self.assertEqual(po.returncode, 0, 'rostopic failed (%s). stdout: %s stderr: %s'%(cmd, out, err))
+        topics_actual = set(out.split('\n')) - set([''])
+        topics_expected = set([x['topic'] for x in topics])
+        topics_extra = topics_actual - topics_expected
+        self.assertEqual(topics_extra, set([]))
+
+    def _test_extra_services(self, services):
+        cmd = ['rosservice', 'list']
+        po = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = po.communicate()
+        self.assertEqual(po.returncode, 0, 'rosservice failed (%s). stdout: %s stderr: %s'%(cmd, out, err))
+        services_actual = set(out.split('\n')) - set([''])
+        services_expected = set([x['service'] for x in services])
+        services_extra = services_actual - services_expected
+        self.assertEqual(services_extra, set([]))
+
+    def _test_topic(self, t):
+        self.assertIn('topic', t)
+        self.assertIn('type', t)
+        self.assertIn('num_publishers', t)
+        self.assertIn('num_subscribers', t)
+
+        cmd = ['rostopic', 'info', t['topic']]
+        po = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = po.communicate()
+        self.assertEqual(po.returncode, 0, 'rostopic info failed (%s). stdout: %s stderr: %s'%(cmd, out, err))
+        self._parse_rostopic(t, out)
+
+    def _parse_rostopic(self, t, out):
+        # Should probably do this through a library API instead...
+
+        # Step 0: make sure we have enough output
+        outsplit = out.split('\n')
+        self.assertTrue(len(outsplit) >= 5)
+
+        type_re = re.compile('\w*Type: (.*)')
+        pub_start_re = re.compile('Publishers:.*')
+        sub_start_re = re.compile('Subscribers:.*')
+        pub_sub_re = re.compile(' *\* *([^ ]*).*')
+
+        # Step 1: check type
+        m = type_re.match(outsplit[0])
+        self.assertEqual(len(m.groups()), 1)
+        self.assertEqual(m.groups()[0], t['type'])
+
+        # Step 2: check num_publishers and num_subscribers
+        state = None
+        pubs = 0
+        subs = 0
+        for l in outsplit:
+            if pub_start_re.match(l):
+                state = 'in_pubs'
+            elif sub_start_re.match(l):
+                state = 'in_subs'
+            else:
+                m = pub_sub_re.match(l)
+                if m and len(m.groups()) == 1:
+                    if state == 'in_pubs':
+                        pubs += 1
+                    elif state == 'in_subs':
+                        subs += 1
+        if t['num_publishers'] >= 0:
+            self.assertEqual(pubs, t['num_publishers'])
+        if t['num_subscribers'] >= 0:
+            self.assertEqual(subs, t['num_subscribers'])
+
+    def _test_service(self, s):
+        self.assertIn('service', s)
+        self.assertIn('type', s)
+
+        cmd = ['rosservice', 'info', s['service']]
+        po = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = po.communicate()
+        self.assertEqual(po.returncode, 0, 'rosservice info failed (%s). stdout: %s stderr: %s'%(cmd, out, err))
+        self._parse_rosservice(s, out)
+
+    def _parse_rosservice(self, s, out):
+        # Should probably do this through a library API instead...
+
+        # Step 0: make sure we have enough output
+        outsplit = out.split('\n')
+        self.assertTrue(len(outsplit) >= 4)
+
+        type_re = re.compile('Type: (.*)')
+
+        # Step 1: check type
+        m = type_re.match(outsplit[2])
+        self.assertEqual(len(m.groups()), 1)
+        self.assertEqual(m.groups()[0], s['type'])
+
+def load_config(files):
+    import yaml
+    topics = []
+    services = []
+    strict = False
+    for f in files:
+        # Ignore args passed in by rostest
+        if f[:2] == '--' or f[:2] == '__':
+            continue
+        # Let parsing exceptions leak out; we'll catch them by noticing the
+        # absence of a test result file.
+        y = yaml.load(open(f))
+        for t in y['topics']:
+            topics.append(t)
+        if 'services' in y:
+            for s in y['services']:
+                services.append(s)
+
+        # TODO: This logic will enforce strictness if any of the provided files
+        # sets strict to true, which isn't necessarily the right thing.
+        if 'strict' in y and y['strict']:
+            strict = True
+    return topics, services, strict
+
+def generate_topic_test(t):
+    def test_func(self):
+        self._test_topic(t)
+    return test_func
+
+def generate_service_test(t):
+    def test_func(self):
+        self._test_service(t)
+    return test_func
+
+def generate_test_extra_topics(topics):
+    def test_func(self):
+        self._test_extra_topics(topics)
+    return test_func
+
+def generate_test_extra_services(services):
+    def test_func(self):
+        self._test_extra_services(services)
+    return test_func
+
+def add_tests(topics, services, strict):
+    for t in topics:
+        test_func = generate_topic_test(t)
+        test_name = "test_topic_%s"%(t['topic'].replace('/','_'))
+        setattr(Tester, test_name, test_func)
+    for s in services:
+        test_func = generate_service_test(s)
+        test_name = "test_service_%s"%(s['service'].replace('/','_'))
+        setattr(Tester, test_name, test_func)
+    if strict:
+        test_func = generate_test_extra_topics(topics)
+        test_name = "test_extra_topics"
+        setattr(Tester, test_name, test_func)
+        test_func = generate_test_extra_services(services)
+        test_name = "test_extra_services"
+        setattr(Tester, test_name, test_func)
+
+if __name__ == '__main__':
+    rospy.init_node('rosapi_checker', anonymous=True)
+
+    # Dynamically generate test cases and stuff them into the Tester class
+    topics, services, strict = load_config(sys.argv[1:])
+    # The rostest node itself will advertise a couple of services
+    services.append({'service': '%s/get_loggers'%(rospy.get_name()),
+                     'type': 'roscpp/GetLoggers'})
+    services.append({'service': '%s/set_logger_level'%(rospy.get_name()),
+                     'type': 'roscpp/SetLoggerLevel'})
+    add_tests(topics, services, strict)
+
+    # Wait until /clock is being published; this can take an unpredictable
+    # amount of time when we're downloading models.
+    while rospy.Time.now().to_sec() == 0.0:
+        print('Waiting for Gazebo to start...')
+        time.sleep(1.0)
+    # Take an extra nap, to allow plugins to be loaded
+    time.sleep(5.0)
+    print('OK, starting test.')
+
+    rostest.run('gazebo_ros', 'api_check', Tester, sys.argv)

--- a/gazebo_ros/test/ros_network/ros_network_default.test
+++ b/gazebo_ros/test/ros_network/ros_network_default.test
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<launch>
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    <arg name="paused"   value="false"/>
+    <arg name="gui"      value="false"/>
+    <arg name="headless" value="false"/>
+    <arg name="debug"    value="false"/>
+    <arg name="enable_ros_network" value="true" />
+  </include>
+
+  <!-- the long timeout is just in case that gazebo needs to download models -->
+  <test pkg="gazebo_ros" type="ros_api_checker" test-name="ros_network_by_default"
+      args="$(find gazebo_ros)/test/ros_network/gazebo_network_api.yaml"
+      time-limit="100.0"/>
+</launch>

--- a/gazebo_ros/test/ros_network/ros_network_disabled.test
+++ b/gazebo_ros/test/ros_network/ros_network_disabled.test
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<launch>
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    <arg name="paused"   value="false"/>
+    <arg name="gui"      value="false"/>
+    <arg name="headless" value="false"/>
+    <arg name="debug"    value="false"/>
+    <arg name="enable_ros_network" value="false"/>
+  </include>
+
+  <!-- the long timeout is just in case that gazebo needs to download models -->
+  <test pkg="gazebo_ros" type="ros_api_checker" test-name="ros_network_by_default"
+      args="$(find gazebo_ros)/test/ros_network/no_gazebo_network_api.yaml"
+      time-limit="100.0"/>
+</launch>


### PR DESCRIPTION
{ port of pull request #585 }
The PR implements a ROS parameter named `enable_ros_network` that allows to disable all the gazebo topics (except /clock) and services that are created from the `gazebo_ros` package. This is useful in situation where the interaction from user with the gazebo simulator should be limited or blocked.

To keep backwards compatibility, by default, the behaviour is to enable all topics and services if the parameter is not present so current code should not experiment any difference at all.

I've added a couple of tests based on the `ros_api_checker` that the OSRF developed during the times of the Virtual Robotics Challenge. It checks all the ROS topics and services in runtime to check if they are exactly the same that is described in the .yaml files available in this PR.
