### PR TITLE
ROS UTILS: prevent segfault when using alternative GazeboRos constructor (indigo-devel)

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_utils.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_utils.h
@@ -168,6 +168,7 @@ public:
         } else {
             ss << "the 'robotNamespace' param did not exit";
         }
+        rosnode_ = boost::shared_ptr<ros::NodeHandle> ( new ros::NodeHandle ( namespace_ ) );
         info_text = plugin_ + "(ns = " + namespace_ + ")";
         ROS_INFO ( "%s: %s" , info_text.c_str(), ss.str().c_str() );
         readCommonParameter ();


### PR DESCRIPTION
{ port of pull request #718 }
Fix #478. This line was likely omitted by accident. When users use this constructor, rosnode_ is not initialized and the program will segfault when rosnode_ is used.