### PR TITLE
Deprecate openni_kinect in favor of depth_camera

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -219,9 +219,10 @@ add_library(gazebo_ros_depth_camera src/gazebo_ros_depth_camera.cpp)
 add_dependencies(gazebo_ros_depth_camera ${PROJECT_NAME}_gencfg)
 target_link_libraries(gazebo_ros_depth_camera gazebo_ros_camera_utils DepthCameraPlugin ${catkin_LIBRARIES})
 
+# Deprecated plugin now just inherits from gazebo_ros_depth_camera
 add_library(gazebo_ros_openni_kinect src/gazebo_ros_openni_kinect.cpp)
-add_dependencies(gazebo_ros_openni_kinect ${PROJECT_NAME}_gencfg)
-target_link_libraries(gazebo_ros_openni_kinect gazebo_ros_camera_utils DepthCameraPlugin ${catkin_LIBRARIES})
+add_dependencies(gazebo_ros_openni_kinect gazebo_ros_depth_camera)
+target_link_libraries(gazebo_ros_openni_kinect gazebo_ros_depth_camera)
 
 add_library(gazebo_ros_gpu_laser src/gazebo_ros_gpu_laser.cpp)
 target_link_libraries(gazebo_ros_gpu_laser ${catkin_LIBRARIES} GpuRayPlugin)
@@ -402,6 +403,10 @@ if (CATKIN_ENABLE_TESTING)
                       test/camera/depth_camera.test
                       test/camera/depth_camera.cpp)
     target_link_libraries(depth_camera-test ${catkin_LIBRARIES})
+    add_rostest_gtest(openi_kinect-test
+                      test/camera/openni_kinect.test
+                      test/camera/depth_camera.cpp)
+    target_link_libraries(openi_kinect-test ${catkin_LIBRARIES})
     add_rostest_gtest(multicamera-test
                       test/camera/multicamera.test
                       test/camera/multicamera.cpp)

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2014 Open Source Robotics Foundation
+ * Copyright (C) 2012-2018 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,6 @@
  * limitations under the License.
  *
 */
-/*
- * Desc: A dynamic controller plugin that publishes ROS image_raw camera_info topic for generic camera sensor.
- * Author: John Hsu
- * Date: 24 Sept 2008
- */
 
 #ifndef GAZEBO_ROS_DEPTH_CAMERA_HH
 #define GAZEBO_ROS_DEPTH_CAMERA_HH
@@ -121,7 +116,10 @@ namespace gazebo
     private: sensor_msgs::PointCloud2 point_cloud_msg_;
     private: sensor_msgs::Image depth_image_msg_;
 
+    /// \brief Minimum range of the point cloud
     private: double point_cloud_cutoff_;
+    /// \brief Maximum range of the point cloud
+    protected: double point_cloud_cutoff_max_;
 
     /// \brief ROS image topic name
     private: std::string point_cloud_topic_name_;

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_openni_kinect.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_openni_kinect.h
@@ -14,134 +14,24 @@
  * limitations under the License.
  *
 */
-/*
- * Desc: A dynamic controller plugin that publishes ROS image_raw camera_info topic for generic camera sensor.
- * Author: John Hsu
- * Date: 24 Sept 2008
+
+/* DEPRECATED.
+ * Instead use, GazeboRosDepthCamera
  */
 
 #ifndef GAZEBO_ROS_OPENNI_KINECT_HH
 #define GAZEBO_ROS_OPENNI_KINECT_HH
 
