### PR TITLE
Corrected depth camera plugin initialization

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -312,7 +312,6 @@ install(TARGETS
   MultiCameraPlugin
   gazebo_ros_depth_camera
   gazebo_ros_openni_kinect
-  gazebo_ros_openni_kinect
   gazebo_ros_laser
   gazebo_ros_block_laser
   gazebo_ros_p3d

--- a/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
@@ -45,6 +45,7 @@ GZ_REGISTER_SENSOR_PLUGIN(GazeboRosDepthCamera)
 GazeboRosDepthCamera::GazeboRosDepthCamera()
 {
   this->point_cloud_connect_count_ = 0;
+  this->depth_image_connect_count_ = 0;
   this->depth_info_connect_count_ = 0;
   this->last_depth_image_camera_info_update_time_ = common::Time(0);
 }


### PR DESCRIPTION
Removed duplicate line in CMakeLists.txt of gazebo_plugins and made sure depth_image_connect_count_ is initialized at zero. 