### PR TITLE
Initialize gazebo with initial physics configuration

### DIFF
--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -2237,31 +2237,9 @@ void GazeboRosApiPlugin::publishModelStates()
 
 void GazeboRosApiPlugin::physicsReconfigureCallback(gazebo_ros::PhysicsConfig &config, uint32_t level)
 {
-  if (!physics_reconfigure_initialized_)
+  bool changed = false;
+  if (physics_reconfigure_initialized_)
   {
-    gazebo_msgs::GetPhysicsProperties srv;
-    physics_reconfigure_get_client_.call(srv);
-
-    config.time_step                   = srv.response.time_step;
-    config.max_update_rate             = srv.response.max_update_rate;
-    config.gravity_x                   = srv.response.gravity.x;
-    config.gravity_y                   = srv.response.gravity.y;
-    config.gravity_z                   = srv.response.gravity.z;
-    config.auto_disable_bodies         = srv.response.ode_config.auto_disable_bodies;
-    config.sor_pgs_precon_iters        = srv.response.ode_config.sor_pgs_precon_iters;
-    config.sor_pgs_iters               = srv.response.ode_config.sor_pgs_iters;
-    config.sor_pgs_rms_error_tol       = srv.response.ode_config.sor_pgs_rms_error_tol;
-    config.sor_pgs_w                   = srv.response.ode_config.sor_pgs_w;
-    config.contact_surface_layer       = srv.response.ode_config.contact_surface_layer;
-    config.contact_max_correcting_vel  = srv.response.ode_config.contact_max_correcting_vel;
-    config.cfm                         = srv.response.ode_config.cfm;
-    config.erp                         = srv.response.ode_config.erp;
-    config.max_contacts                = srv.response.ode_config.max_contacts;
-    physics_reconfigure_initialized_ = true;
-  }
-  else
-  {
-    bool changed = false;
     gazebo_msgs::GetPhysicsProperties srv;
     physics_reconfigure_get_client_.call(srv);
 
@@ -2281,31 +2259,33 @@ void GazeboRosApiPlugin::physicsReconfigureCallback(gazebo_ros::PhysicsConfig &c
     if (config.cfm                            != srv.response.ode_config.cfm)                            changed = true;
     if (config.erp                            != srv.response.ode_config.erp)                            changed = true;
     if ((uint32_t)config.max_contacts         != srv.response.ode_config.max_contacts)                   changed = true;
-
-    if (changed)
-    {
-      // pause simulation if requested
-      gazebo_msgs::SetPhysicsProperties srv;
-      srv.request.time_step                             = config.time_step                   ;
-      srv.request.max_update_rate                       = config.max_update_rate             ;
-      srv.request.gravity.x                             = config.gravity_x                   ;
-      srv.request.gravity.y                             = config.gravity_y                   ;
-      srv.request.gravity.z                             = config.gravity_z                   ;
-      srv.request.ode_config.auto_disable_bodies        = config.auto_disable_bodies         ;
-      srv.request.ode_config.sor_pgs_precon_iters       = config.sor_pgs_precon_iters        ;
-      srv.request.ode_config.sor_pgs_iters              = config.sor_pgs_iters               ;
-      srv.request.ode_config.sor_pgs_rms_error_tol      = config.sor_pgs_rms_error_tol       ;
-      srv.request.ode_config.sor_pgs_w                  = config.sor_pgs_w                   ;
-      srv.request.ode_config.contact_surface_layer      = config.contact_surface_layer       ;
-      srv.request.ode_config.contact_max_correcting_vel = config.contact_max_correcting_vel  ;
-      srv.request.ode_config.cfm                        = config.cfm                         ;
-      srv.request.ode_config.erp                        = config.erp                         ;
-      srv.request.ode_config.max_contacts               = config.max_contacts                ;
-      physics_reconfigure_set_client_.call(srv);
-      ROS_INFO_NAMED("api_plugin", "physics dynamics reconfigure update complete");
-    }
-    ROS_INFO_NAMED("api_plugin", "physics dynamics reconfigure complete");
   }
+
+  if (!physics_reconfigure_initialized_ || changed)
+  {
+    gazebo_msgs::SetPhysicsProperties srv;
+    srv.request.time_step                             = config.time_step                   ;
+    srv.request.max_update_rate                       = config.max_update_rate             ;
+    srv.request.gravity.x                             = config.gravity_x                   ;
+    srv.request.gravity.y                             = config.gravity_y                   ;
+    srv.request.gravity.z                             = config.gravity_z                   ;
+    srv.request.ode_config.auto_disable_bodies        = config.auto_disable_bodies         ;
+    srv.request.ode_config.sor_pgs_precon_iters       = config.sor_pgs_precon_iters        ;
+    srv.request.ode_config.sor_pgs_iters              = config.sor_pgs_iters               ;
+    srv.request.ode_config.sor_pgs_rms_error_tol      = config.sor_pgs_rms_error_tol       ;
+    srv.request.ode_config.sor_pgs_w                  = config.sor_pgs_w                   ;
+    srv.request.ode_config.contact_surface_layer      = config.contact_surface_layer       ;
+    srv.request.ode_config.contact_max_correcting_vel = config.contact_max_correcting_vel  ;
+    srv.request.ode_config.cfm                        = config.cfm                         ;
+    srv.request.ode_config.erp                        = config.erp                         ;
+    srv.request.ode_config.max_contacts               = config.max_contacts                ;
+    physics_reconfigure_set_client_.call(srv);
+
+    physics_reconfigure_initialized_ = true;
+
+    ROS_INFO_NAMED("api_plugin", "physics dynamics reconfigure update complete");
+  }
+  ROS_INFO_NAMED("api_plugin", "physics dynamics reconfigure complete");
 }
 
 void GazeboRosApiPlugin::physicsReconfigureThread()


### PR DESCRIPTION
Gazebo is **not** using any of the following parameters during initialization:

- time_step
- max_update_rate
- gravity_x
- gravity_y
- gravity_z
- auto_disable_bodies
- sor_pgs_precon_iters
- sor_pgs_iters
- sor_pgs_w
- sor_pgs_rms_error_tol
- cfm
- erp
- contact_surface_layer
- contact_max_correcting_vel
- max_contacts

The default values from _Physics.cfg_ and the values specified in your launch file are overwritten during initialization by the default values used inside Gazebo. 

After initialization it is possible to change the parameters (dynamic reconfigure). 

Example:

When I provide a custom `max_update_rate` of 50.0 and call `rosservice call /gazebo/get_physics_properties` after initialization I can see a different `max_update_rate`
 (1000.0) which does not correspond to the default value or my custom value. In my case this leads to excessive CPU usage. 

This fix ensures **SetPhysicsProperties** is called during initialization to deliver the provided settings in your launch file or default values specified in _Physics.cfg_ to Gazebo. 

