### PR TITLE
camera tests: remove -r gazebo arg (indigo)

### DIFF
--- a/gazebo_plugins/test/camera/camera.test
+++ b/gazebo_plugins/test/camera/camera.test
@@ -6,7 +6,7 @@
 
   <node name="gazebo" pkg="gazebo_ros" type="gzserver"
       respawn="false" output="screen"
-      args="-r $(find gazebo_plugins)/test/camera/camera.world" />
+      args="--verbose $(find gazebo_plugins)/test/camera/camera.world" />
 
   <group if="$(arg gui)">
     <node name="gazebo_gui" pkg="gazebo_ros" type="gzclient" respawn="false" output="screen"/>

--- a/gazebo_plugins/test/camera/depth_camera.test
+++ b/gazebo_plugins/test/camera/depth_camera.test
@@ -6,7 +6,7 @@
 
   <node name="gazebo" pkg="gazebo_ros" type="gzserver"
       respawn="false" output="screen"
-      args="-r $(find gazebo_plugins)/test/camera/depth_camera.world" />
+      args="--verbose $(find gazebo_plugins)/test/camera/depth_camera.world" />
 
   <group if="$(arg gui)">
     <node name="gazebo_gui" pkg="gazebo_ros" type="gzclient" respawn="false" output="screen"/>

--- a/gazebo_plugins/test/camera/multicamera.test
+++ b/gazebo_plugins/test/camera/multicamera.test
@@ -4,7 +4,7 @@
 
   <node name="gazebo" pkg="gazebo_ros" type="gzserver"
       respawn="false" output="screen"
-      args="-r $(find gazebo_plugins)/test/camera/multicamera.world" />
+      args="--verbose $(find gazebo_plugins)/test/camera/multicamera.world" />
 
   <test test-name="multicamera" pkg="gazebo_plugins" type="multicamera-test"
       clear_params="true" time-limit="15.0" />


### PR DESCRIPTION
There are a couple failing tests on indigo, but I believe removing the `-r` argument will fix them.

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ros_gazebo_pkgs-ci-default_indigo-trusty-amd64&build=26)](https://build.osrfoundation.org/job/ros_gazebo_pkgs-ci-default_indigo-trusty-amd64/26/) https://build.osrfoundation.org/job/ros_gazebo_pkgs-ci-default_indigo-trusty-amd64/26/testReport/