### PR TITLE
Add auto_distortion parameter to camera utils

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
@@ -157,6 +157,7 @@ namespace gazebo
     protected: double distortion_t1_;
     protected: double distortion_t2_;
 
+    protected: bool auto_distortion_;
     protected: bool border_crop_;
 
     protected: boost::shared_ptr<camera_info_manager::CameraInfoManager> camera_info_manager_;

--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -236,6 +236,15 @@ void GazeboRosCameraUtils::Load(sensors::SensorPtr _parent,
   else
     this->distortion_t2_ = this->sdf->Get<double>("distortionT2");
 
+  // TODO: make default behavior auto_distortion_ = true
+  if (!this->sdf->HasElement("autoDistortion"))
+  {
+    ROS_DEBUG_NAMED("camera_utils", "Camera plugin missing <autoDistortion>, defaults to false");
+    this->auto_distortion_ = false;
+  }
+  else
+    this->auto_distortion_ = this->sdf->Get<bool>("autoDistortion");
+
   if (!this->sdf->HasElement("borderCrop"))
   {
     ROS_DEBUG_NAMED("camera_utils", "Camera plugin missing <borderCrop>, defaults to true");
@@ -548,6 +557,25 @@ void GazeboRosCameraUtils::Init()
   if(this->camera_->LensDistortion())
   {
     this->camera_->LensDistortion()->SetCrop(this->border_crop_);
+  }
+
+  // Get distortion parameters from gazebo sensor if auto_distortion is true
+  if(this->auto_distortion_)
+  {
+#if GAZEBO_MAJOR_VERSION >= 8
+    this->distortion_k1_ = this->camera_->LensDistortion()->K1();
+    this->distortion_k2_ = this->camera_->LensDistortion()->K2();
+    this->distortion_k3_ = this->camera_->LensDistortion()->K3();
+    this->distortion_t1_ = this->camera_->LensDistortion()->P1();
+    this->distortion_t2_ = this->camera_->LensDistortion()->P2();
+#else
+    // TODO: remove version gaurd once gazebo7 is not supported
+    this->distortion_k1_ = this->camera_->LensDistortion()->GetK1();
+    this->distortion_k2_ = this->camera_->LensDistortion()->GetK2();
+    this->distortion_k3_ = this->camera_->LensDistortion()->GetK3();
+    this->distortion_t1_ = this->camera_->LensDistortion()->GetP1();
+    this->distortion_t2_ = this->camera_->LensDistortion()->GetP2();
+#endif
   }
 
   // D = {k1, k2, t1, t2, k3}, as specified in:

--- a/gazebo_plugins/test/camera/distortion_barrel.world
+++ b/gazebo_plugins/test/camera/distortion_barrel.world
@@ -57,11 +57,7 @@
     may result in large black borders on the generated images, or in the
     undistorted version of the images. This will likely skew and invalidate
     the results of camera distortion tests. -->
-            <distortionK1>-0.1</distortionK1>
-            <distortionK2>-0.1</distortionK2>
-            <distortionT1>0.0</distortionT1>
-            <distortionT2>0.0</distortionT2>
-            <distortionK3>-0.1</distortionK3>
+            <autoDistortion>true</autoDistortion>
             <borderCrop>false</borderCrop>
           </plugin>
         </sensor>


### PR DESCRIPTION
For users who chose to model distortion in their cameras, they have to specify the parameters twice in their SDF like in this example:

```
        <sensor type="camera" name="camera_distorted">
          <update_rate>30.0</update_rate>
          <camera name="head">
              ...
            <distortion>
              <k1>0.1</k1>
              <k2>0.1</k2>
              <p1>0</p1>
              <p2>0</p2>
              <k3>0.1</k3>
              <center>0.5 0.5</center>
            </distortion>
          </camera>
          <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
             ...
            <distortionK1>0.1</distortionK1>
            <distortionK2>0.1</distortionK2>
            <distortionT1>0.0</distortionT1>
            <distortionT2>0.0</distortionT2>
            <distortionK3>0.1</distortionK3>
            <borderCrop>false</borderCrop>
          </plugin>
        </sensor>
```

This adds an sdf paramter ```<autoDistortion>``` which will set the distortion coefficents published with camera info to be the same as the gazebo sensor, so users can do this instead:

```
        <sensor type="camera" name="camera_distorted">
          <update_rate>30.0</update_rate>
          <camera name="head">
              ...
            <distortion>
              <k1>0.1</k1>
              <k2>0.1</k2>
              <p1>0</p1>
              <p2>0</p2>
              <k3>0.1</k3>
              <center>0.5 0.5</center>
            </distortion>
          </camera>
          <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
             ...
             <autoDistortion>true</autoDistortion>
          </plugin>
        </sensor>
```

This should probably be the default to pull the coefficients from the sensor (like width, height, etc), but for backwards compatibility this parameter is false by default.