### PR TITLE
Publish camera info in gazebo_ros_depth_camera plugin

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
@@ -218,6 +218,7 @@ void GazeboRosDepthCamera::OnNewDepthFrame(const float *_image,
       // do this first so there's chance for sensor to run 1 frame after activate
       this->parentSensor->SetActive(true);
   }
+  PublishCameraInfo();
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
`PublishCameraInfo()` function was created but it wasn't used. I needed camera info to be published. It might be useful for other people too. 

Thanks for review.