-// ros stuff
-#include <ros/ros.h>
-#include <ros/callback_queue.h>
-#include <ros/advertise_options.h>
-
-// ros messages stuff
-#include <sensor_msgs/PointCloud2.h>
-#include <sensor_msgs/Image.h>
-#include <sensor_msgs/CameraInfo.h>
-#include <sensor_msgs/fill_image.h>
-#include <std_msgs/Float64.h>
-#include <image_transport/image_transport.h>
-
-// gazebo stuff
-#include <sdf/Param.hh>
-#include <gazebo/physics/physics.hh>
-#include <gazebo/transport/TransportTypes.hh>
-#include <gazebo/msgs/MessageTypes.hh>
-#include <gazebo/common/Time.hh>
-#include <gazebo/sensors/SensorTypes.hh>
-#include <gazebo/plugins/DepthCameraPlugin.hh>
-
-// dynamic reconfigure stuff
-#include <gazebo_plugins/GazeboRosOpenniKinectConfig.h>
-#include <dynamic_reconfigure/server.h>
-
-// boost stuff
-#include <boost/thread/mutex.hpp>
-
-// camera stuff
-#include <gazebo_plugins/gazebo_ros_camera_utils.h>
+// Base plugin
+#include <gazebo_plugins/gazebo_ros_depth_camera.h>
 
 namespace gazebo
 {
-  class GazeboRosOpenniKinect : public DepthCameraPlugin, GazeboRosCameraUtils
+  class GazeboRosOpenniKinect : public GazeboRosDepthCamera
   {
-    /// \brief Constructor
-    /// \param parent The parent entity, must be a Model or a Sensor
     public: GazeboRosOpenniKinect();
-
-    /// \brief Destructor
-    public: ~GazeboRosOpenniKinect();
-
-    /// \brief Load the plugin
-    /// \param take in SDF root element
     public: virtual void Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf);
-
-    /// \brief Advertise point cloud and depth image
-    public: virtual void Advertise();
-
-    /// \brief Update the controller
-    protected: virtual void OnNewDepthFrame(const float *_image,
-                   unsigned int _width, unsigned int _height,
-                   unsigned int _depth, const std::string &_format);
-
-    /// \brief Update the controller
-    protected: virtual void OnNewImageFrame(const unsigned char *_image,
-                   unsigned int _width, unsigned int _height,
-                   unsigned int _depth, const std::string &_format);
-
-    /// \brief push point cloud data into ros topic
-    private: void FillPointdCloud(const float *_src);
-
-    /// \brief push depth image data into ros topic
-    private: void FillDepthImage(const float *_src);
-
-    /// \brief Keep track of number of connctions for point clouds
-    private: int point_cloud_connect_count_;
-    private: void PointCloudConnect();
-    private: void PointCloudDisconnect();
-
-    /// \brief Keep track of number of connctions for point clouds
-    private: int depth_image_connect_count_;
-    private: void DepthImageConnect();
-    private: void DepthImageDisconnect();
-
-    private: bool FillPointCloudHelper(sensor_msgs::PointCloud2 &point_cloud_msg,
-                                  uint32_t rows_arg, uint32_t cols_arg,
-                                  uint32_t step_arg, void* data_arg);
-
-    private: bool FillDepthImageHelper( sensor_msgs::Image& image_msg,
-                                  uint32_t height, uint32_t width,
-                                  uint32_t step, void* data_arg);
-
-    /// \brief A pointer to the ROS node.  A node will be instantiated if it does not exist.
-    private: ros::Publisher point_cloud_pub_;
-    private: ros::Publisher depth_image_pub_;
-
-    /// \brief PointCloud2 point cloud message
-    private: sensor_msgs::PointCloud2 point_cloud_msg_;
-    private: sensor_msgs::Image depth_image_msg_;
-
-    /// \brief Minimum range of the point cloud
-    private: double point_cloud_cutoff_;
-    /// \brief Maximum range of the point cloud
-    private: double point_cloud_cutoff_max_;
-
-    /// \brief ROS image topic name
-    private: std::string point_cloud_topic_name_;
-
-
-    /// \brief image where each pixel contains the depth data
-    private: std::string depth_image_topic_name_;
-    private: common::Time depth_sensor_update_time_;
-
-    // overload with our own
-    private: std::string depth_image_camera_info_topic_name_;
-    private: int depth_info_connect_count_;
-    private: void DepthInfoConnect();
-    private: void DepthInfoDisconnect();
-    private: common::Time last_depth_image_camera_info_update_time_;
-    protected: ros::Publisher depth_image_camera_info_pub_;
-
-    using GazeboRosCameraUtils::PublishCameraInfo;
-    protected: virtual void PublishCameraInfo();
-
-    private: event::ConnectionPtr load_connection_;
   };
-
 }
 #endif
 

--- a/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
@@ -455,6 +455,11 @@ bool GazeboRosDepthCamera::FillPointCloudHelper(
     }
   }
 
+  // reconvert to original height and width after the flat reshape
+  point_cloud_msg.height = rows_arg;
+  point_cloud_msg.width = cols_arg;
+  point_cloud_msg.row_step = point_cloud_msg.point_step * point_cloud_msg.width;
+
   return true;
 }
 

--- a/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Open Source Robotics Foundation
+ * Copyright 2013-2018 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,6 @@
  * limitations under the License.
  *
 */
-/*
-   Desc: GazeboRosDepthCamera plugin for simulating cameras in Gazebo
-   Author: John Hsu
-   Date: 24 Sept 2008
- */
 
 #include <algorithm>
 #include <assert.h>
@@ -102,9 +97,19 @@ void GazeboRosDepthCamera::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf
     this->depth_image_camera_info_topic_name_ = _sdf->GetElement("depthImageCameraInfoTopicName")->Get<std::string>();
 
   if (!_sdf->HasElement("pointCloudCutoff"))
+  {
     this->point_cloud_cutoff_ = 0.4;
+    ROS_INFO_NAMED("depth_camera", "Tag <pointCloudCutoff> not set, defaulting to %f", this->point_cloud_cutoff_);
+  }
   else
     this->point_cloud_cutoff_ = _sdf->GetElement("pointCloudCutoff")->Get<double>();
+  if (!_sdf->HasElement("pointCloudCutoffMax"))
+  {
+    this->point_cloud_cutoff_max_ = -1;
+    ROS_INFO_NAMED("depth_camera", "Tag <pointCloudCutoffMax> not set, defaulting to no max");
+  }
+  else
+    this->point_cloud_cutoff_max_ = _sdf->GetElement("pointCloudCutoffMax")->Get<double>();
 
   load_connection_ = GazeboRosCameraUtils::OnLoad(boost::bind(&GazeboRosDepthCamera::Advertise, this));
   GazeboRosCameraUtils::Load(_parent, _sdf);
@@ -222,6 +227,8 @@ void GazeboRosDepthCamera::OnNewDepthFrame(const float *_image,
       // do this first so there's chance for sensor to run 1 frame after activate
       this->parentSensor->SetActive(true);
   }
