### PR TITLE
Triggered camera / multicamera plugins (lunar-devel)

### DIFF
--- a/SENSORS.md
+++ b/SENSORS.md
@@ -211,6 +211,15 @@ details about which code should be submitted to this repository.
    - ***example:*** gazebo_plugins/test/tricycle_drive/
               xacro, launch, world, rviz, etc.
 
+ * ***gazebo_ros_triggered_camera / gazebo_ros_triggered_multicamera***
+   - ***description:*** These camera sensors do not publish unless triggered. They have an
+     additional topic (default name `image_trigger`) that subscribes to std_msgs/Empty messages
+     and will publish a single update after being triggered. Its maximum update rate is currently
+     set by the <update_rate> sdf tag in the <sensor> block.
+     Publishes: sensor_msgs::Image, sensor_msgs::CameraInfo
+   - ***status:*** maintained
+   - ***example:*** gazebo_plugins/test/camera/triggered_camera.*
+
  * ***gazebo_ros_video***
    - ***description:*** Video plugin for displaying ROS image topics on Ogre textures
    - ***status:*** maintained

--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -407,5 +407,9 @@ if (CATKIN_ENABLE_TESTING)
                       test/camera/distortion_pincushion.test
                       test/camera/distortion_pincushion.cpp)
     target_link_libraries(distortion_pincushion_test ${catkin_LIBRARIES})
+    add_rostest_gtest(triggered-camera-test
+                      test/camera/triggered_camera.test
+                      test/camera/triggered_camera.cpp)
+    target_link_libraries(triggered-camera-test ${catkin_LIBRARIES})
   endif()
 endif()

--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -87,7 +87,9 @@ catkin_package(
   gazebo_ros_utils 
   gazebo_ros_camera_utils 
   gazebo_ros_camera 
+  gazebo_ros_triggered_camera
   gazebo_ros_multicamera 
+  gazebo_ros_triggered_multicamera
   gazebo_ros_depth_camera 
   gazebo_ros_openni_kinect 
   gazebo_ros_gpu_laser 
@@ -174,6 +176,11 @@ add_library(gazebo_ros_camera src/gazebo_ros_camera.cpp)
 add_dependencies(gazebo_ros_camera ${PROJECT_NAME}_gencfg)
 target_link_libraries(gazebo_ros_camera gazebo_ros_camera_utils CameraPlugin ${catkin_LIBRARIES})
 
+add_library(gazebo_ros_triggered_camera src/gazebo_ros_triggered_camera.cpp)
+add_dependencies(gazebo_ros_triggered_camera ${PROJECT_NAME}_gencfg)
+target_link_libraries(gazebo_ros_triggered_camera gazebo_ros_camera_utils ${GAZEBO_LIBRARIES} CameraPlugin ${catkin_LIBRARIES})
+
+
 if (NOT GAZEBO_VERSION VERSION_LESS 6.0)
   add_library(gazebo_ros_elevator src/gazebo_ros_elevator.cpp)
   add_dependencies(gazebo_ros_elevator ${PROJECT_NAME}_gencfg)
@@ -183,6 +190,10 @@ endif()
 add_library(gazebo_ros_multicamera src/gazebo_ros_multicamera.cpp)
 add_dependencies(gazebo_ros_multicamera ${PROJECT_NAME}_gencfg)
 target_link_libraries(gazebo_ros_multicamera gazebo_ros_camera_utils MultiCameraPlugin ${catkin_LIBRARIES})
+
+add_library(gazebo_ros_triggered_multicamera src/gazebo_ros_triggered_multicamera.cpp)
+add_dependencies(gazebo_ros_triggered_multicamera ${PROJECT_NAME}_gencfg)
+target_link_libraries(gazebo_ros_triggered_multicamera gazebo_ros_camera_utils gazebo_ros_triggered_camera ${GAZEBO_LIBRARIES} MultiCameraPlugin ${catkin_LIBRARIES})
 
 add_library(gazebo_ros_depth_camera src/gazebo_ros_depth_camera.cpp)
 add_dependencies(gazebo_ros_depth_camera ${PROJECT_NAME}_gencfg)

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
@@ -32,6 +32,7 @@
 #include <sensor_msgs/PointCloud.h>
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/CameraInfo.h>
+#include <std_msgs/Empty.h>
 #include <std_msgs/Float64.h>
 #include <image_transport/image_transport.h>
 #include <camera_info_manager/camera_info_manager.h>
@@ -52,6 +53,7 @@
 namespace gazebo
 {
   class GazeboRosMultiCamera;
+  class GazeboRosTriggeredMultiCamera;
   class GazeboRosCameraUtils
   {
     /// \brief Constructor
@@ -207,10 +209,19 @@ namespace gazebo
     private: boost::thread deferred_load_thread_;
     private: event::EventT<void()> load_event_;
 
+    // make a trigger function that the child classes can override
+    protected: virtual void TriggerCamera();
+    private: void TriggerCameraInternal(const std_msgs::Empty::ConstPtr &dummy);
+    private: ros::Subscriber trigger_subscriber_;
+
+    /// \brief ROS trigger topic name
+    protected: std::string trigger_topic_name_;
+
     /// \brief True if camera util is initialized
     protected: bool initialized_;
 
     friend class GazeboRosMultiCamera;
+    friend class GazeboRosTriggeredMultiCamera;
   };
 }
 #endif

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
@@ -210,7 +210,10 @@ namespace gazebo
     private: event::EventT<void()> load_event_;
 
     // make a trigger function that the child classes can override
+    // and a function that returns bool to indicate whether the trigger
+    // should be used
     protected: virtual void TriggerCamera();
+    protected: virtual bool CanTriggerCamera();
     private: void TriggerCameraInternal(const std_msgs::Empty::ConstPtr &dummy);
     private: ros::Subscriber trigger_subscriber_;
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_triggered_camera.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_triggered_camera.h
@@ -58,6 +58,8 @@ namespace gazebo
 
     protected: virtual void TriggerCamera();
 
+    protected: virtual bool CanTriggerCamera();
+
     protected: event::ConnectionPtr preRenderConnection_;
 
     public: void SetCameraEnabled(const bool _enabled);

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_triggered_camera.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_triggered_camera.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 Open Source Robotics Foundation
+ * Copyright 2017 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,10 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
-*/
-/*
- * Desc: A dynamic controller plugin that publishes ROS image_raw
- *    camera_info topic for generic camera sensor.
 */
 
 #ifndef GAZEBO_ROS_TRIGGERED_CAMERA_HH

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_triggered_camera.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_triggered_camera.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2012 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+/*
+ * Desc: A dynamic controller plugin that publishes ROS image_raw
+ *    camera_info topic for generic camera sensor.
+*/
+
+#ifndef GAZEBO_ROS_TRIGGERED_CAMERA_HH
+#define GAZEBO_ROS_TRIGGERED_CAMERA_HH
+
+#include <string>
+
+// library for processing camera data for gazebo / ros conversions
+#include <gazebo/plugins/CameraPlugin.hh>
+
+#include <gazebo_plugins/gazebo_ros_camera_utils.h>
+
+namespace gazebo
+{
+  class GazeboRosTriggeredMultiCamera;
+  class GazeboRosTriggeredCamera : public CameraPlugin, GazeboRosCameraUtils
+  {
+    /// \brief Constructor
+    /// \param parent The parent entity, must be a Model or a Sensor
+    public: GazeboRosTriggeredCamera();
+
+    /// \brief Destructor
+    public: ~GazeboRosTriggeredCamera();
+
+    /// \brief Load the plugin
+    /// \param take in SDF root element
+    public: void Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf);
+
+    /// \brief Update the controller
+    protected: virtual void OnNewFrame(const unsigned char *_image,
+                   unsigned int _width, unsigned int _height,
+                   unsigned int _depth, const std::string &_format);
+
+    protected: virtual void TriggerCamera();
+
+    protected: event::ConnectionPtr preRenderConnection_;
+
+    public: void SetCameraEnabled(const bool _enabled);
+
+    protected: void PreRender();
+
+    friend class GazeboRosTriggeredMultiCamera;
+  };
+}
+#endif
+

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_triggered_camera.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_triggered_camera.h
@@ -66,7 +66,7 @@ namespace gazebo
 
     protected: void PreRender();
 
