### PR TITLE
Add Node::Create with sdf element

### DIFF
--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -43,6 +43,8 @@ ament_export_dependencies(gazebo_dev)
 
 if(BUILD_TESTING)
   add_subdirectory(test)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 endif()
 
 ament_package()

--- a/gazebo_ros/include/gazebo_ros/gazebo_ros_init.hpp
+++ b/gazebo_ros/include/gazebo_ros/gazebo_ros_init.hpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef GAZEBO_ROS__GAZEBO_ROS_INIT_HPP_
+#define GAZEBO_ROS__GAZEBO_ROS_INIT_HPP_
+
+
 #include <gazebo/common/Plugin.hh>
 
 /// Initializes ROS with the system arguments passed to Gazebo (i.e. calls rclcpp::init).
@@ -29,4 +33,4 @@ public:
   /// \param[in] argv Argument values.
   void Load(int argc, char ** argv);
 };
-
+#endif  // GAZEBO_ROS__GAZEBO_ROS_INIT_HPP_

--- a/gazebo_ros/launch/empty_world.launch.py
+++ b/gazebo_ros/launch/empty_world.launch.py
@@ -15,7 +15,7 @@
 """Launch a Gazebo server with an empty world and initialize ROS with command line arguments."""
 
 import launch
-import launch_ros.actions
+
 
 def generate_launch_description():
     # TODO(anyone): Forward command line arguments once that's supported, see
@@ -28,4 +28,3 @@ def generate_launch_description():
     return launch.LaunchDescription([
         gzserver
     ])
-

--- a/gazebo_ros/src/node.cpp
+++ b/gazebo_ros/src/node.cpp
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 #include <gazebo_ros/node.hpp>
+#include <sdf/Param.hh>
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace gazebo_ros
 {
@@ -27,9 +29,96 @@ Node::~Node()
 {
 }
 
+Node::SharedPtr Node::Create(const std::string & node_name, sdf::ElementPtr sdf)
+{
+  // Get inner <ros> element if full plugin sdf was passed in
+  if (sdf->HasElement("ros")) {
+    sdf = sdf->GetElement("ros");
+  }
+
+  // Initialize arguments
+  std::string name = node_name;
+  std::string ns = "";
+  std::vector<std::string> arguments;
+  std::vector<rclcpp::Parameter> initial_parameters;
+
+  // Override name if tag is present
+  if (sdf->HasElement("node_name")) {
+    name = sdf->GetElement("node_name")->Get<std::string>();
+  }
+
+  // Set namespace if tag is present
+  if (sdf->HasElement("namespace")) {
+    ns = sdf->GetElement("namespace")->Get<std::string>();
+  }
+
+  // Get list of arguments from SDF
+  sdf::ElementPtr argument_sdf = sdf->GetElement("argument");
+  while (argument_sdf) {
+    std::string argument = argument_sdf->Get<std::string>();
+    arguments.push_back(argument);
+    argument_sdf = argument_sdf->GetNextElement("argument");
+  }
+
+  // Convert each parameter tag to a ROS parameter
+  sdf::ElementPtr parameter_sdf = sdf->GetElement("parameter");
+  while (parameter_sdf) {
+    auto param = sdf_to_ros_parameter(parameter_sdf);
+    if (rclcpp::ParameterType::PARAMETER_NOT_SET != param.get_type()) {
+      initial_parameters.push_back(param);
+    }
+    parameter_sdf = parameter_sdf->GetNextElement("parameter");
+  }
+
+  // Use default context
+  auto context = rclcpp::contexts::default_context::get_global_default_context();
+
+  // Create node with parsed arguments
+  return CreateWithArgs(
+    name, ns,
+    context,
+    arguments, initial_parameters);
+}
+
 Node::SharedPtr Node::Create(const std::string & node_name)
 {
-  return Create<const std::string &>(node_name);
+  return CreateWithArgs(node_name);
+}
+
+rclcpp::Parameter Node::sdf_to_ros_parameter(sdf::ElementPtr const & sdf)
+{
+  if (!sdf->HasAttribute("name")) {
+    RCLCPP_WARN(internal_logger(),
+      "Ignoring parameter because it has no attribute 'name'. Tag: %s", sdf->ToString("").c_str());
+    return rclcpp::Parameter();
+  }
+  if (!sdf->HasAttribute("type")) {
+    RCLCPP_WARN(internal_logger(),
+      "Ignoring parameter because it has no attribute 'type'. Tag: %s", sdf->ToString("").c_str());
+    return rclcpp::Parameter();
+  }
+
+  std::string name = sdf->Get<std::string>("name");
+  std::string type = sdf->Get<std::string>("type");
+
+  if ("int" == type) {
+    return rclcpp::Parameter(name, sdf->Get<int>());
+  } else if ("double" == type || "float" == type) {
+    return rclcpp::Parameter(name, sdf->Get<double>());
+  } else if ("bool" == type) {
+    return rclcpp::Parameter(name, sdf->Get<bool>());
+  } else if ("string" == type) {
+    return rclcpp::Parameter(name, sdf->Get<std::string>());
+  } else {
+    RCLCPP_WARN(internal_logger(),
+      "Ignoring parameter because attribute 'type' is invalid. Tag: %s", sdf->ToString("").c_str());
+    return rclcpp::Parameter();
+  }
+}
+
+rclcpp::Logger Node::internal_logger()
+{
+  return rclcpp::get_logger("gazebo_ros_node");
 }
 
 }  // namespace gazebo_ros

