### PR TITLE
Close laser connection on shutdown

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_gpu_laser.cpp
+++ b/gazebo_plugins/src/gazebo_ros_gpu_laser.cpp
@@ -58,6 +58,7 @@ GazeboRosLaser::GazeboRosLaser()
 GazeboRosLaser::~GazeboRosLaser()
 {
   ROS_DEBUG_STREAM_NAMED("gpu_laser","Shutting down GPU Laser");
+  this->laser_scan_sub_.reset();
   this->rosnode_->shutdown();
   delete this->rosnode_;
   ROS_DEBUG_STREAM_NAMED("gpu_laser","Unloaded");


### PR DESCRIPTION
Related to [this Gazebo PR ](https://bitbucket.org/osrf/gazebo/pull-requests/3026) avoids a SIGSEGV when a laser is deleted from the simulation.