-    protected: bool triggered = false;
+    protected: int triggered = 0;
 
     protected: std::mutex mutex;
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_triggered_camera.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_triggered_camera.h
@@ -22,6 +22,7 @@
 #ifndef GAZEBO_ROS_TRIGGERED_CAMERA_HH
 #define GAZEBO_ROS_TRIGGERED_CAMERA_HH
 
+#include <mutex>
 #include <string>
 
 // library for processing camera data for gazebo / ros conversions
@@ -45,6 +46,15 @@ namespace gazebo
     /// \param take in SDF root element
     public: void Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf);
 
+    /// \brief Load the plugin.
+    /// \param[in] _parent Take in SDF root element.
+    /// \param[in] _sdf SDF values.
+    /// \param[in] _camera_name_suffix Suffix of the camera name.
+    /// \param[in] _hack_baseline Multiple camera baseline.
+    public: void Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf,
+                      const std::string &_camera_name_suffix,
+                      double _hack_baseline);
+
     /// \brief Update the controller
     protected: virtual void OnNewFrame(const unsigned char *_image,
                    unsigned int _width, unsigned int _height,
@@ -57,6 +67,10 @@ namespace gazebo
     public: void SetCameraEnabled(const bool _enabled);
 
     protected: void PreRender();
+
+    protected: bool triggered = false;
+
+    protected: std::mutex mutex;
 
     friend class GazeboRosTriggeredMultiCamera;
   };

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_triggered_multicamera.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_triggered_multicamera.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 Open Source Robotics Foundation
+ * Copyright 2017 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_triggered_multicamera.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_triggered_multicamera.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2012 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef GAZEBO_ROS_TRIGGERED_MULTICAMERA_HH
+#define GAZEBO_ROS_TRIGGERED_MULTICAMERA_HH
+
+#include <string>
+#include <vector>
+
+// library for processing camera data for gazebo / ros conversions
+#include <gazebo_plugins/gazebo_ros_triggered_camera.h>
+#include <gazebo_plugins/MultiCameraPlugin.h>
+
+namespace gazebo
+{
+  class GazeboRosTriggeredMultiCamera : public MultiCameraPlugin
+  {
+    /// \brief Constructor
+    /// \param parent The parent entity, must be a Model or a Sensor
+    public: GazeboRosTriggeredMultiCamera();
+
+    /// \brief Destructor
+    public: ~GazeboRosTriggeredMultiCamera();
+
+    /// \brief Load the plugin
+    /// \param take in SDF root element
+    public: void Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf);
+
+    std::vector<GazeboRosTriggeredCamera *> triggered_cameras;
+
+    /// \brief Update the controller
+    /// FIXME: switch to function vectors
+    protected: virtual void OnNewFrameLeft(const unsigned char *_image,
+                   unsigned int _width, unsigned int _height,
+                   unsigned int _depth, const std::string &_format);
+    protected: virtual void OnNewFrameRight(const unsigned char *_image,
+                   unsigned int _width, unsigned int _height,
+                   unsigned int _depth, const std::string &_format);
+
+    /// Bookkeeping flags that will be passed into the underlying
+    /// GazeboRosCameraUtils objects to let them share state about the parent
+    /// sensor.
+    private: boost::shared_ptr<int> image_connect_count_;
+    private: boost::shared_ptr<boost::mutex> image_connect_count_lock_;
+    private: boost::shared_ptr<bool> was_active_;
+
+    protected: event::ConnectionPtr preRenderConnection_;
+    protected: void SetCameraEnabled(const bool _enabled);
+    protected: void PreRender();
+  };
+}
+#endif
+

