### PR TITLE
[ros2] Add sim_time to gazebo_ros_init

### DIFF
--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -31,15 +31,6 @@ ament_target_dependencies(gazebo_ros_node
 )
 ament_export_libraries(gazebo_ros_node)
 
-add_library(gazebo_ros_init SHARED
-  src/gazebo_ros_init.cpp
-)
-ament_target_dependencies(gazebo_ros_init
-  "rclcpp"
-  "gazebo_dev"
-)
-ament_export_libraries(gazebo_ros_init)
-
 add_library(gazebo_ros_utils SHARED
   src/utils.cpp
 )
@@ -48,6 +39,19 @@ ament_target_dependencies(gazebo_ros_utils
   "gazebo_dev"
 )
 ament_export_libraries(gazebo_ros_utils)
+
+add_library(gazebo_ros_init SHARED
+  src/gazebo_ros_init.cpp
+)
+ament_target_dependencies(gazebo_ros_init
+  "rclcpp"
+  "gazebo_dev"
+)
+target_link_libraries(gazebo_ros_init
+  gazebo_ros_node
+  gazebo_ros_utils
+)
+ament_export_libraries(gazebo_ros_init)
 
 ament_export_include_directories(include)
 ament_export_dependencies(rclcpp)

--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -15,6 +15,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(gazebo_dev REQUIRED)
+find_package(geometry_msgs REQUIRED)
 
 include_directories(
   include
@@ -46,6 +47,7 @@ add_library(gazebo_ros_init SHARED
 ament_target_dependencies(gazebo_ros_init
   "rclcpp"
   "gazebo_dev"
+  "geometry_msgs"
 )
 target_link_libraries(gazebo_ros_init
   gazebo_ros_node

--- a/gazebo_ros/include/gazebo_ros/gazebo_ros_init.hpp
+++ b/gazebo_ros/include/gazebo_ros/gazebo_ros_init.hpp
@@ -15,10 +15,17 @@
 #ifndef GAZEBO_ROS__GAZEBO_ROS_INIT_HPP_
 #define GAZEBO_ROS__GAZEBO_ROS_INIT_HPP_
 
-
 #include <gazebo/common/Plugin.hh>
 
+#include <memory>
+
+namespace gazebo_ros
+{
+
+class GazeboRosInitPrivate;
+
 /// Initializes ROS with the system arguments passed to Gazebo (i.e. calls rclcpp::init).
+/// Also publishes the latest simtime to /clock
 class GazeboRosInit : public gazebo::SystemPlugin
 {
 public:
@@ -28,9 +35,12 @@ public:
   /// Destructor
   virtual ~GazeboRosInit();
 
-  /// Called by Gazebo to load plugin.
-  /// \param[in] argc Argument count.
-  /// \param[in] argv Argument values.
+  // Documentation inherited
   void Load(int argc, char ** argv);
+
+private:
+  std::unique_ptr<GazeboRosInitPrivate> impl_;
 };
+
+}  // namespace gazebo_ros
 #endif  // GAZEBO_ROS__GAZEBO_ROS_INIT_HPP_

--- a/gazebo_ros/include/gazebo_ros/gazebo_ros_init.hpp
+++ b/gazebo_ros/include/gazebo_ros/gazebo_ros_init.hpp
@@ -36,7 +36,7 @@ public:
   virtual ~GazeboRosInit();
 
   // Documentation inherited
-  void Load(int argc, char ** argv);
+  void Load(int argc, char ** argv) override;
 
 private:
   std::unique_ptr<GazeboRosInitPrivate> impl_;

--- a/gazebo_ros/include/gazebo_ros/utils.hpp
+++ b/gazebo_ros/include/gazebo_ros/utils.hpp
@@ -60,9 +60,6 @@ std::string SensorFrameID(const gazebo::sensors::Sensor & _sensor, const sdf::El
 class Throttler
 {
 public:
-  /// Create a throttler with a period
-  /// \param[in] _period Period at which IsReady will return true
-  explicit Throttler(const gazebo::common::Time & _period);
   /// Create a throttler with a frequency
   /// \param[in] _hz Frequency at which IsReady will return true, in hertz
   explicit Throttler(const double _hz);

--- a/gazebo_ros/include/gazebo_ros/utils.hpp
+++ b/gazebo_ros/include/gazebo_ros/utils.hpp
@@ -17,6 +17,7 @@
 
 #include <gazebo/sensors/Noise.hh>
 #include <gazebo/sensors/Sensor.hh>
+#include <gazebo/common/Time.hh>
 
 #include <string>
 
@@ -54,6 +55,29 @@ std::string ScopedNameBase(const std::string & str);
 /// \param[in] _sdf SDF pointer which may contain a tag to override the frame id
 /// \return The string representing the tf frame of the sensor
 std::string SensorFrameID(const gazebo::sensors::Sensor & _sensor, const sdf::Element & _sdf);
+
+/// Helper class used to throttle something to a given rate
+class Throttler
+{
+public:
+  /// Create a throttler with a period
+  /// \param[in] _period Period at which IsReady will return true
+  explicit Throttler(const gazebo::common::Time & _period);
+  /// Create a throttler with a frequency
+  /// \param[in] _hz Frequency at which IsReady will return true, in hertz
+  explicit Throttler(const double _hz);
+  /// Check if the enough time has elapsed since the last time IsReady returned true
+  /// \param[in] _time The current time.
+  /// \return false if not enough time has elapsed from the last time IsReady was true
+  /// \return true if enough time has elapsed since the last success
+  bool IsReady(const gazebo::common::Time & _time);
+
+private:
+  /// The time between calls to @IsReady returning true
+  gazebo::common::Time period_;
+  /// The last time @IsReady returned true
+  gazebo::common::Time last_time_;
+};
 
 }  // namespace gazebo_ros
 #endif  // GAZEBO_ROS__UTILS_HPP_

--- a/gazebo_ros/include/gazebo_ros/utils.hpp
+++ b/gazebo_ros/include/gazebo_ros/utils.hpp
@@ -15,9 +15,9 @@
 #ifndef GAZEBO_ROS__UTILS_HPP_
 #define GAZEBO_ROS__UTILS_HPP_
 
+#include <gazebo/common/Time.hh>
 #include <gazebo/sensors/Noise.hh>
 #include <gazebo/sensors/Sensor.hh>
-#include <gazebo/common/Time.hh>
 
 #include <string>
 

--- a/gazebo_ros/include/gazebo_ros/utils.hpp
+++ b/gazebo_ros/include/gazebo_ros/utils.hpp
@@ -66,7 +66,7 @@ public:
   /// Check if the enough time has elapsed since the last time IsReady returned true
   /// \param[in] _time The current time.
   /// \return false if not enough time has elapsed from the last time IsReady was true
-  /// \return true if enough time has elapsed since the last success
+  /// \return true if enough time has elapsed since the last success, or it is the first time.
   bool IsReady(const gazebo::common::Time & _time);
 
 private:

--- a/gazebo_ros/include/gazebo_ros/utils.hpp
+++ b/gazebo_ros/include/gazebo_ros/utils.hpp
@@ -71,7 +71,7 @@ public:
 
 private:
   /// The time between calls to @IsReady returning true
-  gazebo::common::Time period_;
+  double period_;
   /// The last time @IsReady returned true
   gazebo::common::Time last_time_;
 };

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -23,6 +23,7 @@
 
   <build_depend>rclcpp</build_depend>
   <build_depend>gazebo_dev</build_depend>
+  <build_depend>geometry_msgs</build_depend>
 
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>gazebo_dev</exec_depend>
@@ -30,7 +31,6 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <build_depend>geometry_msgs</build_depend>
   <test_depend>std_msgs</test_depend>
 
   <export>

--- a/gazebo_ros/src/gazebo_ros_init.cpp
+++ b/gazebo_ros/src/gazebo_ros_init.cpp
@@ -58,7 +58,8 @@ void GazeboRosInit::Load(int argc, char ** argv)
   // the simulation is paused), late subscribers can receive the previously published message(s).
   rmw_qos_profile_t qos_profile = rmw_qos_profile_default;
   qos_profile.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
-  impl_->clock_pub_ = impl_->ros_node_->create_publisher<rosgraph_msgs::msg::Clock>("/clock",
+  impl_->clock_pub_ = impl_->ros_node_->create_publisher<rosgraph_msgs::msg::Clock>(
+    "/clock",
     qos_profile);
 
   // Get publish rate from parameter if set

--- a/gazebo_ros/src/gazebo_ros_init.cpp
+++ b/gazebo_ros/src/gazebo_ros_init.cpp
@@ -53,7 +53,13 @@ void GazeboRosInit::Load(int argc, char ** argv)
   rclcpp::init(argc, argv);
 
   impl_->ros_node_ = gazebo_ros::Node::Create("gazebo_ros_clock");
-  impl_->clock_pub_ = impl_->ros_node_->create_publisher<rosgraph_msgs::msg::Clock>("/clock");
+
+  // Offer transient local durability on the clock topic so that if publishing is infrequent (e.g.
+  // the simulation is paused), late subscribers can receive the previously published message(s).
+  rmw_qos_profile_t qos_profile = rmw_qos_profile_default;
+  qos_profile.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+  impl_->clock_pub_ = impl_->ros_node_->create_publisher<rosgraph_msgs::msg::Clock>("/clock",
+    qos_profile);
 
   // Get publish rate from parameter if set
   rclcpp::Parameter rate_param;

--- a/gazebo_ros/src/gazebo_ros_init.cpp
+++ b/gazebo_ros/src/gazebo_ros_init.cpp
@@ -14,11 +14,11 @@
 
 #include "gazebo_ros/gazebo_ros_init.hpp"
 
+#include <gazebo/common/Plugin.hh>
+#include <gazebo_ros/conversions.hpp>
 #include <gazebo_ros/node.hpp>
 #include <gazebo_ros/utils.hpp>
-#include <gazebo_ros/conversions.hpp>
 #include <rosgraph_msgs/msg/clock.hpp>
-#include <gazebo/common/Plugin.hh>
 
 #include <memory>
 

--- a/gazebo_ros/src/utils.cpp
+++ b/gazebo_ros/src/utils.cpp
@@ -60,4 +60,30 @@ std::string SensorFrameID(const gazebo::sensors::Sensor & _sensor, const sdf::El
   return gazebo_ros::ScopedNameBase(_sensor.ParentName());
 }
 
+Throttler::Throttler(const gazebo::common::Time & _period)
+: period_(_period),
+  last_time_(0, 0)
+{
+}
+
+Throttler::Throttler(const double _hz)
+: Throttler(gazebo::common::Time(1.0 / _hz))
+{
+}
+
+bool Throttler::IsReady(const gazebo::common::Time & _now)
+{
+  if (_now < last_time_) {
+    last_time_ = _now;
+    return true;
+  }
+
+  if (_now - last_time_ < period_) {
+    return false;
+  }
+
+  last_time_ = _now;
+  return true;
+}
+
 }  // namespace gazebo_ros

--- a/gazebo_ros/src/utils.cpp
+++ b/gazebo_ros/src/utils.cpp
@@ -60,28 +60,26 @@ std::string SensorFrameID(const gazebo::sensors::Sensor & _sensor, const sdf::El
   return gazebo_ros::ScopedNameBase(_sensor.ParentName());
 }
 
-Throttler::Throttler(const gazebo::common::Time & _period)
-: period_(_period),
-  last_time_(0, 0)
-{
-}
-
 Throttler::Throttler(const double _hz)
-: Throttler(gazebo::common::Time(1.0 / _hz))
+: period_(gazebo::common::Time(1.0 / _hz)),
+  last_time_(0, 0)
 {
 }
 
 bool Throttler::IsReady(const gazebo::common::Time & _now)
 {
+  // If time went backwords, reset
   if (_now < last_time_) {
     last_time_ = _now;
     return true;
   }
 
+  // If not enough time has passed, return false
   if (_now - last_time_ < period_) {
     return false;
   }
 
+  // Enough time has passed, set last time to now and return true
   last_time_ = _now;
   return true;
 }

--- a/gazebo_ros/src/utils.cpp
+++ b/gazebo_ros/src/utils.cpp
@@ -61,21 +61,21 @@ std::string SensorFrameID(const gazebo::sensors::Sensor & _sensor, const sdf::El
 }
 
 Throttler::Throttler(const double _hz)
-: period_(gazebo::common::Time(1.0 / _hz)),
+: period_(1.0 / _hz),
   last_time_(0, 0)
 {
 }
 
 bool Throttler::IsReady(const gazebo::common::Time & _now)
 {
-  // If time went backwords, reset
+  // If time went backwards, reset
   if (_now < last_time_) {
     last_time_ = _now;
     return true;
   }
 
   // If not enough time has passed, return false
-  if (_now - last_time_ < period_) {
+  if (period_ > 0 && (_now - last_time_).Double() < period_) {
     return false;
   }
 

--- a/gazebo_ros/test/CMakeLists.txt
+++ b/gazebo_ros/test/CMakeLists.txt
@@ -29,6 +29,7 @@ set(tests
   test_conversions
   test_utils
   test_plugins
+  test_sim_time
 )
 
 foreach(test ${tests})

--- a/gazebo_ros/test/test_sim_time.cpp
+++ b/gazebo_ros/test/test_sim_time.cpp
@@ -1,0 +1,75 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <gazebo_ros/testing_utils.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rosgraph_msgs/msg/clock.hpp>
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+/// Tests the simtime published to /clock by gazebo_ros_init
+class TestSimTime : public ::testing::Test
+{
+public:
+  TestSimTime() {}
+  void SetUp() override;
+  void TearDown() override;
+
+protected:
+  std::unique_ptr<gazebo_ros::GazeboProcess> gazebo_process_;
+};
+
+void TestSimTime::SetUp()
+{
+  gazebo_process_ = std::make_unique<gazebo_ros::GazeboProcess>(std::vector<const char *>{"-s",
+        "libgazebo_ros_init.so"});
+  ASSERT_GT(gazebo_process_->Run(), 0);
+}
+
+void TestSimTime::TearDown()
+{
+  ASSERT_GE(gazebo_process_->Terminate(), 0);
+  gazebo_process_.reset();
+}
+
+TEST_F(TestSimTime, TestClock)
+{
+  auto node = std::make_shared<rclcpp::Node>("my_node");
+  rclcpp::Clock clock;
+
+  using ClockMsg = rosgraph_msgs::msg::Clock;
+
+  auto first_msg =
+    gazebo_ros::get_message_or_timeout<ClockMsg>(node, "/clock", rclcpp::Duration(5, 0));
+  ASSERT_NE(first_msg, nullptr);
+  auto first_msg_time = clock.now();
+
+  auto second_msg =
+    gazebo_ros::get_message_or_timeout<ClockMsg>(node, "/clock", rclcpp::Duration(5, 0));
+  ASSERT_NE(second_msg, nullptr);
+  auto second_msg_time = clock.now();
+
+  ASSERT_GT(second_msg, first_msg);
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/gazebo_ros/test/test_utils.cpp
+++ b/gazebo_ros/test/test_utils.cpp
@@ -92,6 +92,40 @@ TEST(TestUtils, SensorFrameID)
   }
 }
 
+TEST(TestUtils, Throttler)
+{
+  using Time = gazebo::common::Time;
+  using Throttler = gazebo_ros::Throttler;
+  {
+    // Test negative period (always ready)
+    Throttler t(-1);
+    EXPECT_TRUE(t.IsReady(Time()));
+    EXPECT_TRUE(t.IsReady(Time(50, 0)));
+    EXPECT_TRUE(t.IsReady(Time(20, 0)));
+    EXPECT_TRUE(t.IsReady(Time(1E3, 0)));
+  }
+  {
+    // Test frequency
+    Throttler t(2.0);
+    EXPECT_FALSE(t.IsReady(Time(0, 4E8)));
+    EXPECT_TRUE(t.IsReady(Time(0, 6E8)));
+    EXPECT_TRUE(t.IsReady(Time(1E4, 0)));
+    EXPECT_FALSE(t.IsReady(Time(1E4, 4E8)));
+    EXPECT_TRUE(t.IsReady(Time(1E4, 6E8)));
+  }
+  {
+    // Test period
+    Time period(1, 1E3);
+    Throttler t(period);
+    EXPECT_FALSE(t.IsReady(Time()));
+    EXPECT_FALSE(t.IsReady(period - Time(0, 1)));
+    Time new_time = period;
+    EXPECT_TRUE(t.IsReady(new_time));
+    EXPECT_FALSE(t.IsReady(new_time + period - Time(0, 1)));
+    EXPECT_TRUE(t.IsReady(new_time + period));
+  }
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/gazebo_ros/test/test_utils.cpp
+++ b/gazebo_ros/test/test_utils.cpp
@@ -107,22 +107,12 @@ TEST(TestUtils, Throttler)
   {
     // Test frequency
     Throttler t(2.0);
-    EXPECT_FALSE(t.IsReady(Time(0, 4E8)));
     EXPECT_TRUE(t.IsReady(Time(0, 6E8)));
+    EXPECT_FALSE(t.IsReady(Time(0, 7E8)));
+    EXPECT_FALSE(t.IsReady(Time(0, 8E8)));
     EXPECT_TRUE(t.IsReady(Time(1E4, 0)));
-    EXPECT_FALSE(t.IsReady(Time(1E4, 4E8)));
     EXPECT_TRUE(t.IsReady(Time(1E4, 6E8)));
-  }
-  {
-    // Test period
-    Time period(1, 1E3);
-    Throttler t(period);
-    EXPECT_FALSE(t.IsReady(Time()));
-    EXPECT_FALSE(t.IsReady(period - Time(0, 1)));
-    Time new_time = period;
-    EXPECT_TRUE(t.IsReady(new_time));
-    EXPECT_FALSE(t.IsReady(new_time + period - Time(0, 1)));
-    EXPECT_TRUE(t.IsReady(new_time + period));
+    EXPECT_FALSE(t.IsReady(Time(1E4, 9E8)));
   }
 }
 


### PR DESCRIPTION
* Add a Throttler class to utils, something that can be reused in a few places
* Add publishing sim time to /clock in gazebo_ros_init
  * The time of a simulation starts at 0.
  * Subscribers that have transient local durability specified in [their QoS settings](https://github.com/ros2/ros2/wiki/About-Quality-of-Service-Settings) will be able to receive the previously-published time message(s) even if the simulation is paused (up to the queue depth of 10).

Usage:
```
$ ros2 launch gazebo_ros empty_world.launch.py
```
```
$ ros2 topic echo /clock
clock:
  sec: 7
  nanosec: 507000000
```

Wiki: https://github.com/ros-simulation/gazebo_ros_pkgs/wiki/ROS-2-Migration:-ROS-Clocks-and-sim-time
