### PR TITLE
Add horizontal movement option

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_planar_move.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_planar_move.h
@@ -89,7 +89,7 @@ namespace gazebo {
       double y_;
       double rot_;
       bool alive_;
-      bool enable_horizontal_movement_;
+      bool enable_y_axis_; ///< Enable Y-axis movement.
       common::Time last_odom_publish_time_;
       ignition::math::Pose3d last_odom_pose_;
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_planar_move.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_planar_move.h
@@ -89,6 +89,7 @@ namespace gazebo {
       double y_;
       double rot_;
       bool alive_;
+      bool enable_horizontal_movement_;
       common::Time last_odom_publish_time_;
       ignition::math::Pose3d last_odom_pose_;
 

--- a/gazebo_plugins/src/gazebo_ros_planar_move.cpp
+++ b/gazebo_plugins/src/gazebo_ros_planar_move.cpp
@@ -52,6 +52,17 @@ namespace gazebo
         sdf->GetElement("robotNamespace")->Get<std::string>();
     }
 
+    enable_horizontal_movement_ = true;
+    if (!sdf->HasElement ("enableHolizontalMovement"))
+    {
+      ROS_INFO_NAMED("planar_move", "PlanarMovePlugin missing <enableHolizontalMovement>, "
+          "defaults to \"%d\"", enable_horizontal_movement_);
+    }
+    else
+    {
+      enable_horizontal_movement_ = sdf->GetElement("enableHolizontalMovement")->Get<bool>();
+    }
+
     command_topic_ = "cmd_vel";
     if (!sdf->HasElement("commandTopic"))
     {
@@ -208,7 +219,10 @@ namespace gazebo
   {
     boost::mutex::scoped_lock scoped_lock(lock);
     x_ = cmd_msg->linear.x;
-    y_ = cmd_msg->linear.y;
+    if (enable_horizontal_movement_)
+    {
+      y_ = cmd_msg->linear.y;
+    }
     rot_ = cmd_msg->angular.z;
   }
 

--- a/gazebo_plugins/src/gazebo_ros_planar_move.cpp
+++ b/gazebo_plugins/src/gazebo_ros_planar_move.cpp
@@ -52,15 +52,15 @@ namespace gazebo
         sdf->GetElement("robotNamespace")->Get<std::string>();
     }
 
-    enable_horizontal_movement_ = true;
-    if (!sdf->HasElement ("enableHolizontalMovement"))
+    enable_y_axis_ = true;
+    if (!sdf->HasElement ("enableYAxis"))
     {
-      ROS_INFO_NAMED("planar_move", "PlanarMovePlugin missing <enableHolizontalMovement>, "
-          "defaults to \"%d\"", enable_horizontal_movement_);
+      ROS_INFO_NAMED("planar_move", "PlanarMovePlugin missing <enableYAxis>, "
+          "defaults to \"%d\"", enable_y_axis_);
     }
     else
     {
-      enable_horizontal_movement_ = sdf->GetElement("enableHolizontalMovement")->Get<bool>();
+      enable_y_axis_ = sdf->GetElement("enableYAxis")->Get<bool>();
     }
 
     command_topic_ = "cmd_vel";
@@ -219,7 +219,7 @@ namespace gazebo
   {
     boost::mutex::scoped_lock scoped_lock(lock);
     x_ = cmd_msg->linear.x;
-    if (enable_horizontal_movement_)
+    if (enable_y_axis_)
     {
       y_ = cmd_msg->linear.y;
     }


### PR DESCRIPTION
I was looking for a way to simply simulates my differential drive robot which doesn't have any wheel joints on gazebo. So, I added one more parameter that can turn horizontal movement off for the planar move plugin. 

Feel free merge the PR if this can be useful for others.