### PR TITLE
[ros2] ENABLE_DISPLAY_TESTS, and make camera tests more robust

### DIFF
--- a/gazebo_plugins/test/CMakeLists.txt
+++ b/gazebo_plugins/test/CMakeLists.txt
@@ -1,6 +1,8 @@
 find_package(ament_cmake_gtest REQUIRED)
 find_package(cv_bridge REQUIRED)
 
+option(ENABLE_DISPLAY_TESTS "Enable the building of tests that requires a display" OFF)
+
 # Worlds
 file(GLOB worlds RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "worlds/*.world")
 foreach(world ${worlds})
@@ -10,16 +12,21 @@ endforeach()
 
 # Tests
 set(tests
-  test_gazebo_ros_camera
-  # TODO(louise) Test hangs on teardown while destroying 2nd node
-  # test_gazebo_ros_camera_distortion
-  test_gazebo_ros_camera_triggered
   test_gazebo_ros_diff_drive
   test_gazebo_ros_force
   test_gazebo_ros_imu_sensor
   test_gazebo_ros_joint_state_publisher
   test_gazebo_ros_ray_sensor
 )
+
+if(ENABLE_DISPLAY_TESTS)
+set(tests ${tests}
+  test_gazebo_ros_camera
+  # TODO(louise) Test hangs on teardown while destroying 2nd node
+  # test_gazebo_ros_camera_distortion
+  test_gazebo_ros_camera_triggered
+)
+endif()
 
 foreach(test ${tests})
   ament_add_gtest(${test}

--- a/gazebo_plugins/test/test_gazebo_ros_camera.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_camera.cpp
@@ -66,7 +66,12 @@ TEST_P(GazeboRosCameraTest, CameraSubscribeTest)
 
   // Update rate is 0.5 Hz, so we step 3s sim time to be sure we get exactly 1 image at 2s
   world->Step(3000);
-  executor.spin_once(100ms);
+  unsigned int sleep = 0;
+  unsigned int max_sleep = 30;
+  while (sleep < max_sleep && msg_count == 0) {
+    executor.spin_once(100ms);
+    sleep++;
+  }
 
   EXPECT_EQ(1u, msg_count);
   EXPECT_EQ(2.0, image_stamp.sec);

--- a/gazebo_plugins/test/test_gazebo_ros_camera_distortion.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_camera_distortion.cpp
@@ -99,7 +99,7 @@ TEST_P(GazeboRosCameraDistortionTest, CameraSubscribeTest)
 
   // Subscribe to undistorted image
   sensor_msgs::msg::Image::ConstSharedPtr cam_image_undistorted;
-  cam_sub_undistorted_ = image_transport::create_subscription(node,
+  cam_sub_undistorted_ = image_transport::create_subscription(node.get(),
       GetParam().undistorted_topic,
       [&cam_image_undistorted](const sensor_msgs::msg::Image::ConstSharedPtr & _msg) {
         cam_image_undistorted = _msg;
@@ -108,7 +108,7 @@ TEST_P(GazeboRosCameraDistortionTest, CameraSubscribeTest)
 
   // Subscribe to distorted image
   sensor_msgs::msg::Image::ConstSharedPtr cam_image_distorted;
-  cam_sub_distorted_ = image_transport::create_subscription(node,
+  cam_sub_distorted_ = image_transport::create_subscription(node.get(),
       GetParam().distorted_topic,
       [&cam_image_distorted](const sensor_msgs::msg::Image::ConstSharedPtr & _msg) {
         cam_image_distorted = _msg;

--- a/gazebo_plugins/test/test_gazebo_ros_camera_triggered.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_camera_triggered.cpp
@@ -69,7 +69,13 @@ TEST_F(GazeboRosTriggeredCameraTest, CameraSubscribeTest)
 
   // Step a bit and check that we get exactly one message
   world->Step(100);
-  executor.spin_once(100ms);
+
+  unsigned int sleep = 0;
+  unsigned int max_sleep = 30;
+  while (sleep < max_sleep && msg_count == 0) {
+    executor.spin_once(100ms);
+    sleep++;
+  }
 
   EXPECT_EQ(1u, msg_count);
 
@@ -82,7 +88,12 @@ TEST_F(GazeboRosTriggeredCameraTest, CameraSubscribeTest)
 
   // Step a bit and check that we get exactly two messages
   world->Step(100);
-  executor.spin_once(100ms);
+
+  sleep = 0;
+  while (sleep < max_sleep && msg_count < 3) {
+    executor.spin_once(100ms);
+    sleep++;
+  }
 
   EXPECT_EQ(3u, msg_count);
 


### PR DESCRIPTION
This way, to build camera test one needs to run:

`colcon build --packages-select gazebo_plugins --cmake-args -DENABLE_DISPLAY_TESTS=true`

Camera tests will be build in the OSRF build farm, but not on the ROS build farm.