### PR TITLE
[ros2] NoiseVariance as a pointer, ROS quaternion -> ignition conversion

### DIFF
--- a/gazebo_ros/include/gazebo_ros/conversions.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions.hpp
@@ -73,7 +73,7 @@ geometry_msgs::msg::Vector3 Convert(const ignition::math::Vector3d & vec)
 }
 
 /// Generic conversion from an Ignition Math quaternion to another type.
-/// \param[in] in Input vector.
+/// \param[in] in Input quaternion
 /// \return Conversion result
 /// \tparam OUT Output type
 template<class OUT>
@@ -94,6 +94,25 @@ geometry_msgs::msg::Quaternion Convert(const ignition::math::Quaterniond & in)
   msg.z = in.Z();
   msg.w = in.W();
   return msg;
+}
+
+/// Generic conversion from a ROS Quaternion message to another type
+/// \param[in] in Input quaternion
+/// \return Conversion result
+/// \tparam OUT Output type
+template<class OUT>
+OUT Convert(const geometry_msgs::msg::Quaternion & in)
+{
+  return OUT();
+}
+
+/// \brief Specialized conversion from a ROS quaternion message to ignition quaternion
+/// \param[in] in Input quaternion message
+/// \return Ignition math quaternion with same values as the input message
+template<>
+ignition::math::Quaterniond Convert(const geometry_msgs::msg::Quaternion & in)
+{
+  return ignition::math::Quaterniond(in.w, in.x, in.y, in.z);
 }
 
 /// Generic conversion from an Gazebo Time object to another type.

--- a/gazebo_ros/include/gazebo_ros/utils.hpp
+++ b/gazebo_ros/include/gazebo_ros/utils.hpp
@@ -16,6 +16,7 @@
 #define GAZEBO_ROS__UTILS_HPP_
 
 #include <gazebo/sensors/Noise.hh>
+#include <gazebo/sensors/Sensor.hh>
 
 #include <string>
 
@@ -42,6 +43,17 @@ double NoiseVariance(const gazebo::sensors::NoisePtr & _noise_ptr);
 /// \todo Deprecate once with is implemented in gazebo/ignition/sdf.
 ///       See: https://bitbucket.org/osrf/gazebo/issues/1735/add-helper-functions-to-handle-scoped
 std::string ScopedNameBase(const std::string & str);
+
+/// Selects an appropriate tf frame id for a gazebo sensor
+/// \details Either returns the name of the sensor's parent link (without the scope)
+//           or the value of the sdf tag below if it is present.
+/// \code{.xml}
+/// <frame_name>my_tf_frame</frame_name>
+/// \endcode
+/// \param[in] _sensor The gazebo sensor which the frame should be in
+/// \param[in] _sdf SDF pointer which may contain a tag to override the frame id
+/// \return The string representing the tf frame of the sensor
+std::string SensorFrameID(const gazebo::sensors::Sensor & _sensor, const sdf::Element & _sdf);
 
 }  // namespace gazebo_ros
 #endif  // GAZEBO_ROS__UTILS_HPP_

--- a/gazebo_ros/include/gazebo_ros/utils.hpp
+++ b/gazebo_ros/include/gazebo_ros/utils.hpp
@@ -25,9 +25,15 @@ namespace gazebo_ros
 /// Get the variance of a gazebo sensor noise model
 /// \param[in] _noise The gazebo noise model
 /// \return If the model is Gaussian, return the square of the standard deviation.
-///         If the model is no noise, return 0.
-///         If the model is custom, return -1
+/// \return If the model is no noise, return 0.
+/// \return If the model is custom, return -1
 double NoiseVariance(const gazebo::sensors::Noise & _noise);
+
+/// Get the variance of a gazebo sensor noise model
+/// \param[in] _noise_ptr Shared pointer to the gazebo noise model
+/// \return If the pointer is nullptr, return 0.
+/// \return Otherwise, returns the same as @ref NoiseVariance(const gazebo::sensors::Noise &).
+double NoiseVariance(const gazebo::sensors::NoisePtr & _noise_ptr);
 
 /// Gets the base name of a gazebo scoped name
 /// \details Example: given "my_world::my_robot::my_link", returns "my_link"

--- a/gazebo_ros/src/utils.cpp
+++ b/gazebo_ros/src/utils.cpp
@@ -49,4 +49,15 @@ std::string ScopedNameBase(const std::string & str)
   return str.substr(idx + 2);
 }
 
+std::string SensorFrameID(const gazebo::sensors::Sensor & _sensor, const sdf::Element & _sdf)
+{
+  // Return frame from sdf tag if present
+  if (_sdf.HasElement("frame_name")) {
+    return _sdf.Get<std::string>("frame_name");
+  }
+
+  // Otherwise return the unscoped parent link name
+  return gazebo_ros::ScopedNameBase(_sensor.ParentName());
+}
+
 }  // namespace gazebo_ros

--- a/gazebo_ros/src/utils.cpp
+++ b/gazebo_ros/src/utils.cpp
@@ -31,6 +31,12 @@ double NoiseVariance(const gazebo::sensors::Noise & _noise)
   return -1.;
 }
 
