### PR TITLE
Add option to publish depth images in 16UC1

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
@@ -181,6 +181,7 @@ namespace gazebo
     private: int depth_info_connect_count_;
     private: void DepthInfoConnect();
     private: void DepthInfoDisconnect();
+    private: bool use_depth_image_16UC1_format_;
 
     // overload with our own
     private: common::Time depth_sensor_update_time_;

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_openni_kinect.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_openni_kinect.h
@@ -134,6 +134,7 @@ namespace gazebo
     private: void DepthInfoConnect();
     private: void DepthInfoDisconnect();
     private: common::Time last_depth_image_camera_info_update_time_;
+    private: bool use_depth_image_16UC1_format_;
     protected: ros::Publisher depth_image_camera_info_pub_;
 
     using GazeboRosCameraUtils::PublishCameraInfo;

--- a/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
@@ -129,6 +129,12 @@ void GazeboRosDepthCamera::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf
   else
     this->reduce_normals_ = _sdf->GetElement("reduceNormals")->Get<int>();
 
+  // allow optional publication of depth images in 16UC1 instead of 32FC1
+  if (!_sdf->HasElement("useDepth16UC1Format"))
+    this->use_depth_image_16UC1_format_ = false;
+  else
+    this->use_depth_image_16UC1_format_ = _sdf->GetElement("useDepth16UC1Format")->Get<bool>();
+
   load_connection_ = GazeboRosCameraUtils::OnLoad(boost::bind(&GazeboRosDepthCamera::Advertise, this));
   GazeboRosCameraUtils::Load(_parent, _sdf);
 }
@@ -678,16 +684,32 @@ bool GazeboRosDepthCamera::FillDepthImageHelper(
     uint32_t rows_arg, uint32_t cols_arg,
     uint32_t step_arg, void* data_arg)
 {
-  image_msg.encoding = sensor_msgs::image_encodings::TYPE_32FC1;
   image_msg.height = rows_arg;
   image_msg.width = cols_arg;
-  image_msg.step = sizeof(float) * cols_arg;
-  image_msg.data.resize(rows_arg * cols_arg * sizeof(float));
   image_msg.is_bigendian = 0;
+  // deal with the differences in between 32FC1 & 16UC1
+  // http://www.ros.org/reps/rep-0118.html#id4
+  union uint16_or_float
+  {
+    uint16_t* dest_uint16;
+    float* dest_float;
+  };
+  uint16_or_float dest;
+  if (!this->use_depth_image_16UC1_format_)
+  {
+    image_msg.encoding = sensor_msgs::image_encodings::TYPE_32FC1;
+    image_msg.step = sizeof(float) * cols_arg;
+    image_msg.data.resize(rows_arg * cols_arg * sizeof(float));
+    dest.dest_float = (float*)(&(image_msg.data[0]));
+  }
+  else
+  {
+    image_msg.encoding = sensor_msgs::image_encodings::TYPE_16UC1;
+    image_msg.step = sizeof(uint16_t) * cols_arg;
+    image_msg.data.resize(rows_arg * cols_arg * sizeof(uint16_t));
+    dest.dest_uint16 = (uint16_t*)(&(image_msg.data[0]));
+  }
 
-  const float bad_point = std::numeric_limits<float>::quiet_NaN();
-
-  float* dest = (float*)(&(image_msg.data[0]));
   float* toCopyFrom = (float*)data_arg;
   int index = 0;
 
@@ -698,13 +720,20 @@ bool GazeboRosDepthCamera::FillDepthImageHelper(
     {
       float depth = toCopyFrom[index++];
 
-      if (depth > this->point_cloud_cutoff_)
+      if (depth > this->point_cloud_cutoff_ &&
+          depth < this->point_cloud_cutoff_max_)
       {
-        dest[i + j * cols_arg] = depth;
+        if (!this->use_depth_image_16UC1_format_)
+          dest.dest_float[i + j * cols_arg] = depth;
+        else
+          dest.dest_uint16[i + j * cols_arg] = depth * 1000.0;
       }
       else //point in the unseeable range
       {
-        dest[i + j * cols_arg] = bad_point;
+        if (!this->use_depth_image_16UC1_format_)
+          dest.dest_float[i + j * cols_arg] = std::numeric_limits<float>::quiet_NaN();
+        else
+          dest.dest_uint16[i + j * cols_arg] = 0;
       }
     }
   }

--- a/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
@@ -720,8 +720,7 @@ bool GazeboRosDepthCamera::FillDepthImageHelper(
     {
       float depth = toCopyFrom[index++];
 
-      if (depth > this->point_cloud_cutoff_ &&
-          depth < this->point_cloud_cutoff_max_)
+      if (depth > this->point_cloud_cutoff_)
       {
         if (!this->use_depth_image_16UC1_format_)
           dest.dest_float[i + j * cols_arg] = depth;


### PR DESCRIPTION
Given there are sensors in robots that publish depth images natively in the `16UC1` format, it is convenient to be able to simulate it instead of converting manually later on from `32FC1`.
