### PR TITLE
Fix [: Linux: unexpected operator error for the debug script

### DIFF
--- a/gazebo_ros/scripts/debug
+++ b/gazebo_ros/scripts/debug
@@ -2,7 +2,7 @@
 final="$@"
 
 EXT=so
-if [ $(uname) == "Darwin" ]; then
+if [ $(uname) = "Darwin" ]; then
     EXT=dylib
 fi
 


### PR DESCRIPTION
The `gazebo_ros/scripts/debug` script was not patched in #199. The duplicate #209 includes `debug`, but forgot to patch other scripts. The original PR causing the problem was #188.

Please also merge or cherry-pick into the development branches for newer releases or change the target branch accordingly. I only targeted `hydro-devel` to match the original PR #199.