### PR TITLE
[ros2] Additional conversion and utility functions

### DIFF
--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -40,6 +40,15 @@ ament_target_dependencies(gazebo_ros_init
 )
 ament_export_libraries(gazebo_ros_init)
 
+add_library(gazebo_ros_utils SHARED
+  src/utils.cpp
+)
+ament_target_dependencies(gazebo_ros_utils
+  "rclcpp"
+  "gazebo_dev"
+)
+ament_export_libraries(gazebo_ros_utils)
+
 ament_export_include_directories(include)
 ament_export_dependencies(rclcpp)
 ament_export_dependencies(gazebo_dev)
@@ -59,6 +68,7 @@ install(
   TARGETS
     gazebo_ros_node
     gazebo_ros_init
+    gazebo_ros_utils
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)

--- a/gazebo_ros/include/gazebo_ros/conversions.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions.hpp
@@ -72,7 +72,7 @@ geometry_msgs::msg::Vector3 Convert(const ignition::math::Vector3d & vec)
   return msg;
 }
 
-/// Generic conversion from an Ignition Math Quaternion to another type.
+/// Generic conversion from an Ignition Math quaternion to another type.
 /// \param[in] in Input vector.
 /// \return Conversion result
 /// \tparam OUT Output type
@@ -83,7 +83,7 @@ OUT Convert(const ignition::math::Quaterniond & in)
 }
 
 /// \brief Specialized conversion from an Ignition Math Quaternion to a ROS message.
-/// \param[in] vec Ignition Quaternion to convert.
+/// \param[in] in Ignition Quaternion to convert.
 /// \return ROS geometry quaternion message
 template<>
 geometry_msgs::msg::Quaternion Convert(const ignition::math::Quaterniond & in)

--- a/gazebo_ros/include/gazebo_ros/conversions.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions.hpp
@@ -16,7 +16,13 @@
 #define GAZEBO_ROS__CONVERSIONS_HPP_
 
 #include <geometry_msgs/msg/vector3.hpp>
+#include <geometry_msgs/msg/quaternion.hpp>
+#include <builtin_interfaces/msg/time.hpp>
 #include <ignition/math/Vector3.hh>
+#include <gazebo/common/common.hh>
+#include <rclcpp/time.hpp>
+
+#include <string>
 
 namespace gazebo_ros
 {
@@ -65,5 +71,61 @@ geometry_msgs::msg::Vector3 Convert(const ignition::math::Vector3d & vec)
   msg.z = vec.Z();
   return msg;
 }
+
+/// Generic conversion from an Ignition Math Quaternion to another type.
+/// \param[in] in Input vector.
+/// \return Conversion result
+/// \tparam OUT Output type
+template<class OUT>
+OUT Convert(const ignition::math::Quaterniond & in)
+{
+  return OUT();
+}
+
+/// \brief Specialized conversion from an Ignition Math Quaternion to a ROS message.
+/// \param[in] vec Ignition Quaternion to convert.
+/// \return ROS geometry quaternion message
+template<>
+geometry_msgs::msg::Quaternion Convert(const ignition::math::Quaterniond & in)
+{
+  geometry_msgs::msg::Quaternion msg;
+  msg.x = in.X();
+  msg.y = in.Y();
+  msg.z = in.Z();
+  msg.w = in.W();
+  return msg;
+}
+
+/// Generic conversion from an Gazebo Time object to another type.
+/// \param[in] in Input time;
+/// \return Conversion result
+/// \tparam OUT Output type
+template<class OUT>
+OUT Convert(const gazebo::common::Time & in)
+{
+  return OUT();
+}
+
+/// \brief Specialized conversion from an Gazebo Time to a RCLCPP Time.
+/// \param[in] in Gazebo Time to convert.
+/// \return A rclcpp::Time object with the same value as in
+template<>
+rclcpp::Time Convert(const gazebo::common::Time & in)
+{
+  return rclcpp::Time(in.sec, in.nsec, rcl_clock_type_t::RCL_ROS_TIME);
+}
+
+/// \brief Specialized conversion from an Gazebo Time to a ROS Time message.
+/// \param[in] in Gazebo Time to convert.
+/// \return A ROS Time message with the same value as in
+template<>
+builtin_interfaces::msg::Time Convert(const gazebo::common::Time & in)
+{
+  builtin_interfaces::msg::Time time;
+  time.sec = in.sec;
+  time.nanosec = in.nsec;
+  return time;
+}
+
 }  // namespace gazebo_ros
 #endif  // GAZEBO_ROS__CONVERSIONS_HPP_

