### PR TITLE
Depth camera plugin: Reconvert Point Cloud to original height and width

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
@@ -454,6 +454,11 @@ bool GazeboRosDepthCamera::FillPointCloudHelper(
     }
   }
 
+  // reconvert to original height and width after the flat reshape
+  point_cloud_msg.height = rows_arg;
+  point_cloud_msg.width = cols_arg;
+  point_cloud_msg.row_step = point_cloud_msg.point_step * point_cloud_msg.width;
+
   return true;
 }
 


### PR DESCRIPTION
Point cloud height and width was not reset to the correct height and width after the flat reshape.

Inherited change from _gazebo_ros_openni_kinect.cpp_.