### PR TITLE
DIFF DRIVE: wheel odometry twist is child frame

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
@@ -411,8 +411,8 @@ void GazeboRosDiffDrive::UpdateOdometryEncoder()
     odom_.pose.pose.orientation.w = qt.w();
 
     odom_.twist.twist.angular.z = w;
-    odom_.twist.twist.linear.x = dx/seconds_since_last_update;
-    odom_.twist.twist.linear.y = dy/seconds_since_last_update;
+    odom_.twist.twist.linear.x = v;
+    odom_.twist.twist.linear.y = 0;
 }
 
 void GazeboRosDiffDrive::publishOdometry ( double step_time )


### PR DESCRIPTION
#717. In the diff drive plugin in with odometry source set to ENCODER, twist is published in global frame. This is against the convention specified in the Odometry message and inconsistent with there other mode (WORLD), where twist is published in the child frame.