### PR TITLE
GAZEBO ROS: regression test for issue-596

### DIFF
--- a/gazebo_ros/test/CMakeLists.txt
+++ b/gazebo_ros/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 set (rostests_python
   ros_network/ros_network_default.test
   ros_network/ros_network_disabled.test
+  api_resubscribe/api_resubscribe.test
 )
 
 if(CATKIN_ENABLE_TESTING)

--- a/gazebo_ros/test/api_resubscribe/api_resubscribe.test
+++ b/gazebo_ros/test/api_resubscribe/api_resubscribe.test
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<launch>
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    <arg name="paused"   value="false"/>
+    <arg name="gui"      value="false"/>
+    <arg name="headless" value="false"/>
+    <arg name="debug"    value="false"/>
+  </include>
+
+  <test pkg="gazebo_ros" type="test_resubscribe" test-name="test_resubscribe" />
+</launch>

--- a/gazebo_ros/test/api_resubscribe/test_resubscribe
+++ b/gazebo_ros/test/api_resubscribe/test_resubscribe
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+from gazebo_msgs.msg import ModelStates
+import unittest
+import rospy
+
+class TestResubscribe(unittest.TestCase):
+  '''
+  Test that messages from gazebo_ros_api plugin continue to be delivered
+  after a subscriber is shutdown then resubscribed to the same topic.
+
+  Attempts to reproduce the issue described in
+  https://github.com/ros-simulation/gazebo_ros_pkgs/issues/596,
+  which occured in certain versions of gazebo_ros with gazebo8+
+  '''
+  def cb(self, msg):
+      self.fresh = False
+
+  def setUp(self):
+      rospy.init_node('test_ros_api_resubscribe', anonymous=True)
+      self.fresh = True
+
+  def test_resubscribe(self):
+      # Wait for gazebo api plugin to come online
+      service = '/gazebo/set_model_state'
+      try:
+        rospy.wait_for_service(service, 5.0)
+      except rospy.ROSException:
+        self.fail('Timed out waiting for service {}'.format(service))
+
+      # Subscribe and unsubscribe several times
+      for i in range(3):
+        sub = rospy.Subscriber('/gazebo/model_states', ModelStates, self.cb, queue_size=1)
+        # reset fresh flag so we can notice when a message arrives
+        self.fresh = True
+        rospy.sleep(1.0)
+        self.assertFalse(self.fresh)
+        sub.unregister()
+
+if __name__ == '__main__':
+  import rostest
+  import sys
+  rostest.rosrun('gazebo_ros', 'test_resubscribe', TestResubscribe, sys.argv)
+    


### PR DESCRIPTION
Attempt to reproduce bug in issue #596, which is fixed in current versions. Just a nice test to be sure it isn't introduced again

I have confirmed that it fails as expected on lunar 2.7.2 with gazebo8