--- a/gazebo_ros/include/gazebo_ros/node.hpp
+++ b/gazebo_ros/include/gazebo_ros/node.hpp
@@ -37,7 +37,7 @@ class Node : public rclcpp::Node
 {
 public:
   /// Shared pointer to a #gazebo_ros::Node
-  typedef std::shared_ptr<Node> SharedPtr;
+  using SharedPtr = std::shared_ptr<Node>;
 
   /// Destructor
   virtual ~Node();

--- a/gazebo_ros/include/gazebo_ros/testing_utils.hpp
+++ b/gazebo_ros/include/gazebo_ros/testing_utils.hpp
@@ -29,23 +29,24 @@ namespace gazebo_ros
 {
 
 
-/// Helper class to run gzserver in a seperate process and later terminate that process
+/// Helper class to run gzserver in a separate process and later terminate that process
 class GazeboProcess
 {
 public:
-  /// Start gzserver with a list of arugments
-  /// \note The path and --verbose are automaticaly added
+  /// Start gzserver with a list of arguments
+  /// \note The path and --verbose are automatically added
   explicit GazeboProcess(const std::vector<const char *> & args);
 
+  /// Destructor
   ~GazeboProcess();
 
-  /// Start gzserver with the arguments passed to constructuor
+  /// Start gzserver with the arguments passed to constructor
   /// \return The result of fork(), either the pid of gazebo process or error if < 0
-  int run();
+  int Run();
 
-  /// Terminate the child gzserve process
+  /// Terminate the child gzserver process
   /// \return -1 if run() failed or has not been called,
-  int terminate();
+  int Terminate();
 
 private:
   /// Arguments to run gzserver with
@@ -64,10 +65,10 @@ GazeboProcess::GazeboProcess(const std::vector<const char *> & args)
 
 GazeboProcess::~GazeboProcess()
 {
-  terminate();
+  Terminate();
 }
 
-int GazeboProcess::run()
+int GazeboProcess::Run()
 {
   // Fork process so gazebo can be run as child
   pid_ = fork();
@@ -76,7 +77,7 @@ int GazeboProcess::run()
   if (0 == pid_) {
     // Run gazebo with arguments
     if (execvp("gzserver", const_cast<char **>(arguments.data()))) {
-      // Exec failed, cannot return (in seperate process), so just print errno
+      // Exec failed, cannot return (in separate process), so just print errno
       printf("gzserver failed with errno=%d", errno);
       exit(1);
     }
@@ -90,7 +91,7 @@ int GazeboProcess::run()
   return pid_;
 }
 
-int GazeboProcess::terminate()
+int GazeboProcess::Terminate()
 {
   // Return -1
   if (pid_ < 0) {
@@ -132,7 +133,6 @@ get_message_or_timeout(
 
   auto sub = node->create_subscription<T>(topic,
       [&msg_received, &msg](typename T::SharedPtr _msg) {
-        (void) msg;
         // If this is the first message from this topic, increment the counter
         if (!msg_received.exchange(true)) {
           msg = _msg;
@@ -142,6 +142,7 @@ get_message_or_timeout(
   // Wait until message is received or timeout occurs
   using namespace std::literals::chrono_literals; // NOLINT
   auto timeout_absolute = clock.now() + timeout;
+
   while (false == msg_received && clock.now() < timeout_absolute) {
     executor.spin_once(200ms);
   }

--- a/gazebo_ros/include/gazebo_ros/testing_utils.hpp
+++ b/gazebo_ros/include/gazebo_ros/testing_utils.hpp
@@ -1,0 +1,155 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GAZEBO_ROS__TESTING_UTILS_HPP_
+#define GAZEBO_ROS__TESTING_UTILS_HPP_
+
+#include <unistd.h>
+#include <stdlib.h>
+
+#include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
+
+#include <utility>
+#include <vector>
+#include <string>
+
+namespace gazebo_ros
+{
+
+
+/// Helper class to run gzserver in a seperate process and later terminate that process
+class GazeboProcess
+{
+public:
+  /// Start gzserver with a list of arugments
+  /// \note The path and --verbose are automaticaly added
+  explicit GazeboProcess(const std::vector<const char *> & args);
+
+  ~GazeboProcess();
+
+  /// Start gzserver with the arguments passed to constructuor
+  /// \return The result of fork(), either the pid of gazebo process or error if < 0
+  int run();
+
+  /// Terminate the child gzserve process
+  /// \return -1 if run() failed or has not been called,
+  int terminate();
+
+private:
+  /// Arguments to run gzserver with
+  std::vector<const char *> arguments;
+
+  // pid of gzserver
+  int pid_ = -1;
+};
+
+GazeboProcess::GazeboProcess(const std::vector<const char *> & args)
+{
+  arguments = {"/usr/bin/gzserver", "--verbose"};
+  arguments.insert(arguments.end(), args.begin(), args.end());
+  arguments.push_back(nullptr);
+}
+
+GazeboProcess::~GazeboProcess()
+{
+  terminate();
+}
+
+int GazeboProcess::run()
+{
+  // Fork process so gazebo can be run as child
+  pid_ = fork();
+
+  // Child process
+  if (0 == pid_) {
+    // Run gazebo with arguments
+    if (execvp("gzserver", const_cast<char **>(arguments.data()))) {
+      // Exec failed, cannot return (in seperate process), so just print errno
+      printf("gzserver failed with errno=%d", errno);
+      exit(1);
+    }
+  }
+
+  if (pid_ < 0) {
+    return errno;
+  }
+
+  // Parent process, return pid of child (or error produced by fork())
+  return pid_;
+}
+
+int GazeboProcess::terminate()
+{
+  // Return -1
+  if (pid_ < 0) {
+    return ECHILD;
+  }
+
+  // Kill gazebo (simulating ^C command)
+  if (kill(pid_, SIGINT)) {
+    return errno;
+  }
+
+  // Wait for gazebo to terminate
+  if (waitpid(pid_, nullptr, 0) < 0) {
+    return errno;
+  }
+
+  return 0;
+}
+
+
+/// Helper function to get the next message on a ROS topic with a timeout
+/// \param node Pointer to a node to use to subscribe to the topic
+/// \param topic Topic to subscribe to for message
+/// \param timeout Maximum time to wait for message
+/// \tparam T Message type to get
+/// \return Shared pointer to new message, or nullptr if none received before timeout
+template<typename T>
+typename T::SharedPtr
+get_message_or_timeout(
+  rclcpp::Node::SharedPtr node, const std::string & topic,
+  rclcpp::Duration timeout = rclcpp::Duration(5, 0))
+{
+  rclcpp::Clock clock;
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+
+  std::atomic_bool msg_received(false);
+  typename T::SharedPtr msg = nullptr;
+
+  auto sub = node->create_subscription<T>(topic,
+      [&msg_received, &msg](typename T::SharedPtr _msg) {
+        (void) msg;
+        // If this is the first message from this topic, increment the counter
+        if (!msg_received.exchange(true)) {
+          msg = _msg;
+        }
+      });
+
+  // Wait until message is received or timeout occurs
+  using namespace std::literals::chrono_literals; // NOLINT
+  auto timeout_absolute = clock.now() + timeout;
+  while (false == msg_received && clock.now() < timeout_absolute) {
+    executor.spin_once(200ms);
+  }
+
+  return msg;
+}
+
+
+}  // namespace gazebo_ros
+
+#endif  // GAZEBO_ROS__TESTING_UTILS_HPP_

--- a/gazebo_ros/include/gazebo_ros/utils.hpp
+++ b/gazebo_ros/include/gazebo_ros/utils.hpp
@@ -1,0 +1,39 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GAZEBO_ROS__UTILS_HPP_
+#define GAZEBO_ROS__UTILS_HPP_
+
+#include <gazebo/sensors/Noise.hh>
+
+#include <string>
+
+namespace gazebo_ros
+{
+
+/// Get the variance of a gazebo sensor noise model
+/// \param[in] _noise The gazebo noise model
+/// \return The square of the standard deviation if the model is gaussian, otherwise 0
+double NoiseVariance(const gazebo::sensors::Noise & _noise);
+
+/// Gets the base name of a gazebo scoped name
+/// \details Example: given "my_world::my_robot::my_link", returns "my_link"
+/// \param[in] str Input scoped name, see example
+/// \return Input string with all base scopes removed, see example
+/// \todo Deprecate once with is implemented in gazebo/ignition/sdf.
+///       See: https://bitbucket.org/osrf/gazebo/issues/1735/add-helper-functions-to-handle-scoped
+std::string ScopedNameBase(const std::string & str);
+
+}  // namespace gazebo_ros
+#endif  // GAZEBO_ROS__UTILS_HPP_

--- a/gazebo_ros/include/gazebo_ros/utils.hpp
+++ b/gazebo_ros/include/gazebo_ros/utils.hpp
@@ -24,7 +24,9 @@ namespace gazebo_ros
 
 /// Get the variance of a gazebo sensor noise model
 /// \param[in] _noise The gazebo noise model
-/// \return The square of the standard deviation if the model is gaussian, otherwise 0
+/// \return If the model is Gaussian, return the square of the standard deviation.
+///         If the model is no noise, return 0.
+///         If the model is custom, return -1
 double NoiseVariance(const gazebo::sensors::Noise & _noise);
 
 /// Gets the base name of a gazebo scoped name

--- a/gazebo_ros/src/utils.cpp
+++ b/gazebo_ros/src/utils.cpp
@@ -1,0 +1,44 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gazebo_ros/utils.hpp>
+#include <gazebo/sensors/GaussianNoiseModel.hh>
+
+#include <string>
+
+namespace gazebo_ros
+{
+
+double NoiseVariance(const gazebo::sensors::Noise & _noise)
+{
+  if (gazebo::sensors::Noise::NoiseType::GAUSSIAN == _noise.GetNoiseType()) {
+    auto gm = dynamic_cast<const gazebo::sensors::GaussianNoiseModel &>(_noise);
+    return gm.GetStdDev() * gm.GetStdDev();
+  }
+  return 0.;
+}
+
+std::string ScopedNameBase(const std::string & str)
+{
+  // Get index of last :: scope marker
+  auto idx = str.rfind("::");
+  // If not found or at end, return original string
+  if (std::string::npos == idx || (idx + 2) >= str.size()) {
+    return str;
+  }
+  // Otherwise return part after last scope marker
+  return str.substr(idx + 2);
+}
+
+}  // namespace gazebo_ros

--- a/gazebo_ros/src/utils.cpp
+++ b/gazebo_ros/src/utils.cpp
@@ -25,8 +25,10 @@ double NoiseVariance(const gazebo::sensors::Noise & _noise)
   if (gazebo::sensors::Noise::NoiseType::GAUSSIAN == _noise.GetNoiseType()) {
     auto gm = dynamic_cast<const gazebo::sensors::GaussianNoiseModel &>(_noise);
     return gm.GetStdDev() * gm.GetStdDev();
+  } else if (gazebo::sensors::Noise::NoiseType::NONE == _noise.GetNoiseType()) {
+    return 0.;
   }
-  return 0.;
+  return -1.;
 }
 
 std::string ScopedNameBase(const std::string & str)

--- a/gazebo_ros/test/CMakeLists.txt
+++ b/gazebo_ros/test/CMakeLists.txt
@@ -26,6 +26,7 @@ file(COPY worlds DESTINATION .)
 # Tests
 set(tests
   test_conversions
+  test_utils
   test_plugins
 )
 
@@ -38,9 +39,11 @@ foreach(test ${tests})
     TIMEOUT
       120
   )
+  target_link_libraries(${test} gazebo_ros_utils)
   ament_target_dependencies(${test}
     "rclcpp"
     "std_msgs"
+    "gazebo_dev"
   )
 endforeach()
 

--- a/gazebo_ros/test/test_conversions.cpp
+++ b/gazebo_ros/test/test_conversions.cpp
@@ -47,9 +47,8 @@ TEST(TestConversions, Time)
   // Gazebo to rclcpp
   gazebo::common::Time time(200, 100);
   auto rostime = gazebo_ros::Convert<rclcpp::Time>(time);
-  builtin_interfaces::msg::Time tmp(rostime);
-  EXPECT_EQ(200, tmp.sec);
-  EXPECT_EQ(100u, tmp.nanosec);
+  EXPECT_EQ(200E9 + 100u, rostime.nanoseconds());
+
   /// Gazebo to ros message
   auto time_msg = gazebo_ros::Convert<builtin_interfaces::msg::Time>(time);
   EXPECT_EQ(200, time_msg.sec);

--- a/gazebo_ros/test/test_conversions.cpp
+++ b/gazebo_ros/test/test_conversions.cpp
@@ -15,24 +15,45 @@
 #include <gazebo_ros/conversions.hpp>
 #include <gtest/gtest.h>
 
-TEST(TestConversions, RosVectorIgnVector)
+TEST(TestConversions, Vector3)
 {
-  // Ignition
-  ignition::math::Vector3d vec(1.0, 2.0, 3.0);
-
   // Ign to ROS
+  ignition::math::Vector3d vec(1.0, 2.0, 3.0);
   auto msg = gazebo_ros::Convert<geometry_msgs::msg::Vector3>(vec);
-
   EXPECT_EQ(1.0, msg.x);
   EXPECT_EQ(2.0, msg.y);
   EXPECT_EQ(3.0, msg.z);
-
   // ROS to Ign
   vec = gazebo_ros::Convert<ignition::math::Vector3d>(msg);
-
   EXPECT_EQ(1.0, vec.X());
   EXPECT_EQ(2.0, vec.Y());
   EXPECT_EQ(3.0, vec.Z());
+}
+
+TEST(TestConversions, Quaternion)
+{
+  // Ign to ROS
+  ignition::math::Quaterniond quat(1.0, 0.2, 0.4, 0.6);
+  auto quat_msg = gazebo_ros::Convert<geometry_msgs::msg::Quaternion>(quat);
+  EXPECT_EQ(0.2, quat_msg.x);
+  EXPECT_EQ(0.4, quat_msg.y);
+  EXPECT_EQ(0.6, quat_msg.z);
+  EXPECT_EQ(1.0, quat_msg.w);
+}
+
+TEST(TestConversions, Time)
+{
+  // Time conversions
+  // Gazebo to rclcpp
+  gazebo::common::Time time(200, 100);
+  auto rostime = gazebo_ros::Convert<rclcpp::Time>(time);
+  builtin_interfaces::msg::Time tmp(rostime);
+  EXPECT_EQ(200, tmp.sec);
+  EXPECT_EQ(100u, tmp.nanosec);
+  /// Gazebo to ros message
+  auto time_msg = gazebo_ros::Convert<builtin_interfaces::msg::Time>(time);
+  EXPECT_EQ(200, time_msg.sec);
+  EXPECT_EQ(100u, time_msg.nanosec);
 }
 
 int main(int argc, char ** argv)

--- a/gazebo_ros/test/test_utils.cpp
+++ b/gazebo_ros/test/test_utils.cpp
@@ -1,0 +1,59 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gazebo_ros/utils.hpp>
+#include <gazebo/sensors/GaussianNoiseModel.hh>
+#include <gtest/gtest.h>
+
+#include <memory>
+
+TEST(TestUtils, NoiseVariance)
+{
+  // Test no noise has 0 variance
+  {
+    auto noise = gazebo::sensors::Noise(gazebo::sensors::Noise::NoiseType::NONE);
+    EXPECT_EQ(0.0, gazebo_ros::NoiseVariance(noise));
+  }
+
+  // Test gaussian noise type's variance is square of stddev
+  {
+    // SDF for gaussian noise model
+    auto stddev_description = std::make_shared<sdf::Element>();
+    stddev_description->SetName("stddev");
+    stddev_description->AddValue("double", "5.0", true);
+    auto noise_element = std::make_shared<sdf::Element>();
+    noise_element->SetName("noise");
+    noise_element->AddElementDescription(stddev_description);
+
+    // Create noise with sdf
+    auto noise = gazebo::sensors::GaussianNoiseModel();
+    noise.Load(noise_element);
+
+    EXPECT_EQ(25.0, gazebo_ros::NoiseVariance(noise));
+  }
+}
+
+TEST(TestUtils, ScopedNameBase)
+{
+  EXPECT_EQ(gazebo_ros::ScopedNameBase("afgfgf::vnjkkfds::my"), "my");
+  EXPECT_EQ(gazebo_ros::ScopedNameBase("base"), "base");
+  EXPECT_EQ(gazebo_ros::ScopedNameBase(""), "");
+  EXPECT_EQ(gazebo_ros::ScopedNameBase("fdfd::"), "fdfd::");
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/gazebo_ros/test/test_utils.cpp
+++ b/gazebo_ros/test/test_utils.cpp
@@ -23,12 +23,18 @@ TEST(TestUtils, NoiseVariance)
   // Test no noise has 0 variance
   {
     auto noise = gazebo::sensors::Noise(gazebo::sensors::Noise::NoiseType::NONE);
-    EXPECT_EQ(0.0, gazebo_ros::NoiseVariance(noise));
+    EXPECT_EQ(0., gazebo_ros::NoiseVariance(noise));
   }
 
-  // Test gaussian noise type's variance is square of stddev
+  // Test custom noise errors with -1
   {
-    // SDF for gaussian noise model
+    auto noise = gazebo::sensors::Noise(gazebo::sensors::Noise::NoiseType::CUSTOM);
+    EXPECT_EQ(-1., gazebo_ros::NoiseVariance(noise));
+  }
+
+  // Test Gaussian noise type's variance is square of stddev
+  {
+    // SDF for Gaussian noise model
     auto stddev_description = std::make_shared<sdf::Element>();
     stddev_description->SetName("stddev");
     stddev_description->AddValue("double", "5.0", true);


### PR DESCRIPTION
* Add conversion functions for quaternion (will use in Imu port)
* Add conversion functions for time (used in several plugins)
* Move code to launch gzserver in a forked process and get messages with timeouts to a testing_utils file to be reused in future tests (Imu, RaySensor)
* Add utils file for gazebo_ros utilities that are not conversions.
  * Function to get base of scoped gazebo name
  * Function to get variance of a gazebo noise model (will use in Imu, other sensors)