### PR TITLE
Addition of fx and fy camera intrinsics

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
@@ -149,7 +149,8 @@ namespace gazebo
     protected: double cx_prime_;
     protected: double cx_;
     protected: double cy_;
-    protected: double focal_length_;
+    protected: double focal_length_x_;
+    protected: double focal_length_y_;
     protected: double hack_baseline_;
     protected: double distortion_k1_;
     protected: double distortion_k2_;

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
@@ -152,6 +152,7 @@ namespace gazebo
     protected: double focal_length_ ROS_DEPRECATED;
     protected: double focal_length_x_;
     protected: double focal_length_y_;
+    protected: double axis_skew_;
     protected: double hack_baseline_;
     protected: double distortion_k1_;
     protected: double distortion_k2_;

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
@@ -149,6 +149,7 @@ namespace gazebo
     protected: double cx_prime_;
     protected: double cx_;
     protected: double cy_;
+    protected: double focal_length_ ROS_DEPRECATED;
     protected: double focal_length_x_;
     protected: double focal_length_y_;
     protected: double hack_baseline_;

--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -182,8 +182,9 @@ void GazeboRosCameraUtils::Load(sensors::SensorPtr _parent,
 
   if (this->sdf->HasElement("focalLength"))
   {
-    this->focal_length_x_ = this->sdf->Get<double>("focalLength");
-    this->focal_length_y_ = this->focal_length_x_;
+    this->focal_length_ = this->sdf->Get<double>("focalLength"); // deprecated
+    this->focal_length_x_ = this->focal_length_;
+    this->focal_length_y_ = this->focal_length_;
   }
 
   if (!this->sdf->HasElement("focalLengthX"))
@@ -195,7 +196,10 @@ void GazeboRosCameraUtils::Load(sensors::SensorPtr _parent,
     }
   }
   else
