### PR TITLE
GAZEBO_ROS_CONTROL: call readSim every world update (issue #151)

### DIFF
--- a/gazebo_ros_control/include/gazebo_ros_control/gazebo_ros_control_plugin.h
+++ b/gazebo_ros_control/include/gazebo_ros_control/gazebo_ros_control_plugin.h
@@ -116,9 +116,11 @@ protected:
   // Controller manager
   boost::shared_ptr<controller_manager::ControllerManager> controller_manager_;
 
-  // Timing
+  // Period between calls to controller update
   ros::Duration control_period_;
+  // Last time that controllers were updated
   ros::Time last_update_sim_time_ros_;
+  // Last time that hardware readSim and writeSim were called
   ros::Time last_write_sim_time_ros_;
 
   // e_stop_active_ is true if the emergency stop is active.

--- a/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
+++ b/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
@@ -215,19 +215,21 @@ void GazeboRosControlPlugin::Update()
   gazebo::common::Time gz_time_now = parent_model_->GetWorld()->GetSimTime();
 #endif
   ros::Time sim_time_ros(gz_time_now.sec, gz_time_now.nsec);
-  ros::Duration sim_period = sim_time_ros - last_update_sim_time_ros_;
+  ros::Duration update_period = sim_time_ros - last_update_sim_time_ros_;
+  ros::Duration hardware_period = sim_time_ros - last_write_sim_time_ros_;
+  last_write_sim_time_ros_ = sim_time_ros;
 
   robot_hw_sim_->eStopActive(e_stop_active_);
 
+  // Update the robot simulation with the state of the gazebo model
+  robot_hw_sim_->readSim(sim_time_ros, hardware_period);
+
   // Check if we should update the controllers
-  if(sim_period >= control_period_) {
+  if(update_period >= control_period_) {
     // Store this simulation time
     last_update_sim_time_ros_ = sim_time_ros;
 
-    // Update the robot simulation with the state of the gazebo model
-    robot_hw_sim_->readSim(sim_time_ros, sim_period);
-
-    // Compute the controller commands
+    // Determine if controller need to be reset due to e-stop
     bool reset_ctrlrs;
     if (e_stop_active_)
     {
@@ -246,13 +248,13 @@ void GazeboRosControlPlugin::Update()
         reset_ctrlrs = false;
       }
     }
-    controller_manager_->update(sim_time_ros, sim_period, reset_ctrlrs);
+
+    // Compute the controller commands
+    controller_manager_->update(sim_time_ros, update_period, reset_ctrlrs);
   }
 
   // Update the gazebo model with the result of the controller
-  // computation
-  robot_hw_sim_->writeSim(sim_time_ros, sim_time_ros - last_write_sim_time_ros_);
-  last_write_sim_time_ros_ = sim_time_ros;
+  robot_hw_sim_->writeSim(sim_time_ros, hardware_period);
 }
 
 // Called on world reset


### PR DESCRIPTION
* Address issue #151 by calling simulated hardware's readSim every Update loop, not just when controller is updated.
* improve comments so this behavior is clear

I believe this would considered no API change. readSim will be called more frequently (in some cases), but the time and period parameter will still be accurate.