### PR TITLE
Fix spawn_model for Python 3

### DIFF
--- a/gazebo_ros/scripts/spawn_model
+++ b/gazebo_ros/scripts/spawn_model
@@ -162,6 +162,10 @@ class SpawnModelNode():
         # Encode xml object back into string for service call
         model_xml = xml.etree.ElementTree.tostring(xml_parsed)
 
+        # For Python 3
+        if not isinstance(model_xml, str):
+            model_xml = model_xml.decode(encoding='ascii')
+
         # Form requested Pose from arguments
         initial_pose = Pose()
         initial_pose.position.x = self.args.x

--- a/gazebo_ros/scripts/spawn_model
+++ b/gazebo_ros/scripts/spawn_model
@@ -22,7 +22,10 @@ import sys
 import os
 import argparse
 import xml
-from urlparse import urlsplit, SplitResult
+try: # Python 3.x
+    from urllib.parse import urlsplit, SplitResult
+except ImportError: # Python 2.x
+    from urlparse import urlsplit, SplitResult
 from gazebo_ros import gazebo_interface
 from gazebo_msgs.msg import ModelStates
 from gazebo_msgs.srv import DeleteModel


### PR DESCRIPTION
A recent fix (#449) seems to have broken the `spawn_model` script when using Python 3. This is caused due to the `xml.etree.ElementTree.tostring` function returning a `bytestring` in Python 3 while the following code expects a `string`.

Here is the error I received:
```python
Traceback (most recent call last):
  File "/opt/ros/melodic/lib/gazebo_ros/spawn_model", line 233, in <module>
    exit_code = sm.run()
  File "/opt/ros/melodic/lib/gazebo_ros/spawn_model", line 179, in run
    self.args.gazebo_namespace)
  File "/opt/ros/melodic/lib/python3.7/site-packages/gazebo_ros/gazebo_interface.py", line 33, in spawn_urdf_model_client
    resp = spawn_urdf_model(model_name, model_xml, robot_namespace, initial_pose, reference_frame)
  File "/opt/ros/melodic/lib/python3.7/site-packages/rospy/impl/tcpros_service.py", line 439, in __call__
    return self.call(*args, **kwds)
  File "/opt/ros/melodic/lib/python3.7/site-packages/rospy/impl/tcpros_service.py", line 516, in call
    transport.send_message(request, self.seq)
  File "/opt/ros/melodic/lib/python3.7/site-packages/rospy/impl/tcpros_base.py", line 668, in send_message
    serialize_message(self.write_buff, seq, msg)
  File "/opt/ros/melodic/lib/python3.7/site-packages/rospy/msg.py", line 152, in serialize_message
    msg.serialize(b)
  File "/opt/ros/melodic/lib/python3.7/site-packages/gazebo_msgs/srv/_SpawnModel.py", line 103, in serialize
    _x = _x.encode('utf-8')
AttributeError: 'bytes' object has no attribute 'encode'
```