+
+  PublishCameraInfo();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -303,27 +310,31 @@ void GazeboRosDepthCamera::OnNewImageFrame(const unsigned char *_image,
   if (!this->initialized_ || this->height_ <=0 || this->width_ <=0)
     return;
 
-  //ROS_ERROR_NAMED("depth_camera", "camera_ new frame %s %s",this->parentSensor_->GetName().c_str(),this->frame_name_.c_str());
 # if GAZEBO_MAJOR_VERSION >= 7
   this->sensor_update_time_ = this->parentSensor->LastMeasurementTime();
 # else
   this->sensor_update_time_ = this->parentSensor->GetLastMeasurementTime();
 # endif
 
-  if (!this->parentSensor->IsActive())
+  if (this->parentSensor->IsActive())
   {
-    if ((*this->image_connect_count_) > 0)
-      // do this first so there's chance for sensor to run 1 frame after activate
-      this->parentSensor->SetActive(true);
+    if (this->point_cloud_connect_count_ <= 0 &&
+        this->depth_image_connect_count_ <= 0 &&
+        (*this->image_connect_count_) <= 0)
+    {
+      this->parentSensor->SetActive(false);
+    }
+    else
+    {
+      if ((*this->image_connect_count_) > 0)
+        this->PutCameraData(_image);
+    }
   }
   else
   {
     if ((*this->image_connect_count_) > 0)
-    {
-      this->PutCameraData(_image);
-      // TODO(lucasw) publish camera info with depth image
-      // this->PublishCameraInfo(sensor_update_time);
-    }
+      // do this first so there's chance for sensor to run 1 frame after activate
+      this->parentSensor->SetActive(true);
   }
 }
 