--- a/gazebo_ros/test/CMakeLists.txt
+++ b/gazebo_ros/test/CMakeLists.txt
@@ -1,9 +1,5 @@
 find_package(ament_cmake_gtest REQUIRED)
-find_package(ament_lint_auto REQUIRED)
 find_package(std_msgs REQUIRED)
-
-# Linters
-ament_lint_auto_find_test_dependencies()
 
 # Plugins
 set(plugins
@@ -11,6 +7,7 @@ set(plugins
   create_node_without_init
   multiple_nodes
   ros_world_plugin
+  sdf_node
 )
 
 foreach(plugin ${plugins})
@@ -36,6 +33,9 @@ foreach(test ${tests})
     ${test}.cpp
     WORKING_DIRECTORY
       ${CMAKE_CURRENT_BINARY_DIR}
+    # Long timeout because has to run gazebo several times
+    TIMEOUT
+      120
   )
   ament_target_dependencies(${test}
     "rclcpp"

--- a/gazebo_ros/test/plugins/create_node_without_init.cpp
+++ b/gazebo_ros/test/plugins/create_node_without_init.cpp
@@ -46,7 +46,6 @@ void CreateBeforeInit::Load(int, char **)
   using namespace std::chrono_literals;
   timer_ = node->create_wall_timer(1s,
       [node, pub]() {
-
         // Create string message
         auto msg = std_msgs::msg::String();
         msg.data = "Hello world";

--- a/gazebo_ros/test/test_plugins.cpp
+++ b/gazebo_ros/test/test_plugins.cpp
@@ -37,19 +37,44 @@ public:
   // Documentation inherited
   void TearDown() override;
 
-  /// Run gzserver with the given system plugin
-  /// \param[in] params Path of plugin library to load and a vector of topics to subscribe to.
-  void Run(TestParams params);
+  // Documentation inherited
+  void SetUp() override;
 
 private:
   int pid_ = -1;
 };
 
+void TestPlugins::SetUp()
+{
+  auto params = GetParam();
+
+  unsigned int i = 0;
+  std::vector<const char *> args(params.extra_args.size() + 5);
+  args[i++] = "/usr/bin/gzserver";
+  args[i++] = "--verbose";
+  args[i++] = "-s";
+  args[i++] = params.plugin.c_str();
+  for (unsigned int j = i; j < params.extra_args.size() + i; ++j) {
+    args[j] = params.extra_args[j - i].c_str();
+  }
+  args[i + params.extra_args.size()] = NULL;
+
+  // Fork process so gazebo can be run as child
+  pid_ = fork();
+
+  // Child process
+  if (0 == pid_) {
+    // Run gazebo with a plugin with publishes a string to /test
+    ASSERT_TRUE(execvp("gzserver", const_cast<char **>(args.data())));
+    exit(1);
+  } else {
+    // Parent process
+    ASSERT_GT(pid_, 0);
+  }
+}
+
 void TestPlugins::TearDown()
 {
-  // If fork failed, don't need to do anything
-  ASSERT_GE(pid_, 0);
-
   // Kill gazebo (simulating ^C command)
   EXPECT_FALSE(kill(pid_, SIGINT));
 
@@ -57,71 +82,41 @@ void TestPlugins::TearDown()
   wait(nullptr);
 }
 
-void TestPlugins::Run(TestParams params)
+TEST_P(TestPlugins, TestTopicsReceived)
 {
-  std::cout << "Testing plugin: " << params.plugin << std::endl;
-
-  auto topics = params.topics;
-
-  unsigned int i = 0;
-  const char ** args = new const char *[params.extra_args.size() + 5];
-  args[i++] = "/user/bin/gzserver";
-  args[i++] = "--verbose";
-  args[i++] = "-s";
-  args[i++] = params.plugin.c_str();
-  for (unsigned int j = i; j < params.extra_args.size() + i; ++j)
-  {
-    args[j] = params.extra_args[j - i].c_str();
-  }
-  args[i + params.extra_args.size()] = NULL;
-
-  // Fork process so gazebo can be run as child
-  pid_ = fork();
-  if (pid_ < 0) {
-    throw std::runtime_error("fork failed");
-  }
-
-  // Child process
-  if (0 == pid_) {
-
-    // Run gazebo with a plugin with publishes a string to /test
-    ASSERT_TRUE(execvp("gzserver", (char **)args));
-
-    exit(1);
-  }
-
+  auto topics = GetParam().topics;
   // Create node and executor
   rclcpp::executors::SingleThreadedExecutor executor;
   auto node = std::make_shared<rclcpp::Node>("my_node");
   executor.add_node(node);
+
 
   // Subscribe to topics published by plugin
   using StringPtr = std_msgs::msg::String::SharedPtr;
 
   // Track which topics we have received a message from
   size_t topics_received_from = 0;
-  std::vector<bool> received(topics.size());
+  std::vector<bool> received(topics.size(), false);
 
   std::vector<std::shared_ptr<rclcpp::Subscription<std_msgs::msg::String>>> subs;
-  for (size_t i = 0; i < topics.size(); ++i)
-  {
+  for (size_t i = 0; i < topics.size(); ++i) {
     subs.push_back(node->create_subscription<std_msgs::msg::String>(topics[i],
-        [&topics_received_from, &received, i](const StringPtr msg) {
-          (void) msg;
-          // If this is the first message from this topic, increment the counter
-          if (!received[i])
-          {
-            received[i] = true;
-            ++topics_received_from;
-          }
-        }));
+      [&topics_received_from, &received, i](const StringPtr msg) {
+        (void) msg;
+        // If this is the first message from this topic, increment the counter
+        if (!received[i]) {
+          received[i] = true;
+          ++topics_received_from;
+        }
+      }));
   }
 
-  // Wait until message is received or timeout after 5 seconds
+  // Wait until message is received or timeout occurs
   using namespace std::literals::chrono_literals;
-  auto timeout = node->now() + rclcpp::Duration(5s);
+  auto timeout = node->now() + rclcpp::Duration(15s);
+
   while (topics_received_from != topics.size() && node->now() < timeout) {
-    executor.spin_once(50ms);
+    executor.spin_once(200ms);
   }
 
   // Wait a little while so gazebo isn't torn down before created
@@ -131,18 +126,14 @@ void TestPlugins::Run(TestParams params)
   EXPECT_EQ(topics_received_from, topics.size());
 }
 
-TEST_P(TestPlugins, Run)
-{
-  Run(GetParam());
-}
-
 INSTANTIATE_TEST_CASE_P(Plugins, TestPlugins, ::testing::Values(
-   TestParams({"./libargs_init.so", {"test"}, {}}),
-   TestParams({"./libcreate_node_without_init.so", {"test"}, {}}),
-   TestParams({"./libmultiple_nodes.so", {"testA", "testB"}, {}}),
-   TestParams({"libgazebo_ros_init.so", {"new_test"}, {"worlds/ros_world_plugin.world",
-       "ros_world_plugin:/test:=/new_test"}})
-),);
+    TestParams({"./libargs_init.so", {"test"}, {}}),
+    TestParams({"./libcreate_node_without_init.so", {"test"}, {}}),
+    TestParams({"./libmultiple_nodes.so", {"testA", "testB"}, {}}),
+    TestParams({"libgazebo_ros_init.so", {"new_test"}, {"worlds/ros_world_plugin.world",
+        "ros_world_plugin:/test:=/new_test"}}),
+    TestParams({"libgazebo_ros_init.so", {"/foo/my_topic"}, {"worlds/sdf_node_plugin.world"}})
+  ), );
 
 int main(int argc, char ** argv)
 {

--- a/gazebo_ros/test/worlds/sdf_node_plugin.world
+++ b/gazebo_ros/test/worlds/sdf_node_plugin.world
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <world name="default">
+    <plugin name="sdf_plugin" filename="./libsdf_node.so">
+      <ros>
+        <node_name>my_node</node_name>
+        <namespace>/foo</namespace>
+        <argument>test:=my_topic</argument>
+        <parameter name="my_string" type="string">str</parameter>
+        <parameter name="my_bool_true" type="bool">True</parameter>
+        <parameter name="my_bool_false" type="bool">false</parameter>
+        <parameter name="my_int" type="int">42</parameter>
+        <parameter name="my_double" type="double">13.37</parameter>
+
+        <!-- Missing 'name', should be rejected -->
+        <parameter type="int">52</parameter>
+        <!-- Invalid type, should be rejected -->
+        <parameter name="invalid_type" type="uint8">10</parameter>
+        <!-- Missing 'type', should be rejected -->
+        <parameter name="missing_type">Lorem Impsum</parameter>
+      </ros>
+    </plugin>
+  </world>
+</sdf>


### PR DESCRIPTION
Implement the ```Node::Create(const std::string & node_name, sdf::ElementPtr _sdf)``` method discussed in the [ros2 page](https://github.com/ros-simulation/gazebo_ros_pkgs/wiki/ROS-2-integration).

The only difference was I decided to parse the ```<parameter>``` and ```<argument>``` tag in the root of the element instead of within a ```<parameters>```/```<arguments>``` tag to avoid the unnecessary complexity.

Some other changes bundled in:
* Renamed the variadic ```Node::Create(Args && ... args)``` to ```Node::CreateWithArgs```. Without this change, the compiler will never use the alternative ```Node::Create``` definitions and always assume the variadic form is used.
* Move ament linting back to main CmakeList so linting is run on all source files
* Various style fixes
* Small refactor in test_plugins.cpp to do setup operations in the SetUp function as per gtest convention
* Only catch RCL_NOT_INIT exception in Node::Create, instead of any exception.
* Add larger timeouts to tests 

I've noticed that the tests are a bit flakey on my machine with and without these changes. Ticketed to #780