### PR TITLE
fix: Robot namespace tf prefix handled properly

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_p3d.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_p3d.h
@@ -86,7 +86,7 @@ namespace gazebo
     /// \brief frame transform name, should match link name
     /// FIXME: extract link name directly?
     private: std::string frame_name_;
-    private: std::string tf_frame_name_;
+    private: std::string tf_frame_name_;  // @TODO: remove in Noetic (not used anymore)
 
     /// \brief allow specifying constant xyz and rpy offsets
     private: ignition::math::Pose3d offset_;


### PR DESCRIPTION
Handled the same as other plugins, e.g. laser plugin.

Addresses https://github.com/ros-simulation/gazebo_ros_pkgs/issues/846