### PR TITLE
[ros2] World plugin with get/set entity state services

### DIFF
--- a/.ros1_unported/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
+++ b/.ros1_unported/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
@@ -58,23 +58,17 @@
 #include "gazebo_msgs/GetWorldProperties.h"
 
 #include "gazebo_msgs/GetModelProperties.h"
-#include "gazebo_msgs/GetModelState.h"
-#include "gazebo_msgs/SetModelState.h"
 
 #include "gazebo_msgs/GetJointProperties.h"
 #include "gazebo_msgs/ApplyJointEffort.h"
 
 #include "gazebo_msgs/GetLinkProperties.h"
 #include "gazebo_msgs/SetLinkProperties.h"
-#include "gazebo_msgs/SetLinkState.h"
-#include "gazebo_msgs/GetLinkState.h"
 
 #include "gazebo_msgs/GetLightProperties.h"
 #include "gazebo_msgs/SetLightProperties.h"
 
 // Topics
-#include "gazebo_msgs/ModelState.h"
-#include "gazebo_msgs/LinkState.h"
 #include "gazebo_msgs/ModelStates.h"
 #include "gazebo_msgs/LinkStates.h"
 
@@ -139,9 +133,6 @@ public:
   void onModelStatesDisconnect();
 
   /// \brief
-  bool getModelState(gazebo_msgs::GetModelState::Request &req,gazebo_msgs::GetModelState::Response &res);
-
-  /// \brief
   bool getModelProperties(gazebo_msgs::GetModelProperties::Request &req,gazebo_msgs::GetModelProperties::Response &res);
 
   /// \brief
@@ -152,9 +143,6 @@ public:
 
   /// \brief
   bool getLinkProperties(gazebo_msgs::GetLinkProperties::Request &req,gazebo_msgs::GetLinkProperties::Response &res);
-
-  /// \brief
-  bool getLinkState(gazebo_msgs::GetLinkState::Request &req,gazebo_msgs::GetLinkState::Response &res);
 
   /// \brief
   bool getLightProperties(gazebo_msgs::GetLightProperties::Request &req,gazebo_msgs::GetLightProperties::Response &res);
@@ -173,12 +161,6 @@ public:
 
   /// \brief
   bool setJointProperties(gazebo_msgs::SetJointProperties::Request &req,gazebo_msgs::SetJointProperties::Response &res);
-
-  /// \brief
-  bool setModelState(gazebo_msgs::SetModelState::Request &req,gazebo_msgs::SetModelState::Response &res);
-
-  /// \brief
-  void updateModelState(const gazebo_msgs::ModelState::ConstPtr& model_state);
 
   /// \brief
   bool applyJointEffort(gazebo_msgs::ApplyJointEffort::Request &req,gazebo_msgs::ApplyJointEffort::Response &res);
@@ -205,12 +187,6 @@ public:
 
   /// \brief
   bool setModelConfiguration(gazebo_msgs::SetModelConfiguration::Request &req,gazebo_msgs::SetModelConfiguration::Response &res);
-
-  /// \brief
-  bool setLinkState(gazebo_msgs::SetLinkState::Request &req,gazebo_msgs::SetLinkState::Response &res);
-
-  /// \brief
-  void updateLinkState(const gazebo_msgs::LinkState::ConstPtr& link_state);
 
   /// \brief
   bool applyBodyWrench(gazebo_msgs::ApplyBodyWrench::Request &req,gazebo_msgs::ApplyBodyWrench::Response &res);
@@ -274,12 +250,10 @@ private:
   gazebo::event::ConnectionPtr pub_model_states_event_;
   gazebo::event::ConnectionPtr load_gazebo_ros_api_plugin_event_;
 
-  ros::ServiceServer get_model_state_service_;
   ros::ServiceServer get_model_properties_service_;
   ros::ServiceServer get_world_properties_service_;
   ros::ServiceServer get_joint_properties_service_;
   ros::ServiceServer get_link_properties_service_;
-  ros::ServiceServer get_link_state_service_;
   ros::ServiceServer get_light_properties_service_;
   ros::ServiceServer set_light_properties_service_;
   ros::ServiceServer set_link_properties_service_;
@@ -287,18 +261,14 @@ private:
   ros::ServiceServer get_physics_properties_service_;
   ros::ServiceServer apply_body_wrench_service_;
   ros::ServiceServer set_joint_properties_service_;
-  ros::ServiceServer set_model_state_service_;
   ros::ServiceServer apply_joint_effort_service_;
   ros::ServiceServer set_model_configuration_service_;
