### PR TITLE
fix boolean comparision for ros getparam

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_utils.cpp
@@ -98,7 +98,7 @@ void GazeboRos ::getParameterBoolean(bool &_value, const char *_tag_name, const 
     _value = _default;
     if (!sdf_->HasElement(_tag_name)) {
         ROS_WARN_NAMED("utils", "%s: missing <%s> default is %s",
-                 info(), _tag_name,  (_default?"ture":"false"));
+                 info(), _tag_name,  (_default?"true":"false"));
     } else {
         getParameterBoolean(_value, _tag_name);
     }
@@ -108,11 +108,11 @@ void GazeboRos ::getParameterBoolean(bool &_value, const char *_tag_name) {
 
     if (sdf_->HasElement(_tag_name)) {
         std::string value = sdf_->GetElement(_tag_name)->Get<std::string>();
-        if(boost::iequals(value, std::string("true")))
+        if(boost::iequals(value, std::string("true")) || boost::iequals(value, std::string("1")))
         {
             _value = true;
         }
-        else if(boost::iequals(value, std::string("false")))
+        else if(boost::iequals(value, std::string("false")) || boost::iequals(value, std::string("0")))
         {
             _value = false;
         }
@@ -123,7 +123,7 @@ void GazeboRos ::getParameterBoolean(bool &_value, const char *_tag_name) {
         }
     }
     ROS_DEBUG_NAMED("utils", "%s: <%s> = %s",
-              info(), _tag_name,  (_value?"ture":"false"));
+              info(), _tag_name,  (_value?"true":"false"));
 
 }
 


### PR DESCRIPTION
Basically, the method getParameterBoolean() does not support urdf.
This happens because when gazebo parser urdf to sdf, elements declared with true or false is automatically set to 1 or 0. To fix this, I just extend the condition to leads with 1 or 0 notation.

Below is one example of I am talking about. **Check the element alwaysOn**.
example.urdf:
```xml
<?xml version="1.0" ?>
<!-- =================================================================================== -->
<!-- |    This document was autogenerated by xacro from a.xacro                        | -->
<!-- |    EDITING THIS FILE BY HAND IS NOT RECOMMENDED                                 | -->
<!-- =================================================================================== -->
<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
  <link name="base_link">
   <inertial>
     <origin xyz="0 0 0.5" rpy="0 0 0"/>
     <mass value="1"/>
     <inertia ixx="100"  ixy="0"  ixz="0" iyy="100" iyz="0" izz="100" />
   </inertial>
   <visual>
     <origin xyz="0 0 0" rpy="0 0 0" />
     <geometry>
       <box size="1 1 1" />
     </geometry>
     <material name="Cyan">
       <color rgba="0 1.0 1.0 1.0"/>
     </material>
   </visual>
   <collision>
     <origin xyz="0 0 0" rpy="0 0 0"/>
     <geometry>
       <cylinder radius="1" length="0.5"/>
     </geometry>
   </collision>
 </link>
  <gazebo>
    <plugin name="imu_plugin" filename="libgazebo_ros_imu.so">
      <alwaysOn>true</alwaysOn>
      <bodyName>base_link</bodyName>
      <topicName>imu</topicName>
      <serviceName>imu_service</serviceName>
      <gaussianNoise>0.0</gaussianNoise>
      <updateRate>20.0</updateRate>
    </plugin>
  </gazebo>
</robot>
```
Parsing to sdf:
```sh
$ gz sdf --verbose -p example.urdf > example.sdf
```
example.sdf:
```xml
<sdf version='1.6'>
  <model name='robot'>
    <link name='base_link'>
      <pose frame=''>0 0 0 0 -0 0</pose>
      <inertial>
        <pose frame=''>0 0 0.5 0 -0 0</pose>
        <mass>1</mass>
        <inertia>
          <ixx>100</ixx>
          <ixy>0</ixy>
          <ixz>0</ixz>
          <iyy>100</iyy>
          <iyz>0</iyz>
          <izz>100</izz>
        </inertia>
      </inertial>
      <collision name='base_link_collision'>
        <pose frame=''>0 0 0 0 -0 0</pose>
        <geometry>
          <cylinder>
            <length>0.5</length>
            <radius>1</radius>
          </cylinder>
        </geometry>
      </collision>
      <visual name='base_link_visual'>
        <pose frame=''>0 0 0 0 -0 0</pose>
        <geometry>
          <box>
            <size>1 1 1</size>
          </box>
        </geometry>
      </visual>
    </link>
    <static>0</static>
    <plugin name='imu_plugin' filename='libgazebo_ros_imu.so'>
      <alwaysOn>1</alwaysOn>
      <bodyName>base_link</bodyName>
      <topicName>imu</topicName>
      <serviceName>imu_service</serviceName>
      <gaussianNoise>0.0</gaussianNoise>
      <updateRate>20.0</updateRate>
    </plugin>
  </model>
</sdf>
```
