### PR TITLE
ROS API: remove unhelpful error in GetWorldProperties call

### DIFF
--- a/gazebo_msgs/srv/GetWorldProperties.srv
+++ b/gazebo_msgs/srv/GetWorldProperties.srv
@@ -1,6 +1,6 @@
 ---
 float64 sim_time                     # current sim time
 string[] model_names                 # list of models in the world
-bool rendering_enabled               # if X is used
+bool rendering_enabled               # If gazebo rendering engine is enabled, currently always True
 bool success                         # return true if get successful
 string status_message                # comments if available

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -1065,7 +1065,7 @@ bool GazeboRosApiPlugin::getWorldProperties(gazebo_msgs::GetWorldProperties::Req
   for (unsigned int i = 0; i < world_->GetModelCount(); i ++)
     res.model_names.push_back(world_->GetModel(i)->GetName());
 #endif
-  gzerr << "disablign rendering has not been implemented, rendering is always enabled\n";
+  // Note: currently rendering is always enabled in gazebo
   res.rendering_enabled = true; //world->GetRenderEngineEnabled();
   res.success = true;
   res.status_message = "GetWorldProperties: got properties";


### PR DESCRIPTION
Address issue #475. The service message now describes that rendering_enabled is always True, so it is not necessary to spam the user with an error every call.