+  {
     this->focal_length_x_ = this->sdf->Get<double>("focalLengthX");
+    this->focal_length_ = this->focal_length_x_;
+  }
 
   if (!this->sdf->HasElement("focalLengthY"))
   {
@@ -549,10 +553,10 @@ void GazeboRosCameraUtils::Init()
     // check against float precision
     if (!ignition::math::equal(this->focal_length_x_, computed_focal_length))
     {
-      ROS_WARN_NAMED("camera_utils", "The <focal_length>[%f] you have provided for camera_ [%s]"
+      ROS_WARN_NAMED("camera_utils", "The <focal_length_x>[%f] you have provided for camera_ [%s]"
                " is inconsistent with specified image_width [%d] and"
                " HFOV [%f].   Please double check to see that"
-               " focal_length = width_ / (2.0 * tan(HFOV/2.0)),"
+               " focal_length_x = width_ / (2.0 * tan(HFOV/2.0)),"
                " the explected focal_lengtth value is [%f],"
                " please update your camera_ model description accordingly.",
                 this->focal_length_x_, this->parentSensor_->Name().c_str(),

--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -180,6 +180,14 @@ void GazeboRosCameraUtils::Load(sensors::SensorPtr _parent,
   else
     this->cy_ = this->sdf->Get<double>("Cy");
 
+  if (!this->sdf->HasElement("AxisSkew"))
+  {
+    ROS_DEBUG_NAMED("camera_utils", "Camera plugin missing <AxisSkew>, defaults to 0");
+    this->axis_skew_= 0;
+  }
+  else
+    this->axis_skew_ = this->sdf->Get<double>("AxisSkew");
+
   if (this->sdf->HasElement("focalLength"))
   {
     this->focal_length_ = this->sdf->Get<double>("focalLength"); // deprecated
@@ -632,7 +640,7 @@ void GazeboRosCameraUtils::Init()
   camera_info_msg.D[4] = this->distortion_k3_;
   // original camera_ matrix
   camera_info_msg.K[0] = this->focal_length_x_;
-  camera_info_msg.K[1] = 0.0;
+  camera_info_msg.K[1] = this->axis_skew_;
   camera_info_msg.K[2] = this->cx_;
   camera_info_msg.K[3] = 0.0;
   camera_info_msg.K[4] = this->focal_length_y_;
@@ -653,7 +661,7 @@ void GazeboRosCameraUtils::Init()
   // camera_ projection matrix (same as camera_ matrix due
   // to lack of distortion/rectification) (is this generated?)
   camera_info_msg.P[0] = this->focal_length_x_;
-  camera_info_msg.P[1] = 0.0;
+  camera_info_msg.P[1] = this->axis_skew_;
   camera_info_msg.P[2] = this->cx_;
   camera_info_msg.P[3] = -this->focal_length_x_ * this->hack_baseline_;
   camera_info_msg.P[4] = 0.0;

--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -539,29 +539,47 @@ void GazeboRosCameraUtils::Init()
 
 
   double hfov = this->camera_->HFOV().Radian();
-  double computed_focal_length =
+  double computed_focal_length_x =
     (static_cast<double>(this->width_)) /
     (2.0 * tan(hfov / 2.0));
 
+  double vfov = this->camera_->VFOV().Radian();
+  double computed_focal_length_y =
+    (static_cast<double>(this->height_)) /
+    (2.0 * tan(vfov / 2.0));
+
   if (this->focal_length_x_ == 0 || this->focal_length_y_ == 0)
   {
-    this->focal_length_x_ = computed_focal_length;
-    this->focal_length_y_ = computed_focal_length;
+    this->focal_length_x_ = computed_focal_length_x;
+    this->focal_length_y_ = computed_focal_length_y;
   }
   else
   {
     // check against float precision
-    if (!ignition::math::equal(this->focal_length_x_, computed_focal_length))
+    if (!ignition::math::equal(this->focal_length_x_, computed_focal_length_x))
     {
-      ROS_WARN_NAMED("camera_utils", "The <focal_length_x>[%f] you have provided for camera_ [%s]"
-               " is inconsistent with specified image_width [%d] and"
-               " HFOV [%f].   Please double check to see that"
-               " focal_length_x = width_ / (2.0 * tan(HFOV/2.0)),"
-               " the explected focal_lengtth value is [%f],"
+      ROS_WARN_NAMED("camera_utils", "The <focal_length_x> [%f] you have provided for camera [%s]"
+               " is inconsistent with specified image width [%d] and"
+               " HFOV [%f]. Please double check to see that"
+               " focal_length_x = image_width / (2.0 * tan(hfov_radians / 2.0)),"
+               " the explected x focal_length value is [%f],"
                " please update your camera_ model description accordingly.",
                 this->focal_length_x_, this->parentSensor_->Name().c_str(),
                 this->width_, hfov,
-                computed_focal_length);
+                computed_focal_length_x);
+    }
+
+    if (!ignition::math::equal(this->focal_length_y_, computed_focal_length_y))
+    {
+      ROS_WARN_NAMED("camera_utils", "The <focal_length_y> [%f] you have provided for camera [%s]"
+               " is inconsistent with specified image height [%d] and"
+               " VFOV [%f]. Please double check to see that"
+               " focal_length_y = image_height / (2.0 * tan(vfov_radians / 2.0)),"
+               " the explected y focal_length value is [%f],"
+               " please update your camera_ model description accordingly.",
+                this->focal_length_y_, this->parentSensor_->Name().c_str(),
+                this->height_, vfov,
+                computed_focal_length_y);
     }
   }
 

--- a/gazebo_plugins/src/gazebo_ros_prosilica.cpp
+++ b/gazebo_plugins/src/gazebo_ros_prosilica.cpp
@@ -234,11 +234,11 @@ void GazeboRosProsilica::pollCallback(polled_camera::GetPolledImage::Request& re
         this->roiCameraInfoMsg->D[3] = this->distortion_t1_;
         this->roiCameraInfoMsg->D[4] = this->distortion_t2_;
         // original camera matrix
-        this->roiCameraInfoMsg->K[0] = this->focal_length_;
+        this->roiCameraInfoMsg->K[0] = this->focal_length_x_;
         this->roiCameraInfoMsg->K[1] = 0.0;
         this->roiCameraInfoMsg->K[2] = this->cx_ - req.roi.x_offset;
         this->roiCameraInfoMsg->K[3] = 0.0;
-        this->roiCameraInfoMsg->K[4] = this->focal_length_;
+        this->roiCameraInfoMsg->K[4] = this->focal_length_y_;
         this->roiCameraInfoMsg->K[5] = this->cy_ - req.roi.y_offset;
         this->roiCameraInfoMsg->K[6] = 0.0;
         this->roiCameraInfoMsg->K[7] = 0.0;
@@ -254,12 +254,12 @@ void GazeboRosProsilica::pollCallback(polled_camera::GetPolledImage::Request& re
         this->roiCameraInfoMsg->R[7] = 0.0;
         this->roiCameraInfoMsg->R[8] = 1.0;
         // camera projection matrix (same as camera matrix due to lack of distortion/rectification) (is this generated?)
-        this->roiCameraInfoMsg->P[0] = this->focal_length_;
+        this->roiCameraInfoMsg->P[0] = this->focal_length_x_;
         this->roiCameraInfoMsg->P[1] = 0.0;
         this->roiCameraInfoMsg->P[2] = this->cx_ - req.roi.x_offset;
-        this->roiCameraInfoMsg->P[3] = -this->focal_length_ * this->hack_baseline_;
+        this->roiCameraInfoMsg->P[3] = -this->focal_length_x_ * this->hack_baseline_;
         this->roiCameraInfoMsg->P[4] = 0.0;
-        this->roiCameraInfoMsg->P[5] = this->focal_length_;
+        this->roiCameraInfoMsg->P[5] = this->focal_length_y_;
         this->roiCameraInfoMsg->P[6] = this->cy_ - req.roi.y_offset;
         this->roiCameraInfoMsg->P[7] = 0.0;
         this->roiCameraInfoMsg->P[8] = 0.0;


### PR DESCRIPTION
Added the option to specify the X and Y components of the focal length of a gazebo camera.
This PR is the update of #374 for ROS Melodic in Ubuntu 18.04.

Let me know if I need to perform changes / improvements.

Related PRs:
- https://bitbucket.org/osrf/gazebo/pull-requests/2058/added-camera-intrinsics-fx-fy-cx-cy-s
- https://bitbucket.org/osrf/sdformat/pull-requests/248/added-camera-intrinsics-fx-fy-cx-cy-s

Testing world:
- https://github.com/inesc-tec-robotics/gazebo_projection_mapping/blob/hydro-devel/worlds/camera_intrinsics.world