### PR TITLE
[ros2] Add noise to imu test

### DIFF
--- a/gazebo_plugins/test/test_gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_imu_sensor.cpp
@@ -63,9 +63,9 @@ TEST_F(GazeboRosImuSensorTest, ImuMessageCorrect)
   ASSERT_NE(nullptr, pre_movement_msg);
   auto pre_movement_yaw =
     gazebo_ros::Convert<ignition::math::Quaterniond>(pre_movement_msg->orientation).Euler().Z();
-  EXPECT_LT(pre_movement_yaw, 1e-9);
-  EXPECT_LT(pre_movement_msg->linear_acceleration.x, 1e-9);
-  EXPECT_LT(pre_movement_msg->angular_velocity.z, 1e-9);
+  EXPECT_LT(pre_movement_yaw, 0.1);
+  EXPECT_LT(pre_movement_msg->linear_acceleration.x, 0.5);
+  EXPECT_LT(pre_movement_msg->angular_velocity.z, 0.1);
 
   // Apply a force + torque and collect a new message
   for (unsigned int i = 0; i < 5; i++) {
@@ -83,8 +83,8 @@ TEST_F(GazeboRosImuSensorTest, ImuMessageCorrect)
     gazebo_ros::Convert<ignition::math::Quaterniond>(post_movement_msg->orientation).Euler().Z();
   EXPECT_GT(post_movement_yaw, 0.1);
   // The linear acceleration reported by Gazebo flips signs, so we take the absolute value
-  EXPECT_GT(std::abs(post_movement_msg->linear_acceleration.x), 0.1);
-  EXPECT_GT(post_movement_msg->angular_velocity.z, 0.1);
+  EXPECT_GT(std::abs(post_movement_msg->linear_acceleration.x), 1.0);
+  EXPECT_GT(post_movement_msg->angular_velocity.z, 1.0);
 }
 
 int main(int argc, char ** argv)

--- a/gazebo_plugins/test/worlds/gazebo_ros_imu_sensor.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_imu_sensor.world
@@ -33,24 +33,18 @@
                 <noise type="gaussian">
                   <mean>0.0</mean>
                   <stddev>2e-4</stddev>
-                  <bias_mean>0.0000075</bias_mean>
-                  <bias_stddev>0.0000008</bias_stddev>
                 </noise>
               </x>
               <y>
                 <noise type="gaussian">
                   <mean>0.0</mean>
                   <stddev>2e-4</stddev>
-                  <bias_mean>0.0000075</bias_mean>
-                  <bias_stddev>0.0000008</bias_stddev>
                 </noise>
               </y>
               <z>
                 <noise type="gaussian">
                   <mean>0.0</mean>
                   <stddev>2e-4</stddev>
-                  <bias_mean>0.0000075</bias_mean>
-                  <bias_stddev>0.0000008</bias_stddev>
                 </noise>
               </z>
             </angular_velocity>
@@ -59,24 +53,18 @@
                 <noise type="gaussian">
                   <mean>0.0</mean>
                   <stddev>1.7e-2</stddev>
-                  <bias_mean>0.1</bias_mean>
-                  <bias_stddev>0.001</bias_stddev>
                 </noise>
               </x>
               <y>
                 <noise type="gaussian">
                   <mean>0.0</mean>
                   <stddev>1.7e-2</stddev>
-                  <bias_mean>0.1</bias_mean>
-                  <bias_stddev>0.001</bias_stddev>
                 </noise>
               </y>
               <z>
                 <noise type="gaussian">
                   <mean>0.0</mean>
                   <stddev>1.7e-2</stddev>
-                  <bias_mean>0.1</bias_mean>
-                  <bias_stddev>0.001</bias_stddev>
                 </noise>
               </z>
             </linear_acceleration>

--- a/gazebo_plugins/test/worlds/gazebo_ros_imu_sensor.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_imu_sensor.world
@@ -27,6 +27,60 @@
         <sensor name="my_imu" type="imu">
           <always_on>true</always_on>
           <update_rate>30</update_rate>
+          <imu>
+            <angular_velocity>
+              <x>
+                <noise type="gaussian">
+                  <mean>0.0</mean>
+                  <stddev>2e-4</stddev>
+                  <bias_mean>0.0000075</bias_mean>
+                  <bias_stddev>0.0000008</bias_stddev>
+                </noise>
+              </x>
+              <y>
+                <noise type="gaussian">
+                  <mean>0.0</mean>
+                  <stddev>2e-4</stddev>
+                  <bias_mean>0.0000075</bias_mean>
+                  <bias_stddev>0.0000008</bias_stddev>
+                </noise>
+              </y>
+              <z>
+                <noise type="gaussian">
+                  <mean>0.0</mean>
+                  <stddev>2e-4</stddev>
+                  <bias_mean>0.0000075</bias_mean>
+                  <bias_stddev>0.0000008</bias_stddev>
+                </noise>
+              </z>
+            </angular_velocity>
+            <linear_acceleration>
+              <x>
+                <noise type="gaussian">
+                  <mean>0.0</mean>
+                  <stddev>1.7e-2</stddev>
+                  <bias_mean>0.1</bias_mean>
+                  <bias_stddev>0.001</bias_stddev>
+                </noise>
+              </x>
+              <y>
+                <noise type="gaussian">
+                  <mean>0.0</mean>
+                  <stddev>1.7e-2</stddev>
+                  <bias_mean>0.1</bias_mean>
+                  <bias_stddev>0.001</bias_stddev>
+                </noise>
+              </y>
+              <z>
+                <noise type="gaussian">
+                  <mean>0.0</mean>
+                  <stddev>1.7e-2</stddev>
+                  <bias_mean>0.1</bias_mean>
+                  <bias_stddev>0.001</bias_stddev>
+                </noise>
+              </z>
+            </linear_acceleration>
+          </imu>
           <plugin name="my_imu_plugin" filename="libgazebo_ros_imu_sensor.so">
             <ros>
               <namespace>/imu</namespace>


### PR DESCRIPTION
See https://github.com/ros-simulation/gazebo_ros_pkgs/issues/799

It turns out that the noise is being loaded correctly, it was a local issue

Let's double-check when CI is done:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5068)](http://ci.ros2.org/job/ci_linux/5068/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1861)](http://ci.ros2.org/job/ci_linux-aarch64/1861/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4208)](http://ci.ros2.org/job/ci_osx/4208/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5059)](http://ci.ros2.org/job/ci_windows/5059/)