-  ros::ServiceServer set_link_state_service_;
   ros::ServiceServer reset_simulation_service_;
   ros::ServiceServer reset_world_service_;
   ros::ServiceServer pause_physics_service_;
   ros::ServiceServer unpause_physics_service_;
   ros::ServiceServer clear_joint_forces_service_;
   ros::ServiceServer clear_body_wrenches_service_;
-  ros::Subscriber    set_link_state_topic_;
-  ros::Subscriber    set_model_state_topic_;
   ros::Publisher     pub_link_states_;
   ros::Publisher     pub_model_states_;
   int                pub_link_states_connection_count_;
@@ -345,9 +315,6 @@ private:
 
   std::vector<GazeboRosApiPlugin::WrenchBodyJob*> wrench_body_jobs_;
   std::vector<GazeboRosApiPlugin::ForceJointJob*> force_joint_jobs_;
-
-  /// \brief index counters to count the accesses on models via GetModelState
-  std::map<std::string, unsigned int> access_count_get_model_state_;
 
   /// \brief enable the communication of gazebo information using ROS service/topics
   bool enable_ros_network_;

--- a/gazebo_msgs/CMakeLists.txt
+++ b/gazebo_msgs/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(rosidl_default_generators REQUIRED)
 set(msg_files
   "msg/ContactState.msg"
   "msg/ContactsState.msg"
+  "msg/EntityState.msg"
   "msg/LinkState.msg"
   "msg/LinkStates.msg"
   "msg/ModelState.msg"
@@ -39,6 +40,7 @@ set(srv_files
   "srv/DeleteLight.srv"
   "srv/DeleteModel.srv"
   "srv/GetJointProperties.srv"
+  "srv/GetEntityState.srv"
   "srv/GetLightProperties.srv"
   "srv/GetLinkProperties.srv"
   "srv/GetLinkState.srv"
@@ -47,6 +49,7 @@ set(srv_files
   "srv/GetPhysicsProperties.srv"
   "srv/GetWorldProperties.srv"
   "srv/JointRequest.srv"
+  "srv/SetEntityState.srv"
   "srv/SetJointProperties.srv"
   "srv/SetJointTrajectory.srv"
   "srv/SetLightProperties.srv"

--- a/gazebo_msgs/msg/EntityState.msg
+++ b/gazebo_msgs/msg/EntityState.msg
@@ -1,0 +1,9 @@
+# Holds an entity's pose and twist
+string name                 # Entity's scoped name.
+                            # An entity can be a model, link, collision, light, etc.
+                            # Be sure to use gazebo scoped naming notation (e.g. [model_name::link_name])
+geometry_msgs/Pose pose     # Pose in reference frame.
+geometry_msgs/Twist twist   # Twist in reference frame.
+string reference_frame      # Pose/twist are expressed relative to the frame of this entity.
+                            # Leaving empty or "world" defaults to inertial world frame.
+

--- a/gazebo_msgs/msg/LinkState.msg
+++ b/gazebo_msgs/msg/LinkState.msg
@@ -1,3 +1,5 @@
+# Deprecated, kept for ROS 1 bridge.
+# Use EntityState
 # @todo: FIXME: sets pose and twist of a link.  All children link poses/twists of the URDF tree are not updated accordingly, but should be.
 string link_name            # link name, link_names are in gazebo scoped name notation, [model_name::body_name]
 geometry_msgs/Pose pose     # desired pose in reference frame

--- a/gazebo_msgs/msg/ModelState.msg
+++ b/gazebo_msgs/msg/ModelState.msg
@@ -1,3 +1,5 @@
+# Deprecated, kept for ROS 1 bridge.
+# Use EntityState
 # Set Gazebo Model pose and twist
 string model_name           # model to set state (pose and twist)
 geometry_msgs/Pose pose     # desired pose in reference frame

--- a/gazebo_msgs/srv/DeleteLight.srv
+++ b/gazebo_msgs/srv/DeleteLight.srv
@@ -1,3 +1,5 @@
+# Deprecated, kept for ROS 1 bridge.
+# Use DeleteEntity
 string light_name                 # name of the light to be deleted
 ---
 bool success                      # return true if deletion is successful

--- a/gazebo_msgs/srv/DeleteModel.srv
+++ b/gazebo_msgs/srv/DeleteModel.srv
@@ -1,3 +1,5 @@
+# Deprecated, kept for ROS 1 bridge.
+# Use DeleteEntity
 string model_name                 # name of the Gazebo Model to be deleted
 ---
 bool success                      # return true if deletion is successful

--- a/gazebo_msgs/srv/GetEntityState.srv
+++ b/gazebo_msgs/srv/GetEntityState.srv
@@ -1,0 +1,11 @@
+string name                          # Entity's scoped name.
+                                     # An entity can be a model, link, collision, light, etc.
+                                     # Be sure to use gazebo scoped naming notation (e.g. [model_name::link_name])
+string reference_frame               # Return pose and twist relative to this entity.
+                                     # Leaving empty or "world" will use inertial world frame.
+---
+std_msgs/Header header               # Standard metadata for higher-level stamped data types.
+                                     # * header.stamp Timestamp related to the pose.
+                                     # * header.frame_id Filled with the relative_frame.
+gazebo_msgs/EntityState state        # Contains pose and twist.
+bool success                         # Return true if get was successful. If false, the state contains garbage.

--- a/gazebo_msgs/srv/GetLinkState.srv
+++ b/gazebo_msgs/srv/GetLinkState.srv
@@ -1,3 +1,5 @@
+# Deprecated, kept for ROS 1 bridge.
+# Use GetEntityState
 string link_name          # name of link
                           # link names are prefixed by model name, e.g. pr2::base_link
 string reference_frame    # reference frame of returned information, must be a valid link

--- a/gazebo_msgs/srv/GetModelState.srv
+++ b/gazebo_msgs/srv/GetModelState.srv
@@ -1,3 +1,5 @@
+# Deprecated, kept for ROS 1 bridge.
+# Use GetEntityState
 string model_name                    # name of Gazebo Model
 string relative_entity_name          # return pose and twist relative to this entity
                                      # an entity can be a model, body, or geom

--- a/gazebo_msgs/srv/SetEntityState.srv
+++ b/gazebo_msgs/srv/SetEntityState.srv
@@ -1,0 +1,4 @@
+gazebo_msgs/EntityState state   # Entity state to set to.
+                                # Be sure to fill all fields, values of zero have meaning.
+---
+bool success                    # Return true if setting state was successful.

--- a/gazebo_msgs/srv/SetLinkState.srv
+++ b/gazebo_msgs/srv/SetLinkState.srv
@@ -1,3 +1,5 @@
+# Deprecated, kept for ROS 1 bridge.
+# Use SetEntityState
 gazebo_msgs/LinkState link_state
 ---
 bool success                # return true if set wrench successful

--- a/gazebo_msgs/srv/SetModelState.srv
+++ b/gazebo_msgs/srv/SetModelState.srv
@@ -1,3 +1,5 @@
+# Deprecated, kept for ROS 1 bridge.
+# Use SetEntityState
 gazebo_msgs/ModelState model_state
 ---
 bool success                  # return true if setting state successful

--- a/gazebo_msgs/srv/SpawnModel.srv
+++ b/gazebo_msgs/srv/SpawnModel.srv
@@ -1,3 +1,5 @@
+# Deprecated, kept for ROS 1 bridge.
+# Use SpawnEntity
 string model_name                 # name of the model to be spawn
 string model_xml                  # this should be an urdf or gazebo xml
 string robot_namespace            # spawn robot and all ROS interfaces under this namespace

--- a/gazebo_plugins/worlds/gazebo_ros_diff_drive_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_diff_drive_demo.world
@@ -14,7 +14,7 @@
 
   Try listening to TF:
 
-    ros2 run tf2_ros tf2_echo odom chassis
+    ros2 run tf2_ros tf2_echo odom_demo chassis
 
     ros2 run tf2_ros tf2_echo chassis right_wheel
 

--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -76,6 +76,20 @@ target_link_libraries(gazebo_ros_factory
 )
 ament_export_libraries(gazebo_ros_factory)
 
+# gazebo_ros_state
+add_library(gazebo_ros_state SHARED
+  src/gazebo_ros_state.cpp
+)
+ament_target_dependencies(gazebo_ros_state
+  "rclcpp"
+  "gazebo_dev"
+  "gazebo_msgs"
+)
+target_link_libraries(gazebo_ros_state
+  gazebo_ros_node
+)
+ament_export_libraries(gazebo_ros_state)
+
 ament_export_include_directories(include)
 ament_export_dependencies(rclcpp)
 ament_export_dependencies(gazebo_dev)
@@ -96,6 +110,7 @@ install(
     gazebo_ros_factory
     gazebo_ros_init
     gazebo_ros_node
+    gazebo_ros_state
     gazebo_ros_utils
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib

--- a/gazebo_ros/include/gazebo_ros/gazebo_ros_state.hpp
+++ b/gazebo_ros/include/gazebo_ros/gazebo_ros_state.hpp
@@ -1,0 +1,54 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GAZEBO_ROS__GAZEBO_ROS_STATE_HPP_
+#define GAZEBO_ROS__GAZEBO_ROS_STATE_HPP_
+
+#include <gazebo/common/Plugin.hh>
+
+#include <memory>
+
+namespace gazebo_ros
+{
+
+class GazeboRosStatePrivate;
+
+/// Provides services and topics to query and set the state of entities in
+/// simualtion, such as position and velocity.
+///
+///  Services:
+///
+///      get_entity_state (gazebo_msgs::srv::GetEntityState)
+///          Get an entity's position and velocity.
+///
+///      set_entity_state (gazebo_msgs::srv::SetEntityState)
+///          Set an entity's position and velocity.
+class GazeboRosState : public gazebo::WorldPlugin
+{
+public:
+  /// Constructor
+  GazeboRosState();
+
+  /// Destructor
+  virtual ~GazeboRosState();
+
+  // Documentation inherited
+  void Load(gazebo::physics::WorldPtr _world, sdf::ElementPtr _sdf) override;
+
+private:
+  std::unique_ptr<GazeboRosStatePrivate> impl_;
+};
+
+}  // namespace gazebo_ros
+#endif  // GAZEBO_ROS__GAZEBO_ROS_STATE_HPP_

--- a/gazebo_ros/src/gazebo_ros_state.cpp
+++ b/gazebo_ros/src/gazebo_ros_state.cpp
@@ -1,0 +1,216 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/physics/Entity.hh>
+#include <gazebo/physics/Light.hh>
+#include <gazebo/physics/Link.hh>
+#include <gazebo/physics/Model.hh>
+#include <gazebo/physics/World.hh>
+#include <gazebo_msgs/srv/get_entity_state.hpp>
+#include <gazebo_msgs/srv/set_entity_state.hpp>
+#include <gazebo_ros/node.hpp>
+
+#include <memory>
+
+#include "gazebo_ros/conversions/builtin_interfaces.hpp"
+#include "gazebo_ros/conversions/geometry_msgs.hpp"
+#include "gazebo_ros/gazebo_ros_state.hpp"
+
+namespace gazebo_ros
+{
+
+class GazeboRosStatePrivate
+{
+public:
+  /// \brief Callback for get entity state service.
+  /// \param[in] req Request
+  /// \param[out] res Response
+  void GetEntityState(
+    gazebo_msgs::srv::GetEntityState::Request::SharedPtr _req,
+    gazebo_msgs::srv::GetEntityState::Response::SharedPtr _res);
+
+  /// \brief Callback for set entity state service.
+  /// \param[in] req Request
+  /// \param[out] res Response
+  void SetEntityState(
+    gazebo_msgs::srv::SetEntityState::Request::SharedPtr _req,
+    gazebo_msgs::srv::SetEntityState::Response::SharedPtr _res);
+
+  /// \brief World pointer from Gazebo.
+  gazebo::physics::WorldPtr world_;
+
+  /// ROS node for communication, managed by gazebo_ros.
+  gazebo_ros::Node::SharedPtr ros_node_;
+
+  /// \brief ROS service to handle requests for entity states.
+  rclcpp::Service<gazebo_msgs::srv::GetEntityState>::SharedPtr get_entity_state_service_;
+
+  /// \brief ROS service to handle requests to set entity states.
+  rclcpp::Service<gazebo_msgs::srv::SetEntityState>::SharedPtr set_entity_state_service_;
+};
+
+GazeboRosState::GazeboRosState()
+: impl_(std::make_unique<GazeboRosStatePrivate>())
+{
+}
+
+GazeboRosState::~GazeboRosState()
+{
+}
+
+void GazeboRosState::Load(gazebo::physics::WorldPtr _world, sdf::ElementPtr _sdf)
+{
+  impl_->world_ = _world;
+
+  impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
+
+  impl_->get_entity_state_service_ =
+    impl_->ros_node_->create_service<gazebo_msgs::srv::GetEntityState>(
+    "get_entity_state", std::bind(&GazeboRosStatePrivate::GetEntityState, impl_.get(),
+    std::placeholders::_1, std::placeholders::_2));
+
+  impl_->set_entity_state_service_ =
+    impl_->ros_node_->create_service<gazebo_msgs::srv::SetEntityState>(
+    "set_entity_state", std::bind(&GazeboRosStatePrivate::SetEntityState, impl_.get(),
+    std::placeholders::_1, std::placeholders::_2));
+}
+
+void GazeboRosStatePrivate::GetEntityState(
+  gazebo_msgs::srv::GetEntityState::Request::SharedPtr _req,
+  gazebo_msgs::srv::GetEntityState::Response::SharedPtr _res)
+{
+  // Target entity
+  auto entity = world_->EntityByName(_req->name);
+  if (!entity) {
+    _res->success = false;
+
+    RCLCPP_ERROR(ros_node_->get_logger(),
+      "GetEntityState: entity [%s] does not exist", _req->name);
+    return;
+  }
+
+  auto entity_pose = entity->WorldPose();
+  auto entity_lin_vel = entity->WorldLinearVel();
+  auto entity_ang_vel = entity->WorldAngularVel();
+
+  // Frame of reference
+  auto frame = world_->EntityByName(_req->reference_frame);
+  if (frame) {
+    auto frame_pose = frame->WorldPose();
+    auto frame_lin_vel = frame->WorldLinearVel();
+    auto frame_ang_vel = frame->WorldAngularVel();
+
+    entity_pose = entity_pose - frame_pose;
+
+    // convert to relative
+    entity_lin_vel = frame_pose.Rot().RotateVectorReverse(entity_lin_vel - frame_lin_vel);
+    entity_ang_vel = frame_pose.Rot().RotateVectorReverse(entity_ang_vel - frame_ang_vel);
+  } else if (_req->reference_frame == "" || _req->reference_frame == "world") {
+    RCLCPP_DEBUG(ros_node_->get_logger(),
+      "GetEntityState: reference_frame is empty/world, using inertial frame");
+  } else {
+    _res->success = false;
+
+    RCLCPP_ERROR(ros_node_->get_logger(),
+      "GetEntityState: reference entity [%s] not found, did you forget to scope the entity name?",
+      _req->name);
+    return;
+  }
+
+  // Fill in response
+  _res->header.stamp = Convert<builtin_interfaces::msg::Time>(world_->SimTime());
+  _res->header.frame_id = _req->reference_frame;
+
+  _res->state.pose.position = Convert<geometry_msgs::msg::Point>(entity_pose.Pos());
+  _res->state.pose.orientation = Convert<geometry_msgs::msg::Quaternion>(entity_pose.Rot());
+
+  _res->state.twist.linear = Convert<geometry_msgs::msg::Vector3>(entity_lin_vel);
+  _res->state.twist.angular = Convert<geometry_msgs::msg::Vector3>(entity_ang_vel);
+
+  _res->success = true;
+}
+
+void GazeboRosStatePrivate::SetEntityState(
+  gazebo_msgs::srv::SetEntityState::Request::SharedPtr _req,
+  gazebo_msgs::srv::SetEntityState::Response::SharedPtr _res)
+{
+  auto entity_pos = Convert<ignition::math::Vector3d>(_req->state.pose.position);
+  auto entity_rot = Convert<ignition::math::Quaterniond>(_req->state.pose.orientation);
+
+  // Eliminate invalid rotation (0, 0, 0, 0)
+  entity_rot.Normalize();
+
+  ignition::math::Pose3d entity_pose(entity_pos, entity_rot);
+  auto entity_lin_vel = Convert<ignition::math::Vector3d>(_req->state.twist.linear);
+  auto entity_ang_vel = Convert<ignition::math::Vector3d>(_req->state.twist.angular);
+
+  // Target entity
+  auto entity = world_->EntityByName(_req->state.name);
+  if (!entity) {
+    _res->success = false;
+
+    RCLCPP_ERROR(ros_node_->get_logger(),
+      "SetEntityState: entity [%s] does not exist", _req->state.name);
+    return;
+  }
+
+  // Frame of reference
+  auto frame = world_->EntityByName(_req->state.reference_frame);
+  if (frame) {
+    auto frame_pose = frame->WorldPose();
+    entity_pose = entity_pose + frame_pose;
+
+    // Velocities should be commanded in the requested reference
+    // frame, so we need to translate them to the world frame
+    entity_lin_vel = frame_pose.Rot().RotateVector(entity_lin_vel);
+    entity_ang_vel = frame_pose.Rot().RotateVector(entity_ang_vel);
+  } else if (_req->state.reference_frame == "" || _req->state.reference_frame == "world") {
+    RCLCPP_DEBUG(ros_node_->get_logger(),
+      "SetEntityState: reference_frame is empty/world, using inertial frame");
+  } else {
+    _res->success = false;
+
+    RCLCPP_ERROR(ros_node_->get_logger(),
+      "GetEntityState: reference entity [%s] not found, did you forget to scope the entity name?",
+      _req->state.name);
+    return;
+  }
+
+  // Set state
+  auto model = boost::dynamic_pointer_cast<gazebo::physics::Model>(entity);
+  auto link = boost::dynamic_pointer_cast<gazebo::physics::Link>(entity);
+  auto light = boost::dynamic_pointer_cast<gazebo::physics::Light>(entity);
+
+  bool is_paused = world_->IsPaused();
+
+  world_->SetPaused(true);
+  entity->SetWorldPose(entity_pose);
+  world_->SetPaused(is_paused);
+
+  if (model) {
+    model->SetLinearVel(entity_lin_vel);
+    model->SetAngularVel(entity_ang_vel);
+  } else if (link) {
+    link->SetLinearVel(entity_lin_vel);
+    link->SetAngularVel(entity_ang_vel);
+  }
+
+  // Fill response
+  _res->success = true;
+}
+
+GZ_REGISTER_WORLD_PLUGIN(GazeboRosState)
+
+}  // namespace gazebo_ros

--- a/gazebo_ros/test/CMakeLists.txt
+++ b/gazebo_ros/test/CMakeLists.txt
@@ -31,6 +31,7 @@ file(COPY worlds DESTINATION .)
 set(tests
   test_conversions
   test_gazebo_ros_factory
+  test_gazebo_ros_state
   test_node
   test_plugins
   test_sim_time

--- a/gazebo_ros/test/test_gazebo_ros_state.cpp
+++ b/gazebo_ros/test/test_gazebo_ros_state.cpp
@@ -1,0 +1,189 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gazebo/test/ServerFixture.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Vector3.hh>
+
+#include <gazebo_msgs/srv/get_entity_state.hpp>
+#include <gazebo_msgs/srv/set_entity_state.hpp>
+#include <gazebo_ros/conversions/geometry_msgs.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <memory>
+#include <string>
+
+#define tol 10e-2
+
+class GazeboRosStateTest : public gazebo::ServerFixture
+{
+public:
+  // Documentation inherited
+  void SetUp() override;
+
+  /// Helper function to call get state service
+  void GetState(
+    const std::string & _entity,
+    const ignition::math::Pose3d & _pose,
+    const ignition::math::Vector3d & _lin_vel = ignition::math::Vector3d::Zero,
+    const ignition::math::Vector3d & _ang_vel = ignition::math::Vector3d::Zero);
+
+  /// Helper function to call set state service
+  void SetState(
+    const std::string & _entity,
+    const ignition::math::Pose3d & _pose,
+    const ignition::math::Vector3d & _lin_vel = ignition::math::Vector3d::Zero,
+    const ignition::math::Vector3d & _ang_vel = ignition::math::Vector3d::Zero);
+
+  gazebo::physics::WorldPtr world_;
+  rclcpp::Node::SharedPtr node_;
+  std::shared_ptr<rclcpp::Client<gazebo_msgs::srv::GetEntityState>> get_state_client_;
+  std::shared_ptr<rclcpp::Client<gazebo_msgs::srv::SetEntityState>> set_state_client_;
+};
+
+void GazeboRosStateTest::SetUp()
+{
+  // Load world with state plugin and start paused
+  this->Load("worlds/gazebo_ros_state_test.world", true);
+
+  // World
+  world_ = gazebo::physics::get_world();
+  ASSERT_NE(nullptr, world_);
+
+  // Create ROS clients
+  node_ = std::make_shared<rclcpp::Node>("gazebo_ros_state_test");
+  ASSERT_NE(nullptr, node_);
+
+  get_state_client_ =
+    node_->create_client<gazebo_msgs::srv::GetEntityState>("test/get_entity_state");
+  ASSERT_NE(nullptr, get_state_client_);
+  EXPECT_TRUE(get_state_client_->wait_for_service(std::chrono::seconds(1)));
+
+  set_state_client_ =
+    node_->create_client<gazebo_msgs::srv::SetEntityState>("test/set_entity_state");
+  ASSERT_NE(nullptr, set_state_client_);
+  EXPECT_TRUE(set_state_client_->wait_for_service(std::chrono::seconds(1)));
+}
+
+void GazeboRosStateTest::GetState(
+  const std::string & _entity,
+  const ignition::math::Pose3d & _pose,
+  const ignition::math::Vector3d & _lin_vel,
+  const ignition::math::Vector3d & _ang_vel)
+{
+  auto entity = world_->EntityByName(_entity);
+  ASSERT_NE(nullptr, entity);
+
+  auto request = std::make_shared<gazebo_msgs::srv::GetEntityState::Request>();
+  request->name = _entity;
+
+  auto response_future = get_state_client_->async_send_request(request);
+  EXPECT_EQ(rclcpp::executor::FutureReturnCode::SUCCESS,
+    rclcpp::spin_until_future_complete(node_, response_future));
+
+  auto response = response_future.get();
+  ASSERT_NE(nullptr, response);
+  EXPECT_TRUE(response->success);
+
+  EXPECT_NEAR(_pose.Pos().X(), response->state.pose.position.x, tol) << _entity;
+  EXPECT_NEAR(_pose.Pos().Y(), response->state.pose.position.y, tol) << _entity;
+  EXPECT_NEAR(_pose.Pos().Z(), response->state.pose.position.z, tol) << _entity;
+
+  EXPECT_NEAR(_pose.Rot().X(), response->state.pose.orientation.x, tol) << _entity;
+  EXPECT_NEAR(_pose.Rot().Y(), response->state.pose.orientation.y, tol) << _entity;
+  EXPECT_NEAR(_pose.Rot().Z(), response->state.pose.orientation.z, tol) << _entity;
+  EXPECT_NEAR(_pose.Rot().W(), response->state.pose.orientation.w, tol) << _entity;
+
+  EXPECT_NEAR(_lin_vel.X(), response->state.twist.linear.x, tol) << _entity;
+  EXPECT_NEAR(_lin_vel.Y(), response->state.twist.linear.y, tol) << _entity;
+  EXPECT_NEAR(_lin_vel.Z(), response->state.twist.linear.z, tol) << _entity;
+
+  EXPECT_NEAR(_ang_vel.X(), response->state.twist.angular.x, tol) << _entity;
+  EXPECT_NEAR(_ang_vel.Y(), response->state.twist.angular.y, tol) << _entity;
+  EXPECT_NEAR(_ang_vel.Z(), response->state.twist.angular.z, tol) << _entity;
+}
+
+void GazeboRosStateTest::SetState(
+  const std::string & _entity,
+  const ignition::math::Pose3d & _pose,
+  const ignition::math::Vector3d & _lin_vel,
+  const ignition::math::Vector3d & _ang_vel)
+{
+  auto request = std::make_shared<gazebo_msgs::srv::SetEntityState::Request>();
+  request->state.name = _entity;
+  request->state.pose.position = gazebo_ros::Convert<geometry_msgs::msg::Point>(_pose.Pos());
+  request->state.pose.orientation =
+    gazebo_ros::Convert<geometry_msgs::msg::Quaternion>(_pose.Rot());
+  request->state.twist.linear = gazebo_ros::Convert<geometry_msgs::msg::Vector3>(_lin_vel);
+  request->state.twist.angular = gazebo_ros::Convert<geometry_msgs::msg::Vector3>(_ang_vel);
+
+  auto response_future = set_state_client_->async_send_request(request);
+  EXPECT_EQ(rclcpp::executor::FutureReturnCode::SUCCESS,
+    rclcpp::spin_until_future_complete(node_, response_future));
+
+  auto response = response_future.get();
+  ASSERT_NE(nullptr, response);
+  EXPECT_TRUE(response->success);
+}
+
+TEST_F(GazeboRosStateTest, GetSet)
+{
+  // Get / set model state
+  {
+    // Get initial state
+    this->GetState("boxes", ignition::math::Pose3d(0, 0, 0.5, 0, 0, 0));
+
+    // Set new state
+    this->SetState("boxes", ignition::math::Pose3d(1.0, 2.0, 10.0, 0, 0, 0),
+      ignition::math::Vector3d(4.0, 0, 0), ignition::math::Vector3d::Zero);
+
+    // Check new state
+    this->GetState("boxes", ignition::math::Pose3d(1.0, 2.0, 10.0, 0, 0, 0),
+      ignition::math::Vector3d(4.0, 0, 0), ignition::math::Vector3d::Zero);
+  }
+
+  // Get / set light state
+  {
+    // Get initial state
+    this->GetState("sun", ignition::math::Pose3d(0, 0, 10, 0, 0, 0));
+
+    // Set new state
+    this->SetState("sun", ignition::math::Pose3d(1.0, 2.0, 3.0, 0.1, 0.2, 0.3));
+
+    // Check new state
+    this->GetState("sun", ignition::math::Pose3d(1.0, 2.0, 3.0, 0.1, 0.2, 0.3));
+  }
+
+  // Get / set link state
+  {
+    // Get initial state - note that is was moved with the model
+    this->GetState("boxes::top", ignition::math::Pose3d(1.0, 2.0, 11.25, 0, 0, 0),
+      ignition::math::Vector3d(4.0, 0, 0), ignition::math::Vector3d::Zero);
+
+    // Set new state
+    this->SetState("boxes::top", ignition::math::Pose3d(10, 20, 30, 0.1, 0, 0),
+      ignition::math::Vector3d(1.0, 2.0, 3.0), ignition::math::Vector3d(0.0, 0.0, 4.0));
+
+    // Check new state
+    this->GetState("boxes::top", ignition::math::Pose3d(10, 20, 30, 0.1, 0, 0),
+      ignition::math::Vector3d(1.0, 2.0, 3.0), ignition::math::Vector3d(0.0, 0.0, 4.0));
+  }
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/gazebo_ros/test/worlds/gazebo_ros_state_test.world
+++ b/gazebo_ros/test/worlds/gazebo_ros_state_test.world
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <world name="default">
+    <plugin name="gazebo_ros_state" filename="libgazebo_ros_state.so">
+      <ros>
+        <namespace>/test</namespace>
+      </ros>
+    </plugin>
+
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <model name='boxes'>
+      <pose>0 0 0.5 0 0 0</pose>
+
+      <link name='bottom'>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <link name='top'>
+        <pose>0 0 1.25 0 0 0</pose>
+        <self_collide>true</self_collide>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.5</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.5</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+
+    </model>
+  </world>
+</sdf>
+

--- a/gazebo_ros/worlds/gazebo_ros_state_demo.world
+++ b/gazebo_ros/worlds/gazebo_ros_state_demo.world
@@ -1,0 +1,87 @@
+<?xml version="1.0"?>
+<!--
+  Gazebo ROS state plugin demo
+
+  Try for example to get a model's state w.r.t. the world:
+
+      ros2 service call /demo/get_entity_state 'gazebo_msgs/GetEntityState' '{name: "boxes"}'
+
+  Or a link's state w.r.t. the world:
+
+      ros2 service call /demo/get_entity_state 'gazebo_msgs/GetEntityState' '{name: "boxes::bottom", relative_frame: "world"}'
+
+  Or a light's state w.r.t. another entity:
+
+      ros2 service call /demo/get_entity_state 'gazebo_msgs/GetEntityState' '{name: "sun", relative_frame: "ground_plane"}'
+
+  > When setting state, note that the changes for static entities may not be visible on gzclient due to https://bitbucket.org/osrf/gazebo/issues/2560
+
+  Try teleporting a model:
+
+      ros2 service call /demo/set_entity_state 'gazebo_msgs/SetEntityState' '{state: {name: "boxes", pose: {position: {y: 2}}}}'
+
+  Or rotating a light:
+
+      ros2 service call /demo/set_entity_state 'gazebo_msgs/SetEntityState' '{state: {name: "sun", pose: {position: {z: 10}, orientation: {x: 0.1, y: 0.2, z: 0.3, w: 0.5}}}}'
+
+  Try teleporting a model:
+
+      ros2 service call /demo/set_entity_state 'gazebo_msgs/SetEntityState' '{state: {name: "boxes::top", reference_frame: "boxes::top", twist: {angular: {x: 2}}}}'
+-->
+<sdf version="1.6">
+  <world name="default">
+    <plugin name="gazebo_ros_state" filename="libgazebo_ros_state.so">
+      <ros>
+        <namespace>/demo</namespace>
+      </ros>
+    </plugin>
+
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <model name='boxes'>
+      <pose>0 0 0.5 0 0 0</pose>
+
+      <link name='bottom'>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <link name='top'>
+        <pose>0 0 1.25 0 0 0</pose>
+        <self_collide>true</self_collide>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.5</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.5</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+
+    </model>
+  </world>
+</sdf>
+


### PR DESCRIPTION
This is part of breaking `gazebo_ros_api` into several plugins, see #779 and #838.

See the migration documentation: [ROS 2 Migration: Entity states](https://github.com/ros-simulation/gazebo_ros_pkgs/wiki/ROS-2-Migration:-Entity-states).

Try the demo world added in this PR (see the world file for more detailed instructions):

`gazebo  gazebo_ros/worlds/gazebo_ros_state_demo.world`

FYI @mkhansen-intel.