### PR TITLE
[ros2] Split conversions into headers specific to message packages

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_force.cpp
+++ b/gazebo_plugins/src/gazebo_ros_force.cpp
@@ -16,7 +16,7 @@
 #include <gazebo/physics/Link.hh>
 #include <gazebo/physics/Model.hh>
 #include <gazebo_plugins/gazebo_ros_force.hpp>
-#include <gazebo_ros/conversions.hpp>
+#include <gazebo_ros/conversions/geometry_msgs.hpp>
 #include <gazebo_ros/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 

--- a/gazebo_plugins/src/gazebo_ros_force.cpp
+++ b/gazebo_plugins/src/gazebo_ros_force.cpp
@@ -18,6 +18,7 @@
 #include <gazebo_plugins/gazebo_ros_force.hpp>
 #include <gazebo_ros/conversions/geometry_msgs.hpp>
 #include <gazebo_ros/node.hpp>
+#include <geometry_msgs/msg/wrench.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <memory>

--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -13,10 +13,13 @@
 // limitations under the License.
 
 
+#include <builtin_interfaces/msg/time.hpp>
 #include <gazebo_plugins/gazebo_ros_imu_sensor.hpp>
 #include <gazebo_ros/conversions/builtin_interfaces.hpp>
 #include <gazebo_ros/conversions/geometry_msgs.hpp>
 #include <gazebo_ros/utils.hpp>
+#include <geometry_msgs/msg/quaternion.hpp>
+#include <sensor_msgs/msg/imu.hpp>
 
 #include <iostream>
 #include <memory>

--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -14,7 +14,8 @@
 
 
 #include <gazebo_plugins/gazebo_ros_imu_sensor.hpp>
-#include <gazebo_ros/conversions.hpp>
+#include <gazebo_ros/conversions/builtin_interfaces.hpp>
+#include <gazebo_ros/conversions/geometry_msgs.hpp>
 #include <gazebo_ros/utils.hpp>
 
 #include <iostream>

--- a/gazebo_plugins/src/gazebo_ros_joint_state_publisher.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_state_publisher.cpp
@@ -36,7 +36,7 @@
 #include <gazebo/physics/Model.hh>
 #include <gazebo/physics/World.hh>
 #include <gazebo_plugins/gazebo_ros_joint_state_publisher.hpp>
-#include <gazebo_ros/conversions.hpp>
+#include <gazebo_ros/conversions/builtin_interfaces.hpp>
 #include <gazebo_ros/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>

--- a/gazebo_plugins/src/gazebo_ros_ray_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ray_sensor.cpp
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <boost/make_shared.hpp>
 #include <gazebo/transport/transport.hh>
 #include <gazebo_plugins/gazebo_ros_ray_sensor.hpp>
-#include <gazebo_ros/conversions.hpp>
+#include <gazebo_ros/conversions/sensor_msgs.hpp>
 #include <gazebo_ros/node.hpp>
 #include <gazebo_ros/utils.hpp>
 #include <rclcpp/rclcpp.hpp>

--- a/gazebo_plugins/test/test_gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_imu_sensor.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <gazebo/test/ServerFixture.hh>
-#include <gazebo_ros/conversions.hpp>
+#include <gazebo_ros/conversions/geometry_msgs.hpp>
 #include <gazebo_ros/node.hpp>
 #include <gazebo_ros/testing_utils.hpp>
 #include <rclcpp/rclcpp.hpp>

--- a/gazebo_plugins/test/test_gazebo_ros_ray_sensor.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_ray_sensor.cpp
@@ -20,7 +20,8 @@
 #include <sensor_msgs/msg/point_cloud.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/msg/range.hpp>
-#include <gazebo_ros/conversions.hpp>
+#include <gazebo_ros/conversions/geometry_msgs.hpp>
+#include <gazebo_ros/conversions/sensor_msgs.hpp>
 
 #include <memory>
 #include <vector>

--- a/gazebo_plugins/test/test_gazebo_ros_ray_sensor.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_ray_sensor.cpp
@@ -15,13 +15,13 @@
 #include <gazebo/common/Time.hh>
 #include <gazebo/common/Events.hh>
 #include <gazebo/test/ServerFixture.hh>
+#include <gazebo_ros/conversions/geometry_msgs.hpp>
+#include <gazebo_ros/conversions/sensor_msgs.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
 #include <sensor_msgs/msg/point_cloud.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/msg/range.hpp>
