### PR TITLE
Start gzclient with node name gzclient (issue 765)

### DIFF
--- a/gazebo_ros/scripts/gzclient
+++ b/gazebo_ros/scripts/gzclient
@@ -23,6 +23,13 @@ then
     final="$final -g `catkin_find --first-only libgazebo_ros_api_plugin.$EXT`"
 fi
 
+# Set node name to gzclient to not conflict with gazebo (gzserver) node if name is not set
+if [ `expr "$final" : ".*__name.*"` -eq 0 ]
+then
+    final="$final __name:=gzclient"
+fi
+
+
 setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
 
 # source setup.sh, but keep local modifications to GAZEBO_MASTER_URI and GAZEBO_MODEL_DATABASE_URI


### PR DESCRIPTION
Fix issue #765. 

When gzclient and gzserver are run separately using the scripts (a reasonable use case), they both register a node "gazebo", causing one of them to be terminated. This change sets to node name for gzclient to "gzclient" to avoid this conflict (unless the name is manually specified).