--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -125,6 +125,10 @@ void GazeboRosCameraUtils::Load(sensors::SensorPtr _parent,
   if (this->sdf->HasElement("imageTopicName"))
     this->image_topic_name_ = this->sdf->Get<std::string>("imageTopicName");
 
+  this->trigger_topic_name_ = "image_trigger";
+  if (this->sdf->HasElement("triggerTopicName"))
+    this->trigger_topic_name_ = this->sdf->Get<std::string>("triggerTopicName");
+
   this->camera_info_topic_name_ = "camera_info";
   if (this->sdf->HasElement("cameraInfoTopicName"))
     this->camera_info_topic_name_ =
@@ -346,7 +350,24 @@ void GazeboRosCameraUtils::LoadThread()
   this->cameraUpdateRateSubscriber_ = this->rosnode_->subscribe(rate_so);
   */
 
+  ros::SubscribeOptions trigger_so =
+    ros::SubscribeOptions::create<std_msgs::Empty>(
+        this->trigger_topic_name_, 1,
+        boost::bind(&GazeboRosCameraUtils::TriggerCameraInternal, this, _1),
+        ros::VoidPtr(), &this->camera_queue_);
+  this->trigger_subscriber_ = this->rosnode_->subscribe(trigger_so);
+
   this->Init();
+}
+
+void GazeboRosCameraUtils::TriggerCamera()
+{
+}
+
+void GazeboRosCameraUtils::TriggerCameraInternal(
+    const std_msgs::Empty::ConstPtr &dummy)
+{
+  TriggerCamera();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -350,18 +350,26 @@ void GazeboRosCameraUtils::LoadThread()
   this->cameraUpdateRateSubscriber_ = this->rosnode_->subscribe(rate_so);
   */
 
-  ros::SubscribeOptions trigger_so =
-    ros::SubscribeOptions::create<std_msgs::Empty>(
-        this->trigger_topic_name_, 1,
-        boost::bind(&GazeboRosCameraUtils::TriggerCameraInternal, this, _1),
-        ros::VoidPtr(), &this->camera_queue_);
-  this->trigger_subscriber_ = this->rosnode_->subscribe(trigger_so);
+  if (this->CanTriggerCamera())
+  {
+    ros::SubscribeOptions trigger_so =
+      ros::SubscribeOptions::create<std_msgs::Empty>(
+          this->trigger_topic_name_, 1,
+          boost::bind(&GazeboRosCameraUtils::TriggerCameraInternal, this, _1),
+          ros::VoidPtr(), &this->camera_queue_);
+    this->trigger_subscriber_ = this->rosnode_->subscribe(trigger_so);
+  }
 
   this->Init();
 }
 
 void GazeboRosCameraUtils::TriggerCamera()
 {
+}
+
+bool GazeboRosCameraUtils::CanTriggerCamera()
+{
+  return false;
 }
 
 void GazeboRosCameraUtils::TriggerCameraInternal(

--- a/gazebo_plugins/src/gazebo_ros_triggered_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_triggered_camera.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2013 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+/*
+ @mainpage
+   Desc: GazeboRosTriggeredCamera plugin for simulating cameras in Gazebo
+   Author: John Hsu
+   Date: 24 Sept 2008
+*/
+
+#include "gazebo_plugins/gazebo_ros_triggered_camera.h"
+
+#include <float.h>
+#include <string>
+
+#include <gazebo/sensors/Sensor.hh>
+#include <gazebo/sensors/CameraSensor.hh>
+#include <gazebo/sensors/SensorTypes.hh>
+
+namespace gazebo
+{
+// Register this plugin with the simulator
+GZ_REGISTER_SENSOR_PLUGIN(GazeboRosTriggeredCamera)
+
+////////////////////////////////////////////////////////////////////////////////
+// Constructor
+GazeboRosTriggeredCamera::GazeboRosTriggeredCamera()
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Destructor
+GazeboRosTriggeredCamera::~GazeboRosTriggeredCamera()
+{
+  ROS_DEBUG_STREAM_NAMED("camera","Unloaded");
+}
+
+void GazeboRosTriggeredCamera::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
+{
+  // Make sure the ROS node for Gazebo has already been initialized
+  if (!ros::isInitialized())
+  {
+    ROS_FATAL_STREAM("A ROS node for Gazebo has not been initialized, unable to load plugin. "
+      << "Load the Gazebo system plugin 'libgazebo_ros_api_plugin.so' in the gazebo_ros package)");
+    return;
+  }
+
+  CameraPlugin::Load(_parent, _sdf);
+  // copying from CameraPlugin into GazeboRosTriggeredCameraUtils
+  this->parentSensor_ = this->parentSensor;
+  this->width_ = this->width;
+  this->height_ = this->height;
+  this->depth_ = this->depth;
+  this->format_ = this->format;
+  this->camera_ = this->camera;
+
+  GazeboRosCameraUtils::Load(_parent, _sdf);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Update the controller
+void GazeboRosTriggeredCamera::OnNewFrame(const unsigned char *_image,
+    unsigned int _width, unsigned int _height, unsigned int _depth,
+    const std::string &_format)
+{
+# if GAZEBO_MAJOR_VERSION >= 7
+  this->sensor_update_time_ = this->parentSensor_->LastUpdateTime();
+# else
+  this->sensor_update_time_ = this->parentSensor_->GetLastUpdateTime();
+# endif
+
+  if ((*this->image_connect_count_) > 0)
+  {
+    this->PutCameraData(_image);
+    this->PublishCameraInfo();
+  }
+  this->SetCameraEnabled(false);
+}
+
+void GazeboRosTriggeredCamera::TriggerCamera()
+{
+  this->preRenderConnection_ =
+      event::Events::ConnectPreRender(
+          std::bind(&GazeboRosTriggeredCamera::PreRender, this));
+}
+
+void GazeboRosTriggeredCamera::PreRender()
+{
+  this->SetCameraEnabled(true);
+  this->preRenderConnection_.reset();
+}
+
+void GazeboRosTriggeredCamera::SetCameraEnabled(const bool _enabled)
+{
+  this->parentSensor_->SetActive(_enabled);
+  this->parentSensor_->SetUpdateRate(_enabled ? 0.0 : DBL_MIN);
+}
+
+}

--- a/gazebo_plugins/src/gazebo_ros_triggered_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_triggered_camera.cpp
@@ -64,6 +64,7 @@ void GazeboRosTriggeredCamera::Load(sensors::SensorPtr _parent, sdf::ElementPtr 
 
   GazeboRosCameraUtils::Load(_parent, _sdf);
 
+  this->SetCameraEnabled(false);
   this->preRenderConnection_ =
       event::Events::ConnectPreRender(
           std::bind(&GazeboRosTriggeredCamera::PreRender, this));
@@ -76,6 +77,7 @@ void GazeboRosTriggeredCamera::Load(sensors::SensorPtr _parent,
 {
   GazeboRosCameraUtils::Load(_parent, _sdf, _camera_name_suffix, _hack_baseline);
 
+  this->SetCameraEnabled(false);
   this->preRenderConnection_ =
       event::Events::ConnectPreRender(
       std::bind(&GazeboRosTriggeredCamera::PreRender, this));

--- a/gazebo_plugins/src/gazebo_ros_triggered_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_triggered_camera.cpp
@@ -94,11 +94,7 @@ void GazeboRosTriggeredCamera::OnNewFrame(const unsigned char *_image,
     unsigned int _width, unsigned int _height, unsigned int _depth,
     const std::string &_format)
 {
-# if GAZEBO_MAJOR_VERSION >= 7
   this->sensor_update_time_ = this->parentSensor_->LastMeasurementTime();
-# else
-  this->sensor_update_time_ = this->parentSensor_->GetLastUpdateTime();
-# endif
 
   if ((*this->image_connect_count_) > 0)
   {

--- a/gazebo_plugins/src/gazebo_ros_triggered_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_triggered_camera.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Open Source Robotics Foundation
+ * Copyright 2017 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
-*/
-
-/*
- @mainpage
-   Desc: GazeboRosTriggeredCamera plugin for simulating cameras in Gazebo
-   Author: John Hsu
-   Date: 24 Sept 2008
 */
 
 #include "gazebo_plugins/gazebo_ros_triggered_camera.h"

--- a/gazebo_plugins/src/gazebo_ros_triggered_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_triggered_camera.cpp
@@ -97,8 +97,9 @@ void GazeboRosTriggeredCamera::OnNewFrame(const unsigned char *_image,
     this->PublishCameraInfo();
   }
   this->SetCameraEnabled(false);
+
   std::lock_guard<std::mutex> lock(this->mutex);
-  this->triggered = false;
+  this->triggered = std::max(this->triggered-1, 0);
 }
 
 void GazeboRosTriggeredCamera::TriggerCamera()
@@ -106,7 +107,7 @@ void GazeboRosTriggeredCamera::TriggerCamera()
   std::lock_guard<std::mutex> lock(this->mutex);
   if (!this->parentSensor_)
     return;
-  this->triggered = true;
+  this->triggered++;
 }
 
 bool GazeboRosTriggeredCamera::CanTriggerCamera()
@@ -117,8 +118,10 @@ bool GazeboRosTriggeredCamera::CanTriggerCamera()
 void GazeboRosTriggeredCamera::PreRender()
 {
   std::lock_guard<std::mutex> lock(this->mutex);
-  if (this->triggered)
+  if (this->triggered > 0)
+  {
     this->SetCameraEnabled(true);
+  }
 }
 
 void GazeboRosTriggeredCamera::SetCameraEnabled(const bool _enabled)

--- a/gazebo_plugins/src/gazebo_ros_triggered_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_triggered_camera.cpp
@@ -95,7 +95,7 @@ void GazeboRosTriggeredCamera::OnNewFrame(const unsigned char *_image,
     const std::string &_format)
 {
 # if GAZEBO_MAJOR_VERSION >= 7
-  this->sensor_update_time_ = this->parentSensor_->LastUpdateTime();
+  this->sensor_update_time_ = this->parentSensor_->LastMeasurementTime();
 # else
   this->sensor_update_time_ = this->parentSensor_->GetLastUpdateTime();
 # endif

--- a/gazebo_plugins/src/gazebo_ros_triggered_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_triggered_camera.cpp
@@ -107,6 +107,11 @@ void GazeboRosTriggeredCamera::TriggerCamera()
   this->triggered = true;
 }
 
+bool GazeboRosTriggeredCamera::CanTriggerCamera()
+{
+  return true;
+}
+
 void GazeboRosTriggeredCamera::PreRender()
 {
   std::lock_guard<std::mutex> lock(this->mutex);

--- a/gazebo_plugins/src/gazebo_ros_triggered_multicamera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_triggered_multicamera.cpp
@@ -77,20 +77,12 @@ void GazeboRosTriggeredMultiCamera::Load(sensors::SensorPtr _parent,
     cam->image_connect_count_ = this->image_connect_count_;
     cam->image_connect_count_lock_ = this->image_connect_count_lock_;
     cam->was_active_ = this->was_active_;
-# if GAZEBO_MAJOR_VERSION >= 7
     if (this->camera[i]->Name().find("left") != std::string::npos)
-# else
-    if (this->camera[i]->GetName().find("left") != std::string::npos)
-# endif
     {
       // FIXME: hardcoded, left hack_baseline_ 0
       cam->Load(_parent, _sdf, "/left", 0.0);
     }
-# if GAZEBO_MAJOR_VERSION >= 7
     else if (this->camera[i]->Name().find("right") != std::string::npos)
-# else
-    else if (this->camera[i]->GetName().find("right") != std::string::npos)
-# endif
     {
       double hackBaseline = 0.0;
       if (_sdf->HasElement("hackBaseline"))

--- a/gazebo_plugins/src/gazebo_ros_triggered_multicamera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_triggered_multicamera.cpp
@@ -84,8 +84,7 @@ void GazeboRosTriggeredMultiCamera::Load(sensors::SensorPtr _parent,
 # endif
     {
       // FIXME: hardcoded, left hack_baseline_ 0
-      GazeboRosCameraUtils *utils = dynamic_cast<GazeboRosCameraUtils *>(cam);
-      utils->Load(_parent, _sdf, "/left", 0.0);
+      cam->Load(_parent, _sdf, "/left", 0.0);
     }
 # if GAZEBO_MAJOR_VERSION >= 7
     else if (this->camera[i]->Name().find("right") != std::string::npos)
@@ -96,8 +95,7 @@ void GazeboRosTriggeredMultiCamera::Load(sensors::SensorPtr _parent,
       double hackBaseline = 0.0;
       if (_sdf->HasElement("hackBaseline"))
         hackBaseline = _sdf->Get<double>("hackBaseline");
-      GazeboRosCameraUtils *utils = dynamic_cast<GazeboRosCameraUtils *>(cam);
-      utils->Load(_parent, _sdf, "/right", hackBaseline);
+      cam->Load(_parent, _sdf, "/right", hackBaseline);
     }
     this->triggered_cameras.push_back(cam);
   }
@@ -110,17 +108,7 @@ void GazeboRosTriggeredMultiCamera::OnNewFrameLeft(const unsigned char *_image,
     const std::string &_format)
 {
   GazeboRosTriggeredCamera * cam = this->triggered_cameras[0];
-# if GAZEBO_MAJOR_VERSION >= 7
-  cam->sensor_update_time_ = cam->parentSensor_->LastUpdateTime();
-# else
-  cam->sensor_update_time_ = cam->parentSensor_->GetLastUpdateTime();
-# endif
-
-  common::Time cur_time = cam->world_->GetSimTime();
-  cam->PutCameraData(_image);
-  cam->PublishCameraInfo();
-  cam->last_update_time_ = cur_time;
-  cam->SetCameraEnabled(false);
+  cam->OnNewFrame(_image, _width, _height, _depth, _format);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -130,16 +118,6 @@ void GazeboRosTriggeredMultiCamera::OnNewFrameRight(const unsigned char *_image,
     const std::string &_format)
 {
   GazeboRosTriggeredCamera * cam = this->triggered_cameras[1];
-# if GAZEBO_MAJOR_VERSION >= 7
-  cam->sensor_update_time_ = cam->parentSensor_->LastUpdateTime();
-# else
-  cam->sensor_update_time_ = cam->parentSensor_->GetLastUpdateTime();
-# endif
-
-  common::Time cur_time = cam->world_->GetSimTime();
-  cam->PutCameraData(_image);
-  cam->PublishCameraInfo();
-  cam->last_update_time_ = cur_time;
-  cam->SetCameraEnabled(false);
+  cam->OnNewFrame(_image, _width, _height, _depth, _format);
 }
 }

--- a/gazebo_plugins/src/gazebo_ros_triggered_multicamera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_triggered_multicamera.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Open Source Robotics Foundation
+ * Copyright 2017 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,6 @@
  * limitations under the License.
  *
 */
-/*
- * Desc: Syncronizes shutters across multiple cameras
- * Author: John Hsu
- * Date: 10 June 2013
- */
 
 #include <string>
 

--- a/gazebo_plugins/src/gazebo_ros_triggered_multicamera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_triggered_multicamera.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2013 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+/*
+ * Desc: Syncronizes shutters across multiple cameras
+ * Author: John Hsu
+ * Date: 10 June 2013
+ */
+
+#include <string>
+
+#include <gazebo/sensors/Sensor.hh>
+#include <gazebo/sensors/MultiCameraSensor.hh>
+#include <gazebo/sensors/SensorTypes.hh>
+
+#include "gazebo_plugins/gazebo_ros_triggered_multicamera.h"
+
+namespace gazebo
+{
+// Register this plugin with the simulator
+GZ_REGISTER_SENSOR_PLUGIN(GazeboRosTriggeredMultiCamera)
+
+////////////////////////////////////////////////////////////////////////////////
+// Constructor
+GazeboRosTriggeredMultiCamera::GazeboRosTriggeredMultiCamera()
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Destructor
+GazeboRosTriggeredMultiCamera::~GazeboRosTriggeredMultiCamera()
+{
+}
+
+void GazeboRosTriggeredMultiCamera::Load(sensors::SensorPtr _parent,
+  sdf::ElementPtr _sdf)
+{
+  MultiCameraPlugin::Load(_parent, _sdf);
+
+  // Make sure the ROS node for Gazebo has already been initialized
+  if (!ros::isInitialized())
+  {
+    ROS_FATAL_STREAM("A ROS node for Gazebo has not been initialized, unable to load plugin. "
+      << "Load the Gazebo system plugin 'libgazebo_ros_api_plugin.so' in the gazebo_ros package)");
+    return;
+  }
+
+  // initialize shared_ptr members
+  this->image_connect_count_ = boost::shared_ptr<int>(new int(0));
+  this->image_connect_count_lock_ = boost::shared_ptr<boost::mutex>(new boost::mutex);
+  this->was_active_ = boost::shared_ptr<bool>(new bool(false));
+
+  // copying from CameraPlugin into GazeboRosCameraUtils
+  for (unsigned i = 0; i < this->camera.size(); ++i)
+  {
+    GazeboRosTriggeredCamera * cam = new GazeboRosTriggeredCamera();
+    cam->parentSensor_ = this->parentSensor;
+    cam->width_   = this->width[i];
+    cam->height_  = this->height[i];
+    cam->depth_   = this->depth[i];
+    cam->format_  = this->format[i];
+    cam->camera_  = this->camera[i];
+    // Set up a shared connection counter
+    cam->image_connect_count_ = this->image_connect_count_;
+    cam->image_connect_count_lock_ = this->image_connect_count_lock_;
+    cam->was_active_ = this->was_active_;
+# if GAZEBO_MAJOR_VERSION >= 7
+    if (this->camera[i]->Name().find("left") != std::string::npos)
+# else
+    if (this->camera[i]->GetName().find("left") != std::string::npos)
+# endif
+    {
+      // FIXME: hardcoded, left hack_baseline_ 0
+      GazeboRosCameraUtils *utils = dynamic_cast<GazeboRosCameraUtils *>(cam);
+      utils->Load(_parent, _sdf, "/left", 0.0);
+    }
+# if GAZEBO_MAJOR_VERSION >= 7
+    else if (this->camera[i]->Name().find("right") != std::string::npos)
+# else
+    else if (this->camera[i]->GetName().find("right") != std::string::npos)
+# endif
+    {
+      double hackBaseline = 0.0;
+      if (_sdf->HasElement("hackBaseline"))
+        hackBaseline = _sdf->Get<double>("hackBaseline");
+      GazeboRosCameraUtils *utils = dynamic_cast<GazeboRosCameraUtils *>(cam);
+      utils->Load(_parent, _sdf, "/right", hackBaseline);
+    }
+    this->triggered_cameras.push_back(cam);
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Update the controller
+void GazeboRosTriggeredMultiCamera::OnNewFrameLeft(const unsigned char *_image,
+    unsigned int _width, unsigned int _height, unsigned int _depth,
+    const std::string &_format)
+{
+  GazeboRosTriggeredCamera * cam = this->triggered_cameras[0];
+# if GAZEBO_MAJOR_VERSION >= 7
+  cam->sensor_update_time_ = cam->parentSensor_->LastUpdateTime();
+# else
+  cam->sensor_update_time_ = cam->parentSensor_->GetLastUpdateTime();
+# endif
+
+  common::Time cur_time = cam->world_->GetSimTime();
+  cam->PutCameraData(_image);
+  cam->PublishCameraInfo();
+  cam->last_update_time_ = cur_time;
+  cam->SetCameraEnabled(false);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Update the controller
+void GazeboRosTriggeredMultiCamera::OnNewFrameRight(const unsigned char *_image,
+    unsigned int _width, unsigned int _height, unsigned int _depth,
+    const std::string &_format)
+{
+  GazeboRosTriggeredCamera * cam = this->triggered_cameras[1];
+# if GAZEBO_MAJOR_VERSION >= 7
+  cam->sensor_update_time_ = cam->parentSensor_->LastUpdateTime();
+# else
+  cam->sensor_update_time_ = cam->parentSensor_->GetLastUpdateTime();
+# endif
+
+  common::Time cur_time = cam->world_->GetSimTime();
+  cam->PutCameraData(_image);
+  cam->PublishCameraInfo();
+  cam->last_update_time_ = cur_time;
+  cam->SetCameraEnabled(false);
+}
+}

--- a/gazebo_plugins/test/camera/camera.h
+++ b/gazebo_plugins/test/camera/camera.h
@@ -67,6 +67,21 @@ void CameraTest::subscribeTest()
   ROS_INFO_STREAM(time_diff);
   EXPECT_LT(time_diff, 1.0);
   cam_sub_.shutdown();
+
+  // make sure nothing is subscribing to image_trigger topic
+  // there is no easy API, so call getSystemState
+  XmlRpc::XmlRpcValue args, result, payload;
+  args[0] = ros::this_node::getName();
+  EXPECT_TRUE(ros::master::execute("getSystemState", args, result, payload, true));
+  // [publishers, subscribers, services]
+  // subscribers in index 1 of payload
+  for (int i = 0; i < payload[1].size(); ++i)
+  {
+    // [ [topic1, [topic1Subscriber1...topic1SubscriberN]] ... ]
+    // topic name i is in index 0
+    std::string topic = payload[1][i][0];
+    EXPECT_EQ(topic.find("image_trigger"), std::string::npos);
+  }
 }
 
 #endif

--- a/gazebo_plugins/test/camera/camera16bit.test
+++ b/gazebo_plugins/test/camera/camera16bit.test
@@ -12,6 +12,6 @@
     <node name="gazebo_gui" pkg="gazebo_ros" type="gzclient" respawn="false" output="screen"/>
   </group>
 
-  <test test-name="camera" pkg="gazebo_plugins" type="camera-test"
+  <test test-name="camera16bit" pkg="gazebo_plugins" type="camera-test"
       clear_params="true" time-limit="30.0" />
 </launch>

--- a/gazebo_plugins/test/camera/depth_camera.cpp
+++ b/gazebo_plugins/test/camera/depth_camera.cpp
@@ -103,6 +103,21 @@ TEST_F(DepthCameraTest, cameraSubscribeTest)
   cam_sub_.shutdown();
   depth_sub_.shutdown();
   points_sub_.shutdown();
+
+  // make sure nothing is subscribing to image_trigger topic
+  // there is no easy API, so call getSystemState
+  XmlRpc::XmlRpcValue args, result, payload;
+  args[0] = ros::this_node::getName();
+  EXPECT_TRUE(ros::master::execute("getSystemState", args, result, payload, true));
+  // [publishers, subscribers, services]
+  // subscribers in index 1 of payload
+  for (int i = 0; i < payload[1].size(); ++i)
+  {
+    // [ [topic1, [topic1Subscriber1...topic1SubscriberN]] ... ]
+    // topic name i is in index 0
+    std::string topic = payload[1][i][0];
+    EXPECT_EQ(topic.find("image_trigger"), std::string::npos);
+  }
 }
 
 int main(int argc, char** argv)

--- a/gazebo_plugins/test/camera/distortion_barrel.world
+++ b/gazebo_plugins/test/camera/distortion_barrel.world
@@ -1,0 +1,127 @@
+<?xml version="1.0" ?>
+<sdf version="1.4">
+  <world name="default">
+
+    <!-- Global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <model name="camera_distorted">
+      <static>true</static>
+      <pose>0.0 0.0 2.5 0.0 1.5707 0.0</pose>
+      <link name="camera_link">
+        <pose>0 0 0 0 0 0</pose>
+        <visual name="camera_visual">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor type="camera" name="camera_distorted">
+          <update_rate>30.0</update_rate>
+          <camera name="head">
+            <horizontal_fov>0.927295218</horizontal_fov>
+            <image>
+              <width>1000</width>
+              <height>1000</height>
+              <format>R8G8B8</format>
+            </image>
+            <clip>
+              <near>0.02</near>
+              <far>300</far>
+            </clip>
+    <!-- CAUTION: Changing the distortion parameters for this test camera
+    may result in large black borders on the generated images, or in the
+    undistorted version of the images. This will likely skew and invalidate
+    the results of camera distortion tests. -->
+            <distortion>
+              <k1>-0.1</k1>
+              <k2>-0.1</k2>
+              <p1>0</p1>
+              <p2>0</p2>
+              <k3>-0.1</k3>
+              <center>0.5 0.5</center>
+            </distortion>
+          </camera>
+          <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
+            <alwaysOn>true</alwaysOn>
+            <updateRate>0.0</updateRate>
+            <cameraName>camera_distorted</cameraName>
+            <imageTopicName>image_raw</imageTopicName>
+            <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+            <frameName>camera_distorted_link</frameName>
+            <hackBaseline>0.07</hackBaseline>
+    <!-- CAUTION: Changing the distortion parameters for this test camera
+    may result in large black borders on the generated images, or in the
+    undistorted version of the images. This will likely skew and invalidate
+    the results of camera distortion tests. -->
+            <distortionK1>-0.1</distortionK1>
+            <distortionK2>-0.1</distortionK2>
+            <distortionT1>0.0</distortionT1>
+            <distortionT2>0.0</distortionT2>
+            <distortionK3>-0.1</distortionK3>
+            <borderCrop>false</borderCrop>
+          </plugin>
+        </sensor>
+      </link>
+    </model>
+
+    <model name="camera_undistorted">
+      <static>true</static>
+      <pose>0.0 0.0 2.5 0.0 1.5707 0.0</pose>
+      <link name="camera_link">
+        <pose>0 0 0 0 0 0</pose>
+        <visual name="camera_visual">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor type="camera" name="camera_undistorted">
+          <update_rate>30.0</update_rate>
+          <camera name="head">
+            <horizontal_fov>0.927295218</horizontal_fov>
+            <image>
+              <width>1000</width>
+              <height>1000</height>
+              <format>R8G8B8</format>
+            </image>
+            <clip>
+              <near>0.02</near>
+              <far>300</far>
+            </clip>
+            <distortion>
+              <k1>0.0</k1>
+              <k2>0.0</k2>
+              <p1>0.0</p1>
+              <p2>0.0</p2>
+              <k3>0.0</k3>
+              <center>0.5 0.5</center>
+            </distortion>
+          </camera>
+          <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
+            <alwaysOn>true</alwaysOn>
+            <updateRate>0.0</updateRate>
+            <cameraName>camera_undistorted</cameraName>
+            <imageTopicName>image_raw</imageTopicName>
+            <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+            <frameName>camera_undistorted_link</frameName>
+            <hackBaseline>0.0</hackBaseline>
+            <distortionK1>0.0</distortionK1>
+            <distortionK2>0.0</distortionK2>
+            <distortionT1>0.0</distortionT1>
+            <distortionT2>0.0</distortionT2>
+            <distortionK3>0.0</distortionK3>
+          </plugin>
+        </sensor>
+      </link>
+    </model>
+
+    <include>
+      <uri>model://checkerboard_plane</uri>
+    </include>
+</world>
+</sdf>

--- a/gazebo_plugins/test/camera/distortion_pincushion.world
+++ b/gazebo_plugins/test/camera/distortion_pincushion.world
@@ -1,0 +1,127 @@
+<?xml version="1.0" ?>
+<sdf version="1.4">
+  <world name="default">
+
+    <!-- Global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <model name="camera_distorted">
+      <static>true</static>
+      <pose>0.0 0.0 2.5 0.0 1.5707 0.0</pose>
+      <link name="camera_link">
+        <pose>0 0 0 0 0 0</pose>
+        <visual name="camera_visual">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor type="camera" name="camera_distorted">
+          <update_rate>30.0</update_rate>
+          <camera name="head">
+            <horizontal_fov>0.927295218</horizontal_fov>
+            <image>
+              <width>1000</width>
+              <height>1000</height>
+              <format>R8G8B8</format>
+            </image>
+            <clip>
+              <near>0.02</near>
+              <far>300</far>
+            </clip>
+    <!-- CAUTION: Changing the distortion parameters for this test camera
+    may result in large black borders on the generated images, or in the
+    undistorted version of the images. This will likely skew and invalidate
+    the results of camera distortion tests. -->
+            <distortion>
+              <k1>0.1</k1>
+              <k2>0.1</k2>
+              <p1>0</p1>
+              <p2>0</p2>
+              <k3>0.1</k3>
+              <center>0.5 0.5</center>
+            </distortion>
+          </camera>
+          <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
+            <alwaysOn>true</alwaysOn>
+            <updateRate>0.0</updateRate>
+            <cameraName>camera_distorted</cameraName>
+            <imageTopicName>image_raw</imageTopicName>
+            <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+            <frameName>camera_distorted_link</frameName>
+            <hackBaseline>0.07</hackBaseline>
+    <!-- CAUTION: Changing the distortion parameters for this test camera
+    may result in large black borders on the generated images, or in the
+    undistorted version of the images. This will likely skew and invalidate
+    the results of camera distortion tests. -->
+            <distortionK1>0.1</distortionK1>
+            <distortionK2>0.1</distortionK2>
+            <distortionT1>0.0</distortionT1>
+            <distortionT2>0.0</distortionT2>
+            <distortionK3>0.1</distortionK3>
+            <borderCrop>false</borderCrop>
+          </plugin>
+        </sensor>
+      </link>
+    </model>
+
+    <model name="camera_undistorted">
+      <static>true</static>
+      <pose>0.0 0.0 2.5 0.0 1.5707 0.0</pose>
+      <link name="camera_link">
+        <pose>0 0 0 0 0 0</pose>
+        <visual name="camera_visual">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor type="camera" name="camera_undistorted">
+          <update_rate>30.0</update_rate>
+          <camera name="head">
+            <horizontal_fov>0.927295218</horizontal_fov>
+            <image>
+              <width>1000</width>
+              <height>1000</height>
+              <format>R8G8B8</format>
+            </image>
+            <clip>
+              <near>0.02</near>
+              <far>300</far>
+            </clip>
+            <distortion>
+              <k1>0.0</k1>
+              <k2>0.0</k2>
+              <p1>0.0</p1>
+              <p2>0.0</p2>
+              <k3>0.0</k3>
+              <center>0.5 0.5</center>
+            </distortion>
+          </camera>
+          <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
+            <alwaysOn>true</alwaysOn>
+            <updateRate>0.0</updateRate>
+            <cameraName>camera_undistorted</cameraName>
+            <imageTopicName>image_raw</imageTopicName>
+            <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+            <frameName>camera_undistorted_link</frameName>
+            <hackBaseline>0.0</hackBaseline>
+            <distortionK1>0.0</distortionK1>
+            <distortionK2>0.0</distortionK2>
+            <distortionT1>0.0</distortionT1>
+            <distortionT2>0.0</distortionT2>
+            <distortionK3>0.0</distortionK3>
+          </plugin>
+        </sensor>
+      </link>
+    </model>
+
+    <include>
+      <uri>model://checkerboard_plane</uri>
+    </include>
+</world>
+</sdf>

--- a/gazebo_plugins/test/camera/multicamera.cpp
+++ b/gazebo_plugins/test/camera/multicamera.cpp
@@ -91,6 +91,21 @@ TEST_F(MultiCameraTest, cameraSubscribeTest)
   ROS_INFO_STREAM(time_diff);
   EXPECT_LT(time_diff, 1.0);
   // cam_sub_.shutdown();
+
+  // make sure nothing is subscribing to image_trigger topic
+  // there is no easy API, so call getSystemState
+  XmlRpc::XmlRpcValue args, result, payload;
+  args[0] = ros::this_node::getName();
+  EXPECT_TRUE(ros::master::execute("getSystemState", args, result, payload, true));
+  // [publishers, subscribers, services]
+  // subscribers in index 1 of payload
+  for (int i = 0; i < payload[1].size(); ++i)
+  {
+    // [ [topic1, [topic1Subscriber1...topic1SubscriberN]] ... ]
+    // topic name i is in index 0
+    std::string topic = payload[1][i][0];
+    EXPECT_EQ(topic.find("image_trigger"), std::string::npos);
+  }
 }
 
 int main(int argc, char** argv)

--- a/gazebo_plugins/test/camera/triggered_camera.cpp
+++ b/gazebo_plugins/test/camera/triggered_camera.cpp
@@ -29,8 +29,8 @@ TEST_F(TriggeredCameraTest, cameraSubscribeTest)
 {
   image_transport::ImageTransport it(nh_);
   cam_sub_ = it.subscribe("camera1/image_raw", 5,
-                          &CameraTest::imageCallback,
-                          dynamic_cast<CameraTest*>(this));
+                          &TriggeredCameraTest::imageCallback,
+                          dynamic_cast<TriggeredCameraTest*>(this));
 
   // wait for 3 seconds to confirm that we don't receive any images
   for (unsigned int i = 0; i < 30; ++i)

--- a/gazebo_plugins/test/camera/triggered_camera.cpp
+++ b/gazebo_plugins/test/camera/triggered_camera.cpp
@@ -28,7 +28,7 @@ public:
 TEST_F(CameraTest, cameraSubscribeTest)
 {
   image_transport::ImageTransport it(nh_);
-  cam_sub_ = it.subscribe("camera1/image_raw", 1,
+  cam_sub_ = it.subscribe("camera1/image_raw", 5,
                           &CameraTest::imageCallback,
                           dynamic_cast<CameraTest*>(this));
 
@@ -80,19 +80,20 @@ TEST_F(CameraTest, cameraSubscribeTest)
   }
   EXPECT_EQ(images_received_, 1);
 
-  // then send two trigger messages very close together, but only expect one image
+  // then send two trigger messages very close together, and expect two more
+  // images
   trigger_pub.publish(msg);
   ros::spinOnce();
   ros::Duration(0.01).sleep();
   trigger_pub.publish(msg);
   ros::spinOnce();
   ros::Duration(0.01).sleep();
-  for (unsigned int i = 0; i < 10 && 1 == images_received_; ++i)
+  for (unsigned int i = 0; i < 10 && images_received_ < 2; ++i)
   {
     ros::spinOnce();
     ros::Duration(0.1).sleep();
   }
-  EXPECT_EQ(images_received_, 2);
+  EXPECT_EQ(images_received_, 3);
 
   // then wait for 3 seconds to confirm that we don't receive any more images
   for (unsigned int i = 0; i < 30; ++i)
@@ -100,7 +101,7 @@ TEST_F(CameraTest, cameraSubscribeTest)
     ros::spinOnce();
     ros::Duration(0.1).sleep();
   }
-  EXPECT_EQ(images_received_, 2);
+  EXPECT_EQ(images_received_, 3);
 
   cam_sub_.shutdown();
 }

--- a/gazebo_plugins/test/camera/triggered_camera.cpp
+++ b/gazebo_plugins/test/camera/triggered_camera.cpp
@@ -3,7 +3,7 @@
 #include <ros/ros.h>
 #include <std_msgs/Empty.h>
 
-class CameraTest : public testing::Test
+class TriggeredCameraTest : public testing::Test
 {
 protected:
   virtual void SetUp()
@@ -25,7 +25,7 @@ public:
 
 // Test if the camera image is published at all, and that the timestamp
 // is not too long in the past.
-TEST_F(CameraTest, cameraSubscribeTest)
+TEST_F(TriggeredCameraTest, cameraSubscribeTest)
 {
   image_transport::ImageTransport it(nh_);
   cam_sub_ = it.subscribe("camera1/image_raw", 5,

--- a/gazebo_plugins/test/camera/triggered_camera.cpp
+++ b/gazebo_plugins/test/camera/triggered_camera.cpp
@@ -32,22 +32,13 @@ TEST_F(CameraTest, cameraSubscribeTest)
                           &CameraTest::imageCallback,
                           dynamic_cast<CameraTest*>(this));
 
-  // check for first image
-  while (!images_received_)
-  {
-    ros::spinOnce();
-    ros::Duration(0.1).sleep();
-  }
-
-  // then wait for 3 seconds to confirm that we don't receive any more images
-  images_received_ = 0;
+  // wait for 3 seconds to confirm that we don't receive any images
   for (unsigned int i = 0; i < 30; ++i)
   {
     ros::spinOnce();
     ros::Duration(0.1).sleep();
   }
   EXPECT_EQ(images_received_, 0);
-  images_received_ = 0;
 
   // make sure something is subscribing to image_trigger topic
   // there is no easy API, so call getSystemState

--- a/gazebo_plugins/test/camera/triggered_camera.cpp
+++ b/gazebo_plugins/test/camera/triggered_camera.cpp
@@ -1,0 +1,122 @@
+#include <gtest/gtest.h>
+#include <image_transport/image_transport.h>
+#include <ros/ros.h>
+#include <std_msgs/Empty.h>
+
+class CameraTest : public testing::Test
+{
+protected:
+  virtual void SetUp()
+  {
+    images_received_ = 0;
+  }
+
+  ros::NodeHandle nh_;
+  image_transport::Subscriber cam_sub_;
+  int images_received_;
+  ros::Time image_stamp_;
+public:
+  void imageCallback(const sensor_msgs::ImageConstPtr& msg)
+  {
+    image_stamp_ = msg->header.stamp;
+    images_received_++;
+  }
+};
+
+// Test if the camera image is published at all, and that the timestamp
+// is not too long in the past.
+TEST_F(CameraTest, cameraSubscribeTest)
+{
+  image_transport::ImageTransport it(nh_);
+  cam_sub_ = it.subscribe("camera1/image_raw", 1,
+                          &CameraTest::imageCallback,
+                          dynamic_cast<CameraTest*>(this));
+
+  // check for first image
+  while (!images_received_)
+  {
+    ros::spinOnce();
+    ros::Duration(0.1).sleep();
+  }
+
+  // then wait for 3 seconds to confirm that we don't receive any more images
+  images_received_ = 0;
+  for (unsigned int i = 0; i < 30; ++i)
+  {
+    ros::spinOnce();
+    ros::Duration(0.1).sleep();
+  }
+  EXPECT_EQ(images_received_, 0);
+  images_received_ = 0;
+
+  // make sure something is subscribing to image_trigger topic
+  // there is no easy API, so call getSystemState
+  XmlRpc::XmlRpcValue args, result, payload;
+  args[0] = ros::this_node::getName();
+  EXPECT_TRUE(ros::master::execute("getSystemState", args, result, payload, true));
+  // [publishers, subscribers, services]
+  // subscribers in index 1 of payload
+  int trigger_listeners = 0;
+  for (int i = 0; i < payload[1].size(); ++i)
+  {
+    // [ [topic1, [topic1Subscriber1...topic1SubscriberN]] ... ]
+    // topic name i is in index 0
+    std::string topic = payload[1][i][0];
+    if (topic.find("image_trigger") != std::string::npos)
+    {
+      trigger_listeners++;
+    }
+  }
+  EXPECT_EQ(trigger_listeners, 1);
+
+  // publish to trigger topic and expect an update within one second:
+  ros::Publisher trigger_pub = nh_.advertise<std_msgs::Empty>("camera1/image_trigger", 1, true);
+  std_msgs::Empty msg;
+
+  trigger_pub.publish(msg);
+  for (unsigned int i = 0; i < 10 && !images_received_; ++i)
+  {
+    ros::spinOnce();
+    ros::Duration(0.1).sleep();
+  }
+  EXPECT_EQ(images_received_, 1);
+
+  // then wait for 3 seconds to confirm that we don't receive any more images
+  for (unsigned int i = 0; i < 30; ++i)
+  {
+    ros::spinOnce();
+    ros::Duration(0.1).sleep();
+  }
+  EXPECT_EQ(images_received_, 1);
+
+  // then send two trigger messages very close together, but only expect one image
+  trigger_pub.publish(msg);
+  ros::spinOnce();
+  ros::Duration(0.01).sleep();
+  trigger_pub.publish(msg);
+  ros::spinOnce();
+  ros::Duration(0.01).sleep();
+  for (unsigned int i = 0; i < 10 && 1 == images_received_; ++i)
+  {
+    ros::spinOnce();
+    ros::Duration(0.1).sleep();
+  }
+  EXPECT_EQ(images_received_, 2);
+
+  // then wait for 3 seconds to confirm that we don't receive any more images
+  for (unsigned int i = 0; i < 30; ++i)
+  {
+    ros::spinOnce();
+    ros::Duration(0.1).sleep();
+  }
+  EXPECT_EQ(images_received_, 2);
+
+  cam_sub_.shutdown();
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "gazebo_camera_test");
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/gazebo_plugins/test/camera/triggered_camera.test
+++ b/gazebo_plugins/test/camera/triggered_camera.test
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="gui" default="false" />
+
+  <param name="/use_sim_time" value="true" />
+
+  <node name="gazebo" pkg="gazebo_ros" type="gzserver"
+      respawn="false" output="screen"
+      args="--verbose $(find gazebo_plugins)/test/camera/triggered_camera.world" />
+
+  <group if="$(arg gui)">
+    <node name="gazebo_gui" pkg="gazebo_ros" type="gzclient" respawn="false" output="screen"/>
+  </group>
+
+  <test test-name="triggered_camera" pkg="gazebo_plugins" type="triggered-camera-test"
+      clear_params="true" time-limit="30.0" />
+</launch>

--- a/gazebo_plugins/test/camera/triggered_camera.world
+++ b/gazebo_plugins/test/camera/triggered_camera.world
@@ -1,0 +1,140 @@
+<?xml version="1.0" ?>
+<sdf version="1.4">
+
+  <world name="default">
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+
+    <!-- Global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <!-- Focus camera on tall pendulum -->
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose>4.927360 -4.376610 3.740080 0.000000 0.275643 2.356190</pose>
+        <view_controller>orbit</view_controller>
+      </camera>
+    </gui>
+
+  <model name="model_1">
+    <static>false</static>
+    <pose>2.0 0.0 4.0 0.0 0.0 0.0</pose>
+    <link name="link_1">
+      <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+      <inertial>
+        <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+        <inertia>
+          <ixx>1.0</ixx>
+          <ixy>0.0</ixy>
+          <ixz>0.0</ixz>
+          <iyy>1.0</iyy>
+          <iyz>0.0</iyz>
+          <izz>1.0</izz>
+        </inertia>
+        <mass>10.0</mass>
+      </inertial>
+      <visual name="visual_sphere">
+        <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+        <geometry>
+          <sphere>
+            <radius>0.5</radius>
+          </sphere>
+        </geometry>
+        <material>
+          <ambient>0.03 0.5 0.5 1.0</ambient>
+          <script>Gazebo/Green</script>
+        </material>
+        <cast_shadows>true</cast_shadows>
+        <laser_retro>100.0</laser_retro>
+      </visual>
+      <collision name="collision_sphere">
+        <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+        <max_contacts>250</max_contacts>
+        <geometry>
+          <sphere>
+            <radius>0.5</radius>
+          </sphere>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>0.5</mu>
+              <mu2>0.2</mu2>
+              <fdir1>1.0 0 0</fdir1>
+              <slip1>0</slip1>
+              <slip2>0</slip2>
+            </ode>
+          </friction>
+          <bounce>
+            <restitution_coefficient>0</restitution_coefficient>
+            <threshold>1000000.0</threshold>
+          </bounce>
+          <contact>
+            <ode>
+              <soft_cfm>0</soft_cfm>
+              <soft_erp>0.2</soft_erp>
+              <kp>1e15</kp>
+              <kd>1e13</kd>
+              <max_vel>100.0</max_vel>
+              <min_depth>0.0001</min_depth>
+            </ode>
+          </contact>
+        </surface>
+        <laser_retro>100.0</laser_retro>
+      </collision>
+    </link>
+  </model>
+
+  <model name="camera_model">
+    <static>true</static>
+    <pose>0.0 0.0 0.5 0.0 0.0 0.0</pose>
+    <link name="camera_link">
+      <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+    <sensor type="camera" name="camera1">
+      <always_on>0</always_on>
+      <update_rate>1</update_rate>
+      <camera name="head">
+        <horizontal_fov>1.3962634</horizontal_fov>
+        <image>
+          <width>640</width>
+          <height>480</height>
+          <format>R8G8B8</format>
+        </image>
+        <clip>
+          <near>0.02</near>
+          <far>300</far>
+        </clip>
+        <noise>
+          <type>gaussian</type>
+          <!-- Noise is sampled independently per pixel on each frame.  
+               That pixel's noise value is added to each of its color
+               channels, which at that point lie in the range [0,1]. -->
+          <mean>0.0</mean>
+          <stddev>0.007</stddev>
+        </noise>
+      </camera>
+      <plugin name="camera_controller" filename="libgazebo_ros_triggered_camera.so">
+        <alwaysOn>true</alwaysOn>
+        <triggerTopicName>image_trigger</triggerTopicName>
+        <!-- Keep this zero, update_rate will control the frame rate -->
+        <updateRate>0.0</updateRate>
+        <cameraName>camera1</cameraName>
+        <imageTopicName>image_raw</imageTopicName>
+        <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+        <frameName>camera_link</frameName>
+        <hackBaseline>0.07</hackBaseline>
+        <distortionK1>0.0</distortionK1>
+        <distortionK2>0.0</distortionK2>
+        <distortionK3>0.0</distortionK3>
+        <distortionT1>0.0</distortionT1>
+        <distortionT2>0.0</distortionT2>
+      </plugin>
+    </sensor>
+    </link>
+  </model>
+
+  </world>
+</sdf>


### PR DESCRIPTION
{ port of pull request #687 }
This adds a plugin for triggered cameras and multicameras. These sensors do not publish unless triggered. They have an additional topic (default name `image_trigger`) that subscribes to `std_msgs/Empty` messages and will publish a single update after being triggered.

Its maximum update rate is currently set by the `<update_rate>` sdf tag in the `<sensor>` block. Under the hood. If you publish two trigger messages before the camera has a chance to publish, it will only publish once, since a `bool` is used to keep track of the trigger status. The test reflects this behavior.