-#include <gazebo_ros/conversions/geometry_msgs.hpp>
-#include <gazebo_ros/conversions/sensor_msgs.hpp>
 
 #include <memory>
 #include <vector>

--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -13,9 +13,9 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(builtin_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(gazebo_dev REQUIRED)
-find_package(geometry_msgs REQUIRED)
 
 include_directories(
   include
@@ -27,8 +27,8 @@ add_library(gazebo_ros_node SHARED
   src/node.cpp
 )
 ament_target_dependencies(gazebo_ros_node
-  "rclcpp"
   "gazebo_dev"
+  "rclcpp"
 )
 ament_export_libraries(gazebo_ros_node)
 
@@ -36,8 +36,8 @@ add_library(gazebo_ros_utils SHARED
   src/utils.cpp
 )
 ament_target_dependencies(gazebo_ros_utils
-  "rclcpp"
   "gazebo_dev"
+  "rclcpp"
 )
 ament_export_libraries(gazebo_ros_utils)
 
@@ -45,9 +45,9 @@ add_library(gazebo_ros_init SHARED
   src/gazebo_ros_init.cpp
 )
 ament_target_dependencies(gazebo_ros_init
-  "rclcpp"
+  "builtin_interfaces"
   "gazebo_dev"
-  "geometry_msgs"
+  "rclcpp"
 )
 target_link_libraries(gazebo_ros_init
   gazebo_ros_node

--- a/gazebo_ros/include/gazebo_ros/conversions/builtin_interfaces.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/builtin_interfaces.hpp
@@ -15,11 +15,12 @@
 #ifndef GAZEBO_ROS__CONVERSIONS__BUILTIN_INTERFACES_HPP_
 #define GAZEBO_ROS__CONVERSIONS__BUILTIN_INTERFACES_HPP_
 
-#include "gazebo_ros/conversions/generic.hpp"
+#include <gazebo/msgs/time.pb.h>
 
 #include <builtin_interfaces/msg/time.hpp>
 #include <gazebo/common/Time.hh>
-#include <gazebo/msgs/time.pb.h>
+
+#include "gazebo_ros/conversions/generic.hpp"
 
 namespace gazebo_ros
 {

--- a/gazebo_ros/include/gazebo_ros/conversions/builtin_interfaces.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/builtin_interfaces.hpp
@@ -1,0 +1,53 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GAZEBO_ROS__CONVERSIONS__BUILTIN_INTERFACES_HPP_
+#define GAZEBO_ROS__CONVERSIONS__BUILTIN_INTERFACES_HPP_
+
+#include "gazebo_ros/conversions/generic.hpp"
+
+#include <builtin_interfaces/msg/time.hpp>
+#include <gazebo/common/Time.hh>
+
+namespace gazebo_ros
+{
+namespace conversions
+{
+/// \brief Specialized conversion from an Gazebo Time to a ROS Time message.
+/// \param[in] in Gazebo Time to convert.
+/// \return A ROS Time message with the same value as in
+template<>
+builtin_interfaces::msg::Time Convert(const gazebo::common::Time & in)
+{
+  builtin_interfaces::msg::Time time;
+  time.sec = in.sec;
+  time.nanosec = in.nsec;
+  return time;
+}
+
+/// \brief Specialized conversion from an Gazebo Time message to a ROS Time message.
+/// \param[in] in Gazebo Time message to convert.
+/// \return A ROS Time message with the same value as in
+template<>
+builtin_interfaces::msg::Time Convert(const gazebo::msgs::Time & in)
+{
+  builtin_interfaces::msg::Time time;
+  time.sec = in.sec();
+  time.nanosec = in.nsec();
+  return time;
+}
+
+}  // namespace conversions
+}  // namespace gazebo_ros
+#endif  // GAZEBO_ROS__CONVERSIONS__BUILTIN_INTERFACES_HPP_

--- a/gazebo_ros/include/gazebo_ros/conversions/builtin_interfaces.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/builtin_interfaces.hpp
@@ -22,8 +22,6 @@
 
 namespace gazebo_ros
 {
-namespace conversions
-{
 /// \brief Specialized conversion from an Gazebo Time to a ROS Time message.
 /// \param[in] in Gazebo Time to convert.
 /// \return A ROS Time message with the same value as in
@@ -48,6 +46,5 @@ builtin_interfaces::msg::Time Convert(const gazebo::msgs::Time & in)
   return time;
 }
 
-}  // namespace conversions
 }  // namespace gazebo_ros
 #endif  // GAZEBO_ROS__CONVERSIONS__BUILTIN_INTERFACES_HPP_

--- a/gazebo_ros/include/gazebo_ros/conversions/builtin_interfaces.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/builtin_interfaces.hpp
@@ -19,6 +19,7 @@
 
 #include <builtin_interfaces/msg/time.hpp>
 #include <gazebo/common/Time.hh>
+#include <gazebo/msgs/time.pb.h>
 
 namespace gazebo_ros
 {

--- a/gazebo_ros/include/gazebo_ros/conversions/generic.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/generic.hpp
@@ -25,8 +25,6 @@
 
 namespace gazebo_ros
 {
-namespace conversions
-{
 /// \brief Common logger for all conversions
 static rclcpp::Logger conversions_logger = rclcpp::get_logger("gazebo_ros_conversions");
 
@@ -79,6 +77,5 @@ OUT Convert(const gazebo::msgs::Time & in)
   return OUT();
 }
 
-}  // namespace conversions
 }  // namespace gazebo_ros
 #endif  // GAZEBO_ROS__CONVERSIONS__GENERIC_HPP_

--- a/gazebo_ros/include/gazebo_ros/conversions/generic.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/generic.hpp
@@ -18,6 +18,7 @@
 #include <math.h>
 
 #include <gazebo/common/Time.hh>
+#include <gazebo/msgs/time.pb.h>
 #include <ignition/math/Quaternion.hh>
 #include <ignition/math/Vector3.hh>
 #include <rclcpp/logging.hpp>

--- a/gazebo_ros/include/gazebo_ros/conversions/generic.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/generic.hpp
@@ -1,0 +1,84 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GAZEBO_ROS__CONVERSIONS__GENERIC_HPP_
+#define GAZEBO_ROS__CONVERSIONS__GENERIC_HPP_
+
+#include <math.h>
+
+#include <gazebo/common/Time.hh>
+#include <ignition/math/Quaternion.hh>
+#include <ignition/math/Vector3.hh>
+#include <rclcpp/logging.hpp>
+#include <rclcpp/time.hpp>
+
+namespace gazebo_ros
+{
+namespace conversions
+{
+/// \brief Common logger for all conversions
+static rclcpp::Logger conversions_logger = rclcpp::get_logger("gazebo_ros_conversions");
+
+/// Generic conversion from an Ignition Math vector to another type.
+/// \param[in] in Input vector.
+/// \return Conversion result
+/// \tparam OUT Output type
+template<class OUT>
+OUT Convert(const ignition::math::Vector3d & in)
+{
+  return OUT();
+}
+
+/// Generic conversion from an Ignition Math quaternion to another type.
+/// \param[in] in Input quaternion
+/// \return Conversion result
+/// \tparam OUT Output type
+template<class OUT>
+OUT Convert(const ignition::math::Quaterniond & in)
+{
+  return OUT();
+}
+
+/// Generic conversion from an Gazebo Time object to another type.
+/// \param[in] in Input time;
+/// \return Conversion result
+/// \tparam OUT Output type
+template<class OUT>
+OUT Convert(const gazebo::common::Time & in)
+{
+  return OUT();
+}
+
+/// \brief Specialized conversion from an Gazebo Time to a RCLCPP Time.
+/// \param[in] in Gazebo Time to convert.
+/// \return A rclcpp::Time object with the same value as in
+template<>
+rclcpp::Time Convert(const gazebo::common::Time & in)
+{
+  return rclcpp::Time(in.sec, in.nsec, rcl_clock_type_t::RCL_ROS_TIME);
+}
+
+/// Generic conversion from an Gazebo Time message to another type.
+/// \param[in] in Input time
+/// \return Conversion result
+/// \tparam OUT Output type
+template<class OUT>
+OUT Convert(const gazebo::msgs::Time & in)
+{
+  return OUT();
+}
+
+}  // namespace conversions
+}  // namespace gazebo_ros
+#endif  // GAZEBO_ROS__CONVERSIONS__GENERIC_HPP_

--- a/gazebo_ros/include/gazebo_ros/conversions/geometry_msgs.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/geometry_msgs.hpp
@@ -1,0 +1,115 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GAZEBO_ROS__CONVERSIONS__GEOMETRY_MSGS_HPP_
+#define GAZEBO_ROS__CONVERSIONS__GEOMETRY_MSGS_HPP_
+
+#include "gazebo_ros/conversions/generic.hpp"
+
+#include <geometry_msgs/msg/point32.hpp>
+#include <geometry_msgs/msg/quaternion.hpp>
+#include <geometry_msgs/msg/vector3.hpp>
+#include <ignition/math/Quaternion.hh>
+#include <ignition/math/Vector3.hh>
+
+namespace gazebo_ros
+{
+namespace conversions
+{
+
+/// \brief Specialized conversion from a ROS vector message to an Ignition Math vector.
+/// \param[in] msg ROS message to convert.
+/// \return An Ignition Math vector.
+template<>
+ignition::math::Vector3d Convert(const geometry_msgs::msg::Vector3 & msg)
+{
+  ignition::math::Vector3d vec;
+  vec.X(msg.x);
+  vec.Y(msg.y);
+  vec.Z(msg.z);
+  return vec;
+}
+
+/// Generic conversion from a ROS geometry point message to another type.
+/// \param[in] in Input message.
+/// \return Conversion result
+/// \tparam OUT Output type
+template<class OUT>
+OUT Convert(const geometry_msgs::msg::Point32 & in)
+{
+  return OUT();
+}
+
+/// \brief Specialized conversion from a ROS point message to an Ignition Math vector.
+/// \param[in] in ROS message to convert.
+/// \return An Ignition Math vector.
+template<>
+ignition::math::Vector3d Convert(const geometry_msgs::msg::Point32 & in)
+{
+  ignition::math::Vector3d vec;
+  vec.X(in.x);
+  vec.Y(in.y);
+  vec.Z(in.z);
+  return vec;
+}
+
+/// \brief Specialized conversion from an Ignition Math vector to a ROS message.
+/// \param[in] vec Ignition vector to convert.
+/// \return ROS geometry vector message
+template<>
+geometry_msgs::msg::Vector3 Convert(const ignition::math::Vector3d & vec)
+{
+  geometry_msgs::msg::Vector3 msg;
+  msg.x = vec.X();
+  msg.y = vec.Y();
+  msg.z = vec.Z();
+  return msg;
+}
+
+/// \brief Specialized conversion from an Ignition Math Quaternion to a ROS message.
+/// \param[in] in Ignition Quaternion to convert.
+/// \return ROS geometry quaternion message
+template<>
+geometry_msgs::msg::Quaternion Convert(const ignition::math::Quaterniond & in)
+{
+  geometry_msgs::msg::Quaternion msg;
+  msg.x = in.X();
+  msg.y = in.Y();
+  msg.z = in.Z();
+  msg.w = in.W();
+  return msg;
+}
+
+/// Generic conversion from a ROS Quaternion message to another type
+/// \param[in] in Input quaternion
+/// \return Conversion result
+/// \tparam OUT Output type
+template<class OUT>
+OUT Convert(const geometry_msgs::msg::Quaternion & in)
+{
+  return OUT();
+}
+
+/// \brief Specialized conversion from a ROS quaternion message to ignition quaternion
+/// \param[in] in Input quaternion message
+/// \return Ignition math quaternion with same values as the input message
+template<>
+ignition::math::Quaterniond Convert(const geometry_msgs::msg::Quaternion & in)
+{
+  return ignition::math::Quaterniond(in.w, in.x, in.y, in.z);
+}
+
+}  // namespace conversions
+}  // namespace gazebo_ros
+#endif  // GAZEBO_ROS__CONVERSIONS__GEOMETRY_MSGS_HPP_

--- a/gazebo_ros/include/gazebo_ros/conversions/geometry_msgs.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/geometry_msgs.hpp
@@ -25,8 +25,6 @@
 
 namespace gazebo_ros
 {
-namespace conversions
-{
 
 /// \brief Specialized conversion from a ROS vector message to an Ignition Math vector.
 /// \param[in] msg ROS message to convert.
@@ -110,6 +108,5 @@ ignition::math::Quaterniond Convert(const geometry_msgs::msg::Quaternion & in)
   return ignition::math::Quaterniond(in.w, in.x, in.y, in.z);
 }
 
-}  // namespace conversions
 }  // namespace gazebo_ros
 #endif  // GAZEBO_ROS__CONVERSIONS__GEOMETRY_MSGS_HPP_

--- a/gazebo_ros/include/gazebo_ros/conversions/geometry_msgs.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/geometry_msgs.hpp
@@ -15,13 +15,13 @@
 #ifndef GAZEBO_ROS__CONVERSIONS__GEOMETRY_MSGS_HPP_
 #define GAZEBO_ROS__CONVERSIONS__GEOMETRY_MSGS_HPP_
 
-#include "gazebo_ros/conversions/generic.hpp"
-
 #include <geometry_msgs/msg/point32.hpp>
 #include <geometry_msgs/msg/quaternion.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
 #include <ignition/math/Quaternion.hh>
 #include <ignition/math/Vector3.hh>
+
+#include "gazebo_ros/conversions/generic.hpp"
 
 namespace gazebo_ros
 {

--- a/gazebo_ros/include/gazebo_ros/conversions/geometry_msgs.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/geometry_msgs.hpp
@@ -26,6 +26,16 @@
 namespace gazebo_ros
 {
 
+/// Generic conversion from a ROS geometry vector message to another type.
+/// \param[in] in Input message.
+/// \return Conversion result
+/// \tparam OUT Output type
+template<class OUT>
+OUT Convert(const geometry_msgs::msg::Vector3 & in)
+{
+  return OUT();
+}
+
 /// \brief Specialized conversion from a ROS vector message to an Ignition Math vector.
 /// \param[in] msg ROS message to convert.
 /// \return An Ignition Math vector.

--- a/gazebo_ros/include/gazebo_ros/conversions/sensor_msgs.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/sensor_msgs.hpp
@@ -12,21 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GAZEBO_ROS__CONVERSIONS_HPP_
-#define GAZEBO_ROS__CONVERSIONS_HPP_
+#ifndef GAZEBO_ROS__CONVERSIONS__SENSOR_MSGS_HPP_
+#define GAZEBO_ROS__CONVERSIONS__SENSOR_MSGS_HPP_
 
 #include <math.h>
+#include "gazebo_ros/conversions/builtin_interfaces.hpp"
+#include "gazebo_ros/conversions/generic.hpp"
 
-#include <builtin_interfaces/msg/time.hpp>
-#include <gazebo/common/Time.hh>
 #include <gazebo/msgs/laserscan_stamped.pb.h>
 #include <geometry_msgs/msg/point32.hpp>
-#include <geometry_msgs/msg/quaternion.hpp>
-#include <geometry_msgs/msg/vector3.hpp>
-#include <ignition/math/Quaternion.hh>
-#include <ignition/math/Vector3.hh>
 #include <rclcpp/logging.hpp>
-#include <rclcpp/time.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/msg/point_cloud.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
@@ -37,179 +32,15 @@
 #include <sstream>  // NOLINT
 #include <sensor_msgs/point_cloud2_iterator.hpp>  // NOLINT
 
-#include <string>
 #include <algorithm>
 #include <limits>
 
 namespace gazebo_ros
 {
+namespace conversions
+{
 /// \brief Common logger for all conversions
 static rclcpp::Logger conversions_logger = rclcpp::get_logger("gazebo_ros_conversions");
-
-/// Generic conversion from a ROS geometry vector message to another type.
-/// \param[in] in Input message.
-/// \return Conversion result
-/// \tparam OUT Output type
-template<class OUT>
-OUT Convert(const geometry_msgs::msg::Vector3 & in)
-{
-  return OUT();
-}
-
-/// \brief Specialized conversion from a ROS vector message to an Ignition Math vector.
-/// \param[in] msg ROS message to convert.
-/// \return An Ignition Math vector.
-template<>
-ignition::math::Vector3d Convert(const geometry_msgs::msg::Vector3 & msg)
-{
-  ignition::math::Vector3d vec;
-  vec.X(msg.x);
-  vec.Y(msg.y);
-  vec.Z(msg.z);
-  return vec;
-}
-
-/// Generic conversion from a ROS geometry point message to another type.
-/// \param[in] in Input message.
-/// \return Conversion result
-/// \tparam OUT Output type
-template<class OUT>
-OUT Convert(const geometry_msgs::msg::Point32 & in)
-{
-  return OUT();
-}
-
-/// \brief Specialized conversion from a ROS point message to an Ignition Math vector.
-/// \param[in] in ROS message to convert.
-/// \return An Ignition Math vector.
-template<>
-ignition::math::Vector3d Convert(const geometry_msgs::msg::Point32 & in)
-{
-  ignition::math::Vector3d vec;
-  vec.X(in.x);
-  vec.Y(in.y);
-  vec.Z(in.z);
-  return vec;
-}
-
-/// Generic conversion from an Ignition Math vector to another type.
-/// \param[in] in Input vector.
-/// \return Conversion result
-/// \tparam OUT Output type
-template<class OUT>
-OUT Convert(const ignition::math::Vector3d & in)
-{
-  return OUT();
-}
-
-/// \brief Specialized conversion from an Ignition Math vector to a ROS message.
-/// \param[in] vec Ignition vector to convert.
-/// \return ROS geometry vector message
-template<>
-geometry_msgs::msg::Vector3 Convert(const ignition::math::Vector3d & vec)
-{
-  geometry_msgs::msg::Vector3 msg;
-  msg.x = vec.X();
-  msg.y = vec.Y();
-  msg.z = vec.Z();
-  return msg;
-}
-
-/// Generic conversion from an Ignition Math quaternion to another type.
-/// \param[in] in Input quaternion
-/// \return Conversion result
-/// \tparam OUT Output type
-template<class OUT>
-OUT Convert(const ignition::math::Quaterniond & in)
-{
-  return OUT();
-}
-
-/// \brief Specialized conversion from an Ignition Math Quaternion to a ROS message.
-/// \param[in] in Ignition Quaternion to convert.
-/// \return ROS geometry quaternion message
-template<>
-geometry_msgs::msg::Quaternion Convert(const ignition::math::Quaterniond & in)
-{
-  geometry_msgs::msg::Quaternion msg;
-  msg.x = in.X();
-  msg.y = in.Y();
-  msg.z = in.Z();
-  msg.w = in.W();
-  return msg;
-}
-
-/// Generic conversion from a ROS Quaternion message to another type
-/// \param[in] in Input quaternion
-/// \return Conversion result
-/// \tparam OUT Output type
-template<class OUT>
-OUT Convert(const geometry_msgs::msg::Quaternion & in)
-{
-  return OUT();
-}
-
-/// \brief Specialized conversion from a ROS quaternion message to ignition quaternion
-/// \param[in] in Input quaternion message
-/// \return Ignition math quaternion with same values as the input message
-template<>
-ignition::math::Quaterniond Convert(const geometry_msgs::msg::Quaternion & in)
-{
-  return ignition::math::Quaterniond(in.w, in.x, in.y, in.z);
-}
-
-/// Generic conversion from an Gazebo Time object to another type.
-/// \param[in] in Input time;
-/// \return Conversion result
-/// \tparam OUT Output type
-template<class OUT>
-OUT Convert(const gazebo::common::Time & in)
-{
-  return OUT();
-}
-
-/// \brief Specialized conversion from an Gazebo Time to a RCLCPP Time.
-/// \param[in] in Gazebo Time to convert.
-/// \return A rclcpp::Time object with the same value as in
-template<>
-rclcpp::Time Convert(const gazebo::common::Time & in)
-{
-  return rclcpp::Time(in.sec, in.nsec, rcl_clock_type_t::RCL_ROS_TIME);
-}
-
-/// \brief Specialized conversion from an Gazebo Time to a ROS Time message.
-/// \param[in] in Gazebo Time to convert.
-/// \return A ROS Time message with the same value as in
-template<>
-builtin_interfaces::msg::Time Convert(const gazebo::common::Time & in)
-{
-  builtin_interfaces::msg::Time time;
-  time.sec = in.sec;
-  time.nanosec = in.nsec;
-  return time;
-}
-
-/// Generic conversion from an Gazebo Time message to another type.
-/// \param[in] in Input time
-/// \return Conversion result
-/// \tparam OUT Output type
-template<class OUT>
-OUT Convert(const gazebo::msgs::Time & in)
-{
-  return OUT();
-}
-
-/// \brief Specialized conversion from an Gazebo Time message to a ROS Time message.
-/// \param[in] in Gazebo Time message to convert.
-/// \return A ROS Time message with the same value as in
-template<>
-builtin_interfaces::msg::Time Convert(const gazebo::msgs::Time & in)
-{
-  builtin_interfaces::msg::Time time;
-  time.sec = in.sec();
-  time.nanosec = in.nsec();
-  return time;
-}
 
 /// Generic conversion from an Gazebo Laser Scan message to another type.
 /// \param[in] in Input message;
@@ -485,5 +316,6 @@ sensor_msgs::msg::Range Convert(const gazebo::msgs::LaserScanStamped & in, doubl
   return range_msg;
 }
 
+}  // namespace conversions
 }  // namespace gazebo_ros
-#endif  // GAZEBO_ROS__CONVERSIONS_HPP_
+#endif  // GAZEBO_ROS__CONVERSIONS__SENSOR_MSGS_HPP_

--- a/gazebo_ros/include/gazebo_ros/conversions/sensor_msgs.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/sensor_msgs.hpp
@@ -16,8 +16,6 @@
 #define GAZEBO_ROS__CONVERSIONS__SENSOR_MSGS_HPP_
 
 #include <math.h>
-#include "gazebo_ros/conversions/builtin_interfaces.hpp"
-#include "gazebo_ros/conversions/generic.hpp"
 
 #include <gazebo/msgs/laserscan_stamped.pb.h>
 #include <geometry_msgs/msg/point32.hpp>
@@ -26,14 +24,13 @@
 #include <sensor_msgs/msg/point_cloud.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
 #include <sensor_msgs/msg/range.hpp>
-
-// Remove sstream and NOLINTs after the following patch is released:
-// https://github.com/ros2/common_interfaces/pull/54
-#include <sstream>  // NOLINT
-#include <sensor_msgs/point_cloud2_iterator.hpp>  // NOLINT
+#include <sensor_msgs/point_cloud2_iterator.hpp>
 
 #include <algorithm>
 #include <limits>
+
+#include "gazebo_ros/conversions/builtin_interfaces.hpp"
+#include "gazebo_ros/conversions/generic.hpp"
 
 namespace gazebo_ros
 {

--- a/gazebo_ros/include/gazebo_ros/conversions/sensor_msgs.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/sensor_msgs.hpp
@@ -37,8 +37,6 @@
 
 namespace gazebo_ros
 {
-namespace conversions
-{
 /// \brief Common logger for all conversions
 static rclcpp::Logger conversions_logger = rclcpp::get_logger("gazebo_ros_conversions");
 
@@ -316,6 +314,5 @@ sensor_msgs::msg::Range Convert(const gazebo::msgs::LaserScanStamped & in, doubl
   return range_msg;
 }
 
-}  // namespace conversions
 }  // namespace gazebo_ros
 #endif  // GAZEBO_ROS__CONVERSIONS__SENSOR_MSGS_HPP_

--- a/gazebo_ros/include/gazebo_ros/conversions/sensor_msgs.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/sensor_msgs.hpp
@@ -37,9 +37,6 @@
 
 namespace gazebo_ros
 {
-/// \brief Common logger for all conversions
-static rclcpp::Logger conversions_logger = rclcpp::get_logger("gazebo_ros_conversions");
-
 /// Generic conversion from an Gazebo Laser Scan message to another type.
 /// \param[in] in Input message;
 /// \param[in] min_intensity The minimum intensity value to clip the output intensities
@@ -118,7 +115,7 @@ sensor_msgs::msg::PointCloud Convert(
 
   // Gazebo sends an infinite vertical step if the number of samples is 1
   // Surprisingly, not setting the <vertical> tag results in nan instead of inf, which is ok
-  if (isinf(vertical_angle_step)) {
+  if (std::isinf(vertical_angle_step)) {
     RCLCPP_WARN_ONCE(conversions_logger, "Infinite angle step results in wrong PointCloud");
   }
 
@@ -154,7 +151,7 @@ sensor_msgs::msg::PointCloud Convert(
 
       double r = *range_iter;
       // Skip NaN / inf points
-      if (!isfinite(r)) {
+      if (!std::isfinite(r)) {
         continue;
       }
 
@@ -205,7 +202,7 @@ sensor_msgs::msg::PointCloud2 Convert(
 
   // Gazebo sends an infinite vertical step if the number of samples is 1
   // Surprisingly, not setting the <vertical> tag results in nan instead of inf, which is ok
-  if (isinf(vertical_angle_step)) {
+  if (std::isinf(vertical_angle_step)) {
     RCLCPP_WARN_ONCE(conversions_logger, "Infinite angle step results in wrong PointCloud2");
   }
 
@@ -251,7 +248,7 @@ sensor_msgs::msg::PointCloud2 Convert(
 
       double r = *range_iter;
       // Skip NaN / inf points
-      if (!isfinite(r)) {
+      if (!std::isfinite(r)) {
         continue;
       }
 

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -25,7 +25,6 @@
   <depend>gazebo_dev</depend>
   <depend>rclcpp</depend>
 
-  <build_export_depend>builtin_interfaces</build_export_depend>
   <build_export_depend>geometry_msgs</build_export_depend>
   <build_export_depend>sensor_msgs</build_export_depend>
 

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -31,6 +31,7 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>sensor_msgs</test_depend>
   <test_depend>std_msgs</test_depend>
 
   <export>

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -25,6 +25,10 @@
   <depend>gazebo_dev</depend>
   <depend>rclcpp</depend>
 
+  <build_export_depend>builtin_interfaces</build_export_depend>
+  <build_export_depend>geometry_msgs</build_export_depend>
+  <build_export_depend>sensor_msgs</build_export_depend>
+
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -21,16 +21,14 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>rclcpp</build_depend>
-  <build_depend>gazebo_dev</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-
-  <exec_depend>rclcpp</exec_depend>
-  <exec_depend>gazebo_dev</exec_depend>
+  <depend>builtin_interfaces</depend>
+  <depend>gazebo_dev</depend>
+  <depend>rclcpp</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>geometry_msgs</test_depend>
   <test_depend>sensor_msgs</test_depend>
   <test_depend>std_msgs</test_depend>
 

--- a/gazebo_ros/src/gazebo_ros_init.cpp
+++ b/gazebo_ros/src/gazebo_ros_init.cpp
@@ -15,7 +15,7 @@
 #include "gazebo_ros/gazebo_ros_init.hpp"
 
 #include <gazebo/common/Plugin.hh>
-#include <gazebo_ros/conversions.hpp>
+#include <gazebo_ros/conversions/builtin_interfaces.hpp>
 #include <gazebo_ros/node.hpp>
 #include <gazebo_ros/utils.hpp>
 #include <rosgraph_msgs/msg/clock.hpp>

--- a/gazebo_ros/test/CMakeLists.txt
+++ b/gazebo_ros/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(ament_cmake_gtest REQUIRED)
+find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
@@ -46,9 +47,10 @@ foreach(test ${tests})
     gazebo_ros_utils
   )
   ament_target_dependencies(${test}
-    "rclcpp"
+    "builtin_interfaces"
     "geometry_msgs"
     "gazebo_dev"
+    "rclcpp"
     "sensor_msgs"
     "std_msgs"
   )

--- a/gazebo_ros/test/CMakeLists.txt
+++ b/gazebo_ros/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 find_package(ament_cmake_gtest REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 
 # Plugins
@@ -46,9 +47,10 @@ foreach(test ${tests})
   )
   ament_target_dependencies(${test}
     "rclcpp"
-    "std_msgs"
     "geometry_msgs"
     "gazebo_dev"
+    "sensor_msgs"
+    "std_msgs"
   )
 endforeach()
 

--- a/gazebo_ros/test/test_conversions.cpp
+++ b/gazebo_ros/test/test_conversions.cpp
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gazebo_ros/conversions.hpp>
+#include <gazebo_ros/conversions/builtin_interfaces.hpp>
+#include <gazebo_ros/conversions/sensor_msgs.hpp>
+#include <gazebo_ros/conversions/geometry_msgs.hpp>
 #include <gtest/gtest.h>
 
 TEST(TestConversions, Vector3)


### PR DESCRIPTION
Otherwise any package that included `conversions.hpp` needed to build depend on all of the message packages included in that header.

Noticed the need for this because since https://github.com/ros-simulation/gazebo_ros_pkgs/pull/785 has been merged, `gazebo_ros` on the `ros2` branch can't be built in isolation (missing dependency on `sensor_msgs`):
```
In file included from /home/dhood/ros2_ws/src/ros2/gazebo_ros_pkgs/gazebo_ros/test/test_conversions.cpp:15:0:
/home/dhood/ros2_ws/src/ros2/gazebo_ros_pkgs/gazebo_ros/include/gazebo_ros/conversions.hpp:30:44: fatal error: sensor_msgs/msg/point_cloud2.hpp: No such file or directory
```

A similar thing happened when https://github.com/ros-simulation/gazebo_ros_pkgs/pull/784 was merged requiring `geometry_msgs` (fixed in 80f3a789e2b670ea3f7ccd534d245e3036d337b3).

@chapulina not sure how you have been building locally but since the buildfarm won't catch issues building in isolation, if you can switch to an isolated build that will help catch these issues earlier :smile: (`colcon build` will use isolation by default)