### PR TITLE
Fix handling of boolean values

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_utils.cpp
@@ -98,7 +98,7 @@ void GazeboRos ::getParameterBoolean(bool &_value, const char *_tag_name, const 
     _value = _default;
     if (!sdf_->HasElement(_tag_name)) {
         ROS_WARN_NAMED("utils", "%s: missing <%s> default is %s",
-                 info(), _tag_name,  (_default?"ture":"false"));
+                 info(), _tag_name,  (_default?"true":"false"));
     } else {
         getParameterBoolean(_value, _tag_name);
     }
@@ -108,22 +108,22 @@ void GazeboRos ::getParameterBoolean(bool &_value, const char *_tag_name) {
 
     if (sdf_->HasElement(_tag_name)) {
         std::string value = sdf_->GetElement(_tag_name)->Get<std::string>();
-        if(boost::iequals(value, std::string("true")))
+        if(boost::iequals(value, std::string("true")) || boost::iequals(value, std::string("1")))
         {
             _value = true;
         }
-        else if(boost::iequals(value, std::string("false")))
+        else if(boost::iequals(value, std::string("false")) || boost::iequals(value, std::string("0")))
         {
             _value = false;
         }
         else
         {
-            ROS_WARN_NAMED("utils", "%s: <%s> must be either true or false",
-                     info(), _tag_name);
+            ROS_WARN_NAMED("utils", "%s: <%s> must be either true or false but is '%s'",
+                     info(), _tag_name, value.c_str());
         }
     }
     ROS_DEBUG_NAMED("utils", "%s: <%s> = %s",
-              info(), _tag_name,  (_value?"ture":"false"));
+              info(), _tag_name,  (_value?"true":"false"));
 
 }
 


### PR DESCRIPTION
since Gazebo API returns 'true'/'false' as '1'/'0' strings

Signed-off-by: Timo Korthals <tkorthals@cit-ec.uni-bielefeld.de>