### PR TITLE
[ros2] Add check if rclcpp::init() has been called

### DIFF
--- a/gazebo_ros/src/gazebo_ros_factory.cpp
+++ b/gazebo_ros/src/gazebo_ros_factory.cpp
@@ -106,10 +106,8 @@ GazeboRosFactory::~GazeboRosFactory()
 {
 }
 
-void GazeboRosFactory::Load(int argc, char ** argv)
+void GazeboRosFactory::Load(int /* argc */, char ** /* argv */)
 {
-  rclcpp::init(argc, argv);
-
   // Keep this in the constructor for performance.
   // sdf::initFile causes disk access.
   sdf::initFile("root.sdf", impl_->factory_sdf_);

--- a/gazebo_ros/src/gazebo_ros_init.cpp
+++ b/gazebo_ros/src/gazebo_ros_init.cpp
@@ -50,9 +50,15 @@ GazeboRosInit::~GazeboRosInit()
 void GazeboRosInit::Load(int argc, char ** argv)
 {
   // Initialize ROS with arguments
-  rclcpp::init(argc, argv);
-
-  impl_->ros_node_ = gazebo_ros::Node::Get();
+  if (!rclcpp::is_initialized()) {
+    rclcpp::init(argc, argv);
+    impl_->ros_node_ = gazebo_ros::Node::Get();
+  } else {
+    impl_->ros_node_ = gazebo_ros::Node::Get();
+    RCLCPP_WARN(impl_->ros_node_->get_logger(),
+      "gazebo_ros_init didn't initialize ROS "
+      "because it's already initialized with other arguments");
+  }
 
   // Offer transient local durability on the clock topic so that if publishing is infrequent (e.g.
   // the simulation is paused), late subscribers can receive the previously published message(s).

--- a/gazebo_ros/test/test_plugins.cpp
+++ b/gazebo_ros/test/test_plugins.cpp
@@ -73,6 +73,8 @@ INSTANTIATE_TEST_CASE_P(Plugins, TestPlugins, ::testing::Values(
     TestParams({{"-s", "./libmultiple_nodes.so"}, {"testA", "testB"}}),
     TestParams({{"-s", "libgazebo_ros_init.so", "worlds/ros_world_plugin.world",
         "hello_ros_world:/test:=/new_test"}, {"new_test"}}),
+    TestParams({{"-s", "libgazebo_ros_init.so", "-s", "libgazebo_ros_factory.so",
+        "worlds/ros_world_plugin.world"}, {"test"}}),
     TestParams({{"-s", "libgazebo_ros_init.so", "worlds/sdf_node_plugin.world"}, {"/foo/my_topic"}})
   ), );
 


### PR DESCRIPTION
Hi,

I would like to use both ``gazebo_ros_init`` and ``gazebo_ros_factory`` plugins at the same time. But when I tried that, it failed.

```bash
tamaki@pc:~$ gzserver --verbose -s libgazebo_ros_init.so -s libgazebo_ros_factory.so
Gazebo multi-robot simulator, version 9.0.0
Copyright (C) 2012 Open Source Robotics Foundation.
Released under the Apache 2 License.
http://gazebosim.org

terminate called after throwing an instance of 'rclcpp::ContextAlreadyInitialized'
  what():  context is already initialized
Aborted (core dumped)
```
This PR adds check if ``rclcpp::init()`` has been called before calling it.