@@ -331,6 +342,7 @@ void GazeboRosDepthCamera::OnNewImageFrame(const unsigned char *_image,
 // Put camera data to the interface
 void GazeboRosDepthCamera::FillPointdCloud(const float *_src)
 {
+  // TODO: use scoped lock gaurds
   this->lock_.lock();
 
   this->point_cloud_msg_.header.frame_id = this->frame_name_;
@@ -417,10 +429,11 @@ bool GazeboRosDepthCamera::FillPointCloudHelper(
       // hardcoded rotation rpy(-M_PI/2, 0, -M_PI/2) is built-in
       // to urdf, where the *_optical_frame should have above relative
       // rotation from the physical camera *_frame
-      *iter_x      = depth * tan(yAngle);
-      *iter_y      = depth * tan(pAngle);
-      if(depth > this->point_cloud_cutoff_)
+      if (depth > this->point_cloud_cutoff_ &&
+         (this->point_cloud_cutoff_max_ < 0 || depth < this->point_cloud_cutoff_max_))
       {
+        *iter_x      = depth * tan(yAngle);
+        *iter_y      = depth * tan(pAngle);
         *iter_z    = depth;
       }
       else //point in the unseeable range
@@ -489,7 +502,8 @@ bool GazeboRosDepthCamera::FillDepthImageHelper(
     {
       float depth = toCopyFrom[index++];
 
-      if (depth > this->point_cloud_cutoff_)
+      if (depth > this->point_cloud_cutoff_ &&
+         (this->point_cloud_cutoff_max_ < 0 || depth < this->point_cloud_cutoff_max_))
       {
         dest[i + j * cols_arg] = depth;
       }
@@ -510,48 +524,15 @@ void GazeboRosDepthCamera::PublishCameraInfo()
   if (this->depth_info_connect_count_ > 0)
   {
 # if GAZEBO_MAJOR_VERSION >= 7
-    common::Time sensor_update_time = this->parentSensor_->LastMeasurementTime();
+    this->sensor_update_time_ =  this->parentSensor_->LastMeasurementTime();
 # else
-    common::Time sensor_update_time = this->parentSensor_->GetLastMeasurementTime();
+    this->sensor_update_time_ =  this->parentSensor_->GetLastMeasurementTime();
 # endif
-    this->sensor_update_time_ = sensor_update_time;
-    if (sensor_update_time - this->last_depth_image_camera_info_update_time_ >= this->update_period_)
+    if (this->sensor_update_time_ - this->last_depth_image_camera_info_update_time_ >= this->update_period_)
     {
-      this->PublishCameraInfo(this->depth_image_camera_info_pub_);  // , sensor_update_time);
-      this->last_depth_image_camera_info_update_time_ = sensor_update_time;
+      this->PublishCameraInfo(this->depth_image_camera_info_pub_);
+      this->last_depth_image_camera_info_update_time_ = this->sensor_update_time_;
     }
   }
 }
-
-//@todo: publish disparity similar to openni_camera_deprecated/src/nodelets/openni_nodelet.cpp.
-/*
-#include <stereo_msgs/DisparityImage.h>
-pub_disparity_ = comm_nh.advertise<stereo_msgs::DisparityImage > ("depth/disparity", 5, subscriberChanged2, subscriberChanged2);
-
-void GazeboRosDepthCamera::PublishDisparityImage(const DepthImage& depth, ros::Time time)
-{
-  stereo_msgs::DisparityImagePtr disp_msg = boost::make_shared<stereo_msgs::DisparityImage > ();
-  disp_msg->header.stamp                  = time;
-  disp_msg->header.frame_id               = device_->isDepthRegistered () ? rgb_frame_id_ : depth_frame_id_;
-  disp_msg->image.header                  = disp_msg->header;
-  disp_msg->image.encoding                = sensor_msgs::image_encodings::TYPE_32FC1;
-  disp_msg->image.height                  = depth_height_;
-  disp_msg->image.width                   = depth_width_;
-  disp_msg->image.step                    = disp_msg->image.width * sizeof (float);
-  disp_msg->image.data.resize (disp_msg->image.height * disp_msg->image.step);
-  disp_msg->T = depth.getBaseline ();
-  disp_msg->f = depth.getFocalLength () * depth_width_ / depth.getWidth ();
-
-  /// @todo Compute these values from DepthGenerator::GetDeviceMaxDepth() and the like
-  disp_msg->min_disparity = 0.0;
-  disp_msg->max_disparity = disp_msg->T * disp_msg->f / 0.3;
-  disp_msg->delta_d = 0.125;
-
-  depth.fillDisparityImage (depth_width_, depth_height_, reinterpret_cast<float*>(&disp_msg->image.data[0]), disp_msg->image.step);
-
-  pub_disparity_.publish (disp_msg);
-}
-*/
-
-
 }

--- a/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
+++ b/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Open Source Robotics Foundation
+ * Copyright 2013-2018 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,26 +15,7 @@
  *
 */
 
-/*
-   Desc: GazeboRosOpenniKinect plugin for simulating cameras in Gazebo
-   Author: John Hsu
-   Date: 24 Sept 2008
- */
-
-#include <algorithm>
-#include <assert.h>
-#include <boost/thread/thread.hpp>
-#include <boost/bind.hpp>
-
 #include <gazebo_plugins/gazebo_ros_openni_kinect.h>
-
-#include <gazebo/sensors/Sensor.hh>
-#include <sdf/sdf.hh>
-#include <gazebo/sensors/SensorTypes.hh>
-
-#include <sensor_msgs/point_cloud2_iterator.h>
-
-#include <tf/tf.h>
 
 namespace gazebo
 {
@@ -43,439 +24,35 @@ GZ_REGISTER_SENSOR_PLUGIN(GazeboRosOpenniKinect)
 
 ////////////////////////////////////////////////////////////////////////////////
 // Constructor
-GazeboRosOpenniKinect::GazeboRosOpenniKinect()
+GazeboRosOpenniKinect::GazeboRosOpenniKinect() : GazeboRosDepthCamera()
 {
-  this->point_cloud_connect_count_ = 0;
-  this->depth_info_connect_count_ = 0;
-  this->depth_image_connect_count_ = 0;
-  this->last_depth_image_camera_info_update_time_ = common::Time(0);
-}
 
-////////////////////////////////////////////////////////////////////////////////
-// Destructor
-GazeboRosOpenniKinect::~GazeboRosOpenniKinect()
-{
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 // Load the controller
 void GazeboRosOpenniKinect::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
 {
-  DepthCameraPlugin::Load(_parent, _sdf);
+  // Warn user that this plugin is deprecated and to migrate to depth camera
+  ROS_WARN_NAMED("depth_camera", "gazebo_ros_openni_kinect is deprecated. Please use gazebo_ros_depth_camera instead");
 
-  // copying from DepthCameraPlugin into GazeboRosCameraUtils
-  this->parentSensor_ = this->parentSensor;
-  this->width_ = this->width;
-  this->height_ = this->height;
-  this->depth_ = this->depth;
-  this->format_ = this->format;
-  this->camera_ = this->depthCamera;
-
-  // using a different default
-  if (!_sdf->HasElement("imageTopicName"))
-    this->image_topic_name_ = "ir/image_raw";
-  if (!_sdf->HasElement("cameraInfoTopicName"))
-    this->camera_info_topic_name_ = "ir/camera_info";
-
-  // point cloud stuff
-  if (!_sdf->HasElement("pointCloudTopicName"))
-    this->point_cloud_topic_name_ = "points";
-  else
-    this->point_cloud_topic_name_ = _sdf->GetElement("pointCloudTopicName")->Get<std::string>();
-
-  // depth image stuff
-  if (!_sdf->HasElement("depthImageTopicName"))
-    this->depth_image_topic_name_ = "depth/image_raw";
-  else
-    this->depth_image_topic_name_ = _sdf->GetElement("depthImageTopicName")->Get<std::string>();
-
-  if (!_sdf->HasElement("depthImageCameraInfoTopicName"))
-    this->depth_image_camera_info_topic_name_ = "depth/camera_info";
-  else
-    this->depth_image_camera_info_topic_name_ = _sdf->GetElement("depthImageCameraInfoTopicName")->Get<std::string>();
-
-  if (!_sdf->HasElement("pointCloudCutoff"))
-    this->point_cloud_cutoff_ = 0.4;
-  else
-    this->point_cloud_cutoff_ = _sdf->GetElement("pointCloudCutoff")->Get<double>();
+  // For API compatibility, openni_kinect pointCloudCutoffMax must default to 5 while depth camera
+  // defautls to -1 (no limit).
   if (!_sdf->HasElement("pointCloudCutoffMax"))
-    this->point_cloud_cutoff_max_ = 5.0;
-  else
-    this->point_cloud_cutoff_max_ = _sdf->GetElement("pointCloudCutoffMax")->Get<double>();
-
-  load_connection_ = GazeboRosCameraUtils::OnLoad(boost::bind(&GazeboRosOpenniKinect::Advertise, this));
-  GazeboRosCameraUtils::Load(_parent, _sdf);
-}
-
-void GazeboRosOpenniKinect::Advertise()
-{
-  ros::AdvertiseOptions point_cloud_ao =
-    ros::AdvertiseOptions::create<sensor_msgs::PointCloud2 >(
-      this->point_cloud_topic_name_,1,
-      boost::bind( &GazeboRosOpenniKinect::PointCloudConnect,this),
-      boost::bind( &GazeboRosOpenniKinect::PointCloudDisconnect,this),
-      ros::VoidPtr(), &this->camera_queue_);
-  this->point_cloud_pub_ = this->rosnode_->advertise(point_cloud_ao);
-
-  ros::AdvertiseOptions depth_image_ao =
-    ros::AdvertiseOptions::create< sensor_msgs::Image >(
-      this->depth_image_topic_name_,1,
-      boost::bind( &GazeboRosOpenniKinect::DepthImageConnect,this),
-      boost::bind( &GazeboRosOpenniKinect::DepthImageDisconnect,this),
-      ros::VoidPtr(), &this->camera_queue_);
-  this->depth_image_pub_ = this->rosnode_->advertise(depth_image_ao);
-
-  ros::AdvertiseOptions depth_image_camera_info_ao =
-    ros::AdvertiseOptions::create<sensor_msgs::CameraInfo>(
-        this->depth_image_camera_info_topic_name_,1,
-        boost::bind( &GazeboRosOpenniKinect::DepthInfoConnect,this),
-        boost::bind( &GazeboRosOpenniKinect::DepthInfoDisconnect,this),
-        ros::VoidPtr(), &this->camera_queue_);
-  this->depth_image_camera_info_pub_ = this->rosnode_->advertise(depth_image_camera_info_ao);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Increment count
-void GazeboRosOpenniKinect::PointCloudConnect()
-{
-  this->point_cloud_connect_count_++;
-  (*this->image_connect_count_)++;
-  this->parentSensor->SetActive(true);
-}
-////////////////////////////////////////////////////////////////////////////////
-// Decrement count
-void GazeboRosOpenniKinect::PointCloudDisconnect()
-{
-  this->point_cloud_connect_count_--;
-  (*this->image_connect_count_)--;
-  if (this->point_cloud_connect_count_ <= 0)
-    this->parentSensor->SetActive(false);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Increment count
-void GazeboRosOpenniKinect::DepthImageConnect()
-{
-  this->depth_image_connect_count_++;
-  this->parentSensor->SetActive(true);
-}
-////////////////////////////////////////////////////////////////////////////////
-// Decrement count
-void GazeboRosOpenniKinect::DepthImageDisconnect()
-{
-  this->depth_image_connect_count_--;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Increment count
-void GazeboRosOpenniKinect::DepthInfoConnect()
-{
-  this->depth_info_connect_count_++;
-}
-////////////////////////////////////////////////////////////////////////////////
-// Decrement count
-void GazeboRosOpenniKinect::DepthInfoDisconnect()
-{
-  this->depth_info_connect_count_--;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Update the controller
-void GazeboRosOpenniKinect::OnNewDepthFrame(const float *_image,
-    unsigned int _width, unsigned int _height, unsigned int _depth,
-    const std::string &_format)
-{
-  if (!this->initialized_ || this->height_ <=0 || this->width_ <=0)
-    return;
-
-  this->depth_sensor_update_time_ = this->parentSensor->LastMeasurementTime();
-  if (this->parentSensor->IsActive())
   {
-    if (this->point_cloud_connect_count_ <= 0 &&
-        this->depth_image_connect_count_ <= 0 &&
-        (*this->image_connect_count_) <= 0)
-    {
-      this->parentSensor->SetActive(false);
-    }
-    else
-    {
-      if (this->point_cloud_connect_count_ > 0)
-        this->FillPointdCloud(_image);
-
-      if (this->depth_image_connect_count_ > 0)
-        this->FillDepthImage(_image);
-    }
-  }
-  else
-  {
-    if (this->point_cloud_connect_count_ > 0 ||
-        this->depth_image_connect_count_ <= 0)
-      // do this first so there's chance for sensor to run 1 frame after activate
-      this->parentSensor->SetActive(true);
-  }
-  PublishCameraInfo();
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Update the controller
-void GazeboRosOpenniKinect::OnNewImageFrame(const unsigned char *_image,
-    unsigned int _width, unsigned int _height, unsigned int _depth,
-    const std::string &_format)
-{
-  if (!this->initialized_ || this->height_ <=0 || this->width_ <=0)
-    return;
-
-  //ROS_ERROR_NAMED("openni_kinect", "camera_ new frame %s %s",this->parentSensor_->Name().c_str(),this->frame_name_.c_str());
-  this->sensor_update_time_ = this->parentSensor_->LastMeasurementTime();
-
-  if (this->parentSensor->IsActive())
-  {
-    if (this->point_cloud_connect_count_ <= 0 &&
-        this->depth_image_connect_count_ <= 0 &&
-        (*this->image_connect_count_) <= 0)
-    {
-      this->parentSensor->SetActive(false);
-    }
-    else
-    {
-      if ((*this->image_connect_count_) > 0)
-        this->PutCameraData(_image);
-    }
-  }
-  else
-  {
-    if ((*this->image_connect_count_) > 0)
-      // do this first so there's chance for sensor to run 1 frame after activate
-      this->parentSensor->SetActive(true);
-  }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Put point cloud data to the interface
-void GazeboRosOpenniKinect::FillPointdCloud(const float *_src)
-{
-  this->lock_.lock();
-
-  this->point_cloud_msg_.header.frame_id = this->frame_name_;
-  this->point_cloud_msg_.header.stamp.sec = this->depth_sensor_update_time_.sec;
-  this->point_cloud_msg_.header.stamp.nsec = this->depth_sensor_update_time_.nsec;
-  this->point_cloud_msg_.width = this->width;
-  this->point_cloud_msg_.height = this->height;
-  this->point_cloud_msg_.row_step = this->point_cloud_msg_.point_step * this->width;
-
-  ///copy from depth to point cloud message
-  FillPointCloudHelper(this->point_cloud_msg_,
-                 this->height,
-                 this->width,
-                 this->skip_,
-                 (void*)_src );
-
-  this->point_cloud_pub_.publish(this->point_cloud_msg_);
-
-  this->lock_.unlock();
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Put depth image data to the interface
-void GazeboRosOpenniKinect::FillDepthImage(const float *_src)
-{
-  this->lock_.lock();
-  // copy data into image
-  this->depth_image_msg_.header.frame_id = this->frame_name_;
-  this->depth_image_msg_.header.stamp.sec = this->depth_sensor_update_time_.sec;
-  this->depth_image_msg_.header.stamp.nsec = this->depth_sensor_update_time_.nsec;
-
-  ///copy from depth to depth image message
-  FillDepthImageHelper(this->depth_image_msg_,
-                 this->height,
-                 this->width,
-                 this->skip_,
-                 (void*)_src );
-
-  this->depth_image_pub_.publish(this->depth_image_msg_);
-
-  this->lock_.unlock();
-}
-
-
-// Fill depth information
-bool GazeboRosOpenniKinect::FillPointCloudHelper(
-    sensor_msgs::PointCloud2 &point_cloud_msg,
-    uint32_t rows_arg, uint32_t cols_arg,
-    uint32_t step_arg, void* data_arg)
-{
-  sensor_msgs::PointCloud2Modifier pcd_modifier(point_cloud_msg);
-  pcd_modifier.setPointCloud2FieldsByString(2, "xyz", "rgb");
-  // convert to flat array shape, we need to reconvert later
-  pcd_modifier.resize(rows_arg*cols_arg);
-  point_cloud_msg.is_dense = true;
-
-  sensor_msgs::PointCloud2Iterator<float> iter_x(point_cloud_msg_, "x");
-  sensor_msgs::PointCloud2Iterator<float> iter_y(point_cloud_msg_, "y");
-  sensor_msgs::PointCloud2Iterator<float> iter_z(point_cloud_msg_, "z");
-  sensor_msgs::PointCloud2Iterator<uint8_t> iter_rgb(point_cloud_msg_, "rgb");
-
-  float* toCopyFrom = (float*)data_arg;
-  int index = 0;
-
-  double hfov = this->parentSensor->DepthCamera()->HFOV().Radian();
-  double fl = ((double)this->width) / (2.0 *tan(hfov/2.0));
-
-  // convert depth to point cloud
-  for (uint32_t j=0; j<rows_arg; j++)
-  {
-    double pAngle;
-    if (rows_arg>1) pAngle = atan2( (double)j - 0.5*(double)(rows_arg-1), fl);
-    else            pAngle = 0.0;
-
-    for (uint32_t i=0; i<cols_arg; i++, ++iter_x, ++iter_y, ++iter_z, ++iter_rgb)
-    {
-      double yAngle;
-      if (cols_arg>1) yAngle = atan2( (double)i - 0.5*(double)(cols_arg-1), fl);
-      else            yAngle = 0.0;
-
-      double depth = toCopyFrom[index++]; // + 0.0*this->myParent->GetNearClip();
-
-      if(depth > this->point_cloud_cutoff_ &&
-         depth < this->point_cloud_cutoff_max_)
-      {
-        // in optical frame
-        // hardcoded rotation rpy(-M_PI/2, 0, -M_PI/2) is built-in
-        // to urdf, where the *_optical_frame should have above relative
-        // rotation from the physical camera *_frame
-        *iter_x = depth * tan(yAngle);
-        *iter_y = depth * tan(pAngle);
-        *iter_z = depth;
-      }
-      else //point in the unseeable range
-      {
-        *iter_x = *iter_y = *iter_z = std::numeric_limits<float>::quiet_NaN ();
-        point_cloud_msg.is_dense = false;
-      }
-
-      // put image color data for each point
-      uint8_t*  image_src = (uint8_t*)(&(this->image_msg_.data[0]));
-      if (this->image_msg_.data.size() == rows_arg*cols_arg*3)
-      {
-        // color
-        iter_rgb[0] = image_src[i*3+j*cols_arg*3+0];
-        iter_rgb[1] = image_src[i*3+j*cols_arg*3+1];
-        iter_rgb[2] = image_src[i*3+j*cols_arg*3+2];
-      }
-      else if (this->image_msg_.data.size() == rows_arg*cols_arg)
-      {
-        // mono (or bayer?  @todo; fix for bayer)
-        iter_rgb[0] = image_src[i+j*cols_arg];
-        iter_rgb[1] = image_src[i+j*cols_arg];
-        iter_rgb[2] = image_src[i+j*cols_arg];
-      }
-      else
-      {
-        // no image
-        iter_rgb[0] = 0;
-        iter_rgb[1] = 0;
-        iter_rgb[2] = 0;
-      }
-    }
+    ROS_INFO_NAMED("depth_camera", "Tag <pointCloudCutoffMax> not set, defaulting to 5.0");
+    // Create element description for this tag
+    sdf::ElementPtr element = std::make_shared<sdf::Element>();
+    element->SetName("pointCloudCutoffMax");
+    element->AddValue("double", "5.0", false, "");
+    element->Set<double>(5.0);
+    _sdf->AddElementDescription(element);
+    // Force the element to be generated so depth camera doesn't go with its default
+    sdf::ElementPtr my_element = _sdf->GetElement("pointCloudCutoffMax");
   }
 
-  // reconvert to original height and width after the flat reshape
-  point_cloud_msg.height = rows_arg;
-  point_cloud_msg.width = cols_arg;
-  point_cloud_msg.row_step = point_cloud_msg.point_step * point_cloud_msg.width;
-
-  return true;
+  // Load parent plugin
+  this->GazeboRosDepthCamera::Load(_parent, _sdf);
 }
-
-// Fill depth information
-bool GazeboRosOpenniKinect::FillDepthImageHelper(
-    sensor_msgs::Image& image_msg,
-    uint32_t rows_arg, uint32_t cols_arg,
-    uint32_t step_arg, void* data_arg)
-{
-  image_msg.encoding = sensor_msgs::image_encodings::TYPE_32FC1;
-  image_msg.height = rows_arg;
-  image_msg.width = cols_arg;
-  image_msg.step = sizeof(float) * cols_arg;
-  image_msg.data.resize(rows_arg * cols_arg * sizeof(float));
-  image_msg.is_bigendian = 0;
-
-  const float bad_point = std::numeric_limits<float>::quiet_NaN();
-
-  float* dest = (float*)(&(image_msg.data[0]));
-  float* toCopyFrom = (float*)data_arg;
-  int index = 0;
-
-  // convert depth to point cloud
-  for (uint32_t j = 0; j < rows_arg; j++)
-  {
-    for (uint32_t i = 0; i < cols_arg; i++)
-    {
-      float depth = toCopyFrom[index++];
-
-      if (depth > this->point_cloud_cutoff_ &&
-          depth < this->point_cloud_cutoff_max_)
-      {
-        dest[i + j * cols_arg] = depth;
-      }
-      else //point in the unseeable range
-      {
-        dest[i + j * cols_arg] = bad_point;
-      }
-    }
-  }
-  return true;
-}
-
-void GazeboRosOpenniKinect::PublishCameraInfo()
-{
-  ROS_DEBUG_NAMED("openni_kinect", "publishing default camera info, then openni kinect camera info");
-  GazeboRosCameraUtils::PublishCameraInfo();
-
-  if (this->depth_info_connect_count_ > 0)
-  {
-    this->sensor_update_time_ = this->parentSensor_->LastMeasurementTime();
-#if GAZEBO_MAJOR_VERSION >= 8
-    common::Time cur_time = this->world_->SimTime();
-#else
-    common::Time cur_time = this->world_->GetSimTime();
-#endif
-    if (this->sensor_update_time_ - this->last_depth_image_camera_info_update_time_ >= this->update_period_)
-    {
-      this->PublishCameraInfo(this->depth_image_camera_info_pub_);
-      this->last_depth_image_camera_info_update_time_ = this->sensor_update_time_;
-    }
-  }
-}
-
-//@todo: publish disparity similar to openni_camera_deprecated/src/nodelets/openni_nodelet.cpp.
-/*
-#include <stereo_msgs/DisparityImage.h>
-pub_disparity_ = comm_nh.advertise<stereo_msgs::DisparityImage > ("depth/disparity", 5, subscriberChanged2, subscriberChanged2);
-
-void GazeboRosDepthCamera::PublishDisparityImage(const DepthImage& depth, ros::Time time)
-{
-  stereo_msgs::DisparityImagePtr disp_msg = boost::make_shared<stereo_msgs::DisparityImage > ();
-  disp_msg->header.stamp                  = time;
-  disp_msg->header.frame_id               = device_->isDepthRegistered () ? rgb_frame_id_ : depth_frame_id_;
-  disp_msg->image.header                  = disp_msg->header;
-  disp_msg->image.encoding                = sensor_msgs::image_encodings::TYPE_32FC1;
-  disp_msg->image.height                  = depth_height_;
-  disp_msg->image.width                   = depth_width_;
-  disp_msg->image.step                    = disp_msg->image.width * sizeof (float);
-  disp_msg->image.data.resize (disp_msg->image.height * disp_msg->image.step);
-  disp_msg->T = depth.getBaseline ();
-  disp_msg->f = depth.getFocalLength () * depth_width_ / depth.getWidth ();
-
-  /// @todo Compute these values from DepthGenerator::GetDeviceMaxDepth() and the like
-  disp_msg->min_disparity = 0.0;
-  disp_msg->max_disparity = disp_msg->T * disp_msg->f / 0.3;
-  disp_msg->delta_d = 0.125;
-
-  depth.fillDisparityImage (depth_width_, depth_height_, reinterpret_cast<float*>(&disp_msg->image.data[0]), disp_msg->image.step);
-
-  pub_disparity_.publish (disp_msg);
-}
-*/
 
 }

--- a/gazebo_plugins/test/camera/depth_camera.cpp
+++ b/gazebo_plugins/test/camera/depth_camera.cpp
@@ -55,22 +55,6 @@ TEST_F(DepthCameraTest, cameraSubscribeTest)
   points_sub_ = nh_.subscribe("camera1/points", 1,
                              &DepthCameraTest::pointsCallback,
                              dynamic_cast<DepthCameraTest*>(this));
-#if 0
-  // wait for gazebo to start publishing
-  // TODO(lucasw) this isn't really necessary since this test
-  // is purely passive
-  bool wait_for_topic = true;
-  while (wait_for_topic)
-  {
-    // @todo this fails without the additional 0.5 second sleep after the
-    // publisher comes online, which means on a slower or more heavily
-    // loaded system it may take longer than 0.5 seconds, and the test
-    // would hang until the timeout is reached and fail.
-    if (cam_sub_.getNumPublishers() > 0)
-       wait_for_topic = false;
-    ros::Duration(0.5).sleep();
-  }
-#endif
 
   while (!has_new_image_ || !has_new_depth_ || !has_new_points_)
   {

--- a/gazebo_plugins/test/camera/openni_kinect.test
+++ b/gazebo_plugins/test/camera/openni_kinect.test
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="gui" value="false"/>
+
+  <param name="/use_sim_time" value="true" />
+
+  <node name="gazebo" pkg="gazebo_ros" type="gzserver"
+      respawn="false" output="screen"
+      args="--verbose $(find gazebo_plugins)/test/camera/openni_kinect.world" />
+
+  <group if="$(arg gui)">
+    <node name="gazebo_gui" pkg="gazebo_ros" type="gzclient" respawn="false" output="screen"/>
+  </group>
+
+  <test test-name="depth_camera" pkg="gazebo_plugins" type="depth_camera-test"
+      clear_params="true" time-limit="30.0" />
+</launch>

--- a/gazebo_plugins/test/camera/openni_kinect.world
+++ b/gazebo_plugins/test/camera/openni_kinect.world
@@ -1,0 +1,135 @@
+<?xml version="1.0" ?>
+<sdf version="1.4">
+
+  <world name="default">
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+
+    <!-- Global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <!-- Focus camera on tall pendulum -->
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose>4.927360 -4.376610 3.740080 0.000000 0.275643 2.356190</pose>
+        <view_controller>orbit</view_controller>
+      </camera>
+    </gui>
+
+  <model name="model_1">
+    <static>false</static>
+    <pose>2.0 0.0 4.0 0.0 0.0 0.0</pose>
+    <link name="link_1">
+      <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+      <inertial>
+        <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+        <inertia>
+          <ixx>1.0</ixx>
+          <ixy>0.0</ixy>
+          <ixz>0.0</ixz>
+          <iyy>1.0</iyy>
+          <iyz>0.0</iyz>
+          <izz>1.0</izz>
+        </inertia>
+        <mass>10.0</mass>
+      </inertial>
+      <visual name="visual_sphere">
+        <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+        <geometry>
+          <sphere>
+            <radius>0.5</radius>
+          </sphere>
+        </geometry>
+        <material>
+          <ambient>0.03 0.5 0.5 1.0</ambient>
+          <script>Gazebo/Green</script>
+        </material>
+        <cast_shadows>true</cast_shadows>
+        <laser_retro>100.0</laser_retro>
+      </visual>
+      <collision name="collision_sphere">
+        <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+        <max_contacts>250</max_contacts>
+        <geometry>
+          <sphere>
+            <radius>0.5</radius>
+          </sphere>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>0.5</mu>
+              <mu2>0.2</mu2>
+              <fdir1>1.0 0 0</fdir1>
+              <slip1>0</slip1>
+              <slip2>0</slip2>
+            </ode>
+          </friction>
+          <bounce>
+            <restitution_coefficient>0</restitution_coefficient>
+            <threshold>1000000.0</threshold>
+          </bounce>
+          <contact>
+            <ode>
+              <soft_cfm>0</soft_cfm>
+              <soft_erp>0.2</soft_erp>
+              <kp>1e15</kp>
+              <kd>1e13</kd>
+              <max_vel>100.0</max_vel>
+              <min_depth>0.0001</min_depth>
+            </ode>
+          </contact>
+        </surface>
+        <laser_retro>100.0</laser_retro>
+      </collision>
+    </link>
+  </model>
+
+  <model name="camera_model">
+    <static>true</static>
+    <pose>0.0 0.0 0.5 0.0 0.0 0.0</pose>
+    <link name="camera_link">
+      <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+      <sensor type="depth" name="camera1">
+        <update_rate>0.5</update_rate>
+        <camera name="head">
+          <horizontal_fov>1.3962634</horizontal_fov>
+          <image>
+            <width>640</width>
+            <height>480</height>
+            <format>R8G8B8</format>
+          </image>
+          <clip>
+            <near>0.02</near>
+            <far>300</far>
+          </clip>
+        </camera>
+        <plugin name="camera_controller" filename="libgazebo_ros_openni_kinect.so">
+          <alwaysOn>true</alwaysOn>
+          <!-- Keep this zero, update_rate will control the frame rate -->
+          <updateRate>0.0</updateRate>
+          <cameraName>camera1</cameraName>
+          <imageTopicName>image_raw</imageTopicName>
+          <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+          <depthImageTopicName>depth/image_raw</depthImageTopicName>
+          <!-- neither camera info is getting published, frame_id is empty
+            in points and both image headers -->
+          <depthImageCameraInfoTopicName>depth/camera_info</depthImageCameraInfoTopicName>
+          <pointCloudTopicName>points</pointCloudTopicName>
+          <frameName>camera_link</frameName>
+          <pointCloudCutoff>0.001</pointCloudCutoff>
+          <distortionK1>0.0</distortionK1>
+          <distortionK2>0.0</distortionK2>
+          <distortionK3>0.0</distortionK3>
+          <distortionT1>0.0</distortionT1>
+          <distortionT2>0.0</distortionT2>
+        </plugin>
+      </sensor>
+    </link>
+  </model>
+
+  </world>
+</sdf>


### PR DESCRIPTION
For several years there has been two nearly identical plugins, openni_kinnect and depth_camera. This is confusing for users and had lead to several bugs from not porting changes in one to the other. 

This PR makes openni_kinect inherit from depth_camera and print a deprecation warning on load so users will switch to depth_camera. Some fixes/features from openni_kinnect are also ported into depth_camera. 

The API for using both plugins should remain the same, but ABI for both had to be broken (this isn't very important as they are dynamically loaded anyways). 

Also added a test for openni_kinnect to ensure it still works

Implements #127 
Replaces #749 
Fixes #569
Replaces #570 