+double NoiseVariance(const gazebo::sensors::NoisePtr & _noise_ptr)
+{
+  if (!_noise_ptr) {return 0.;}
+  return NoiseVariance(*_noise_ptr);
+}
+
 std::string ScopedNameBase(const std::string & str)
 {
   // Get index of last :: scope marker

--- a/gazebo_ros/test/test_conversions.cpp
+++ b/gazebo_ros/test/test_conversions.cpp
@@ -39,6 +39,12 @@ TEST(TestConversions, Quaternion)
   EXPECT_EQ(0.4, quat_msg.y);
   EXPECT_EQ(0.6, quat_msg.z);
   EXPECT_EQ(1.0, quat_msg.w);
+
+  auto ign_quat = gazebo_ros::Convert<ignition::math::Quaterniond>(quat_msg);
+  EXPECT_EQ(0.2, ign_quat.X());
+  EXPECT_EQ(0.4, ign_quat.Y());
+  EXPECT_EQ(0.6, ign_quat.Z());
+  EXPECT_EQ(1.0, ign_quat.W());
 }
 
 TEST(TestConversions, Time)

--- a/gazebo_ros/test/test_utils.cpp
+++ b/gazebo_ros/test/test_utils.cpp
@@ -22,14 +22,17 @@ TEST(TestUtils, NoiseVariance)
 {
   // Test no noise has 0 variance
   {
-    auto noise = gazebo::sensors::Noise(gazebo::sensors::Noise::NoiseType::NONE);
+    auto noise = std::make_shared<gazebo::sensors::Noise>(gazebo::sensors::Noise::NoiseType::NONE);
     EXPECT_EQ(0., gazebo_ros::NoiseVariance(noise));
+    EXPECT_EQ(0., gazebo_ros::NoiseVariance(*noise));
   }
 
   // Test custom noise errors with -1
   {
-    auto noise = gazebo::sensors::Noise(gazebo::sensors::Noise::NoiseType::CUSTOM);
+    auto noise =
+      std::make_shared<gazebo::sensors::Noise>(gazebo::sensors::Noise::NoiseType::CUSTOM);
     EXPECT_EQ(-1., gazebo_ros::NoiseVariance(noise));
+    EXPECT_EQ(-1., gazebo_ros::NoiseVariance(*noise));
   }
 
   // Test Gaussian noise type's variance is square of stddev
@@ -43,10 +46,17 @@ TEST(TestUtils, NoiseVariance)
     noise_element->AddElementDescription(stddev_description);
 
     // Create noise with sdf
-    auto noise = gazebo::sensors::GaussianNoiseModel();
-    noise.Load(noise_element);
+    auto noise = std::make_shared<gazebo::sensors::GaussianNoiseModel>();
+    noise->Load(noise_element);
 
     EXPECT_EQ(25.0, gazebo_ros::NoiseVariance(noise));
+    EXPECT_EQ(25.0, gazebo_ros::NoiseVariance(*noise));
+  }
+
+  {
+    // Test nullptr noise
+    gazebo::sensors::NoisePtr noise = nullptr;
+    EXPECT_EQ(0., gazebo_ros::NoiseVariance(noise));
   }
 }
 

--- a/gazebo_ros/test/test_utils.cpp
+++ b/gazebo_ros/test/test_utils.cpp
@@ -14,9 +14,11 @@
 
 #include <gazebo_ros/utils.hpp>
 #include <gazebo/sensors/GaussianNoiseModel.hh>
+#include <gazebo/sensors/sensors.hh>
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <string>
 
 TEST(TestUtils, NoiseVariance)
 {
@@ -66,6 +68,28 @@ TEST(TestUtils, ScopedNameBase)
   EXPECT_EQ(gazebo_ros::ScopedNameBase("base"), "base");
   EXPECT_EQ(gazebo_ros::ScopedNameBase(""), "");
   EXPECT_EQ(gazebo_ros::ScopedNameBase("fdfd::"), "fdfd::");
+}
+
+TEST(TestUtils, SensorFrameID)
+{
+  {
+    auto stddev_description = std::make_shared<sdf::Element>();
+    stddev_description->SetName("frame_name");
+    stddev_description->AddValue("string", "", false);
+    auto noise_element = std::make_shared<sdf::Element>();
+    noise_element->SetName("noise");
+    noise_element->AddElementDescription(stddev_description);
+    noise_element->GetElement("frame_name")->Set<std::string>("foo");
+    gazebo::sensors::CameraSensor s;
+    EXPECT_EQ(gazebo_ros::SensorFrameID(s, *noise_element), "foo");
+  }
+
+  {
+    sdf::Element sdf;
+    gazebo::sensors::CameraSensor s;
+    s.SetParent("world::my_robot::link", 0);
+    EXPECT_EQ(gazebo_ros::SensorFrameID(s, sdf), "link");
+  }
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
* Add conversion function going from geometry msgs quaternion to ignition quaternion
* Add a new signature for NoiseVariance, which takes a NoisePtr and return 0.0 if it is null (which indicates no noise)
* Add SensorFrameID, to standardize how the various sensor plugins select the frame to tf publish in