### PR TITLE
[ros2] Port time commands (pause / reset)

### DIFF
--- a/.ros1_unported/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
+++ b/.ros1_unported/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
@@ -166,18 +166,6 @@ public:
   bool applyJointEffort(gazebo_msgs::ApplyJointEffort::Request &req,gazebo_msgs::ApplyJointEffort::Response &res);
 
   /// \brief
-  bool resetSimulation(std_srvs::Empty::Request &req,std_srvs::Empty::Response &res);
-
-  /// \brief
-  bool resetWorld(std_srvs::Empty::Request &req,std_srvs::Empty::Response &res);
-
-  /// \brief
-  bool pausePhysics(std_srvs::Empty::Request &req,std_srvs::Empty::Response &res);
-
-  /// \brief
-  bool unpausePhysics(std_srvs::Empty::Request &req,std_srvs::Empty::Response &res);
-
-  /// \brief
   bool clearJointForces(gazebo_msgs::JointRequest::Request &req,gazebo_msgs::JointRequest::Response &res);
   bool clearJointForces(std::string joint_name);
 
@@ -263,10 +251,6 @@ private:
   ros::ServiceServer set_joint_properties_service_;
   ros::ServiceServer apply_joint_effort_service_;
   ros::ServiceServer set_model_configuration_service_;
-  ros::ServiceServer reset_simulation_service_;
-  ros::ServiceServer reset_world_service_;
-  ros::ServiceServer pause_physics_service_;
-  ros::ServiceServer unpause_physics_service_;
   ros::ServiceServer clear_joint_forces_service_;
   ros::ServiceServer clear_body_wrenches_service_;
   ros::Publisher     pub_link_states_;

--- a/.ros1_unported/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/.ros1_unported/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -351,24 +351,6 @@ void GazeboRosApiPlugin::advertiseServices()
   set_joint_properties_service_ = nh_->advertiseService(set_joint_properties_aso);
 
   // Advertise more services on the custom queue
-  std::string pause_physics_service_name("pause_physics");
-  ros::AdvertiseServiceOptions pause_physics_aso =
-    ros::AdvertiseServiceOptions::create<std_srvs::Empty>(
-                                                          pause_physics_service_name,
-                                                          boost::bind(&GazeboRosApiPlugin::pausePhysics,this,_1,_2),
-                                                          ros::VoidPtr(), &gazebo_queue_);
-  pause_physics_service_ = nh_->advertiseService(pause_physics_aso);
-
-  // Advertise more services on the custom queue
-  std::string unpause_physics_service_name("unpause_physics");
-  ros::AdvertiseServiceOptions unpause_physics_aso =
-    ros::AdvertiseServiceOptions::create<std_srvs::Empty>(
-                                                          unpause_physics_service_name,
-                                                          boost::bind(&GazeboRosApiPlugin::unpausePhysics,this,_1,_2),
-                                                          ros::VoidPtr(), &gazebo_queue_);
-  unpause_physics_service_ = nh_->advertiseService(unpause_physics_aso);
-
-  // Advertise more services on the custom queue
   std::string apply_body_wrench_service_name("apply_body_wrench");
   ros::AdvertiseServiceOptions apply_body_wrench_aso =
     ros::AdvertiseServiceOptions::create<gazebo_msgs::ApplyBodyWrench>(
@@ -403,25 +385,6 @@ void GazeboRosApiPlugin::advertiseServices()
                                                                    boost::bind(&GazeboRosApiPlugin::clearBodyWrenches,this,_1,_2),
                                                                    ros::VoidPtr(), &gazebo_queue_);
   clear_body_wrenches_service_ = nh_->advertiseService(clear_body_wrenches_aso);
-
-  // Advertise more services on the custom queue
-  std::string reset_simulation_service_name("reset_simulation");
-  ros::AdvertiseServiceOptions reset_simulation_aso =
-    ros::AdvertiseServiceOptions::create<std_srvs::Empty>(
-                                                          reset_simulation_service_name,
-                                                          boost::bind(&GazeboRosApiPlugin::resetSimulation,this,_1,_2),
-                                                          ros::VoidPtr(), &gazebo_queue_);
-  reset_simulation_service_ = nh_->advertiseService(reset_simulation_aso);
-
-  // Advertise more services on the custom queue
-  std::string reset_world_service_name("reset_world");
-  ros::AdvertiseServiceOptions reset_world_aso =
-    ros::AdvertiseServiceOptions::create<std_srvs::Empty>(
-                                                          reset_world_service_name,
-                                                          boost::bind(&GazeboRosApiPlugin::resetWorld,this,_1,_2),
-                                                          ros::VoidPtr(), &gazebo_queue_);
-  reset_world_service_ = nh_->advertiseService(reset_world_aso);
-
 
   // set param for use_sim_time if not set by user already
   if(!(nh_->hasParam("/use_sim_time")))
@@ -953,30 +916,6 @@ bool GazeboRosApiPlugin::applyJointEffort(gazebo_msgs::ApplyJointEffort::Request
 
   res.success = false;
   res.status_message = "ApplyJointEffort: joint not found";
-  return true;
-}
-
-bool GazeboRosApiPlugin::resetSimulation(std_srvs::Empty::Request &req,std_srvs::Empty::Response &res)
-{
-  world_->Reset();
-  return true;
-}
-
-bool GazeboRosApiPlugin::resetWorld(std_srvs::Empty::Request &req,std_srvs::Empty::Response &res)
-{
-  world_->ResetEntities(gazebo::physics::Base::MODEL);
-  return true;
-}
-
-bool GazeboRosApiPlugin::pausePhysics(std_srvs::Empty::Request &req,std_srvs::Empty::Response &res)
-{
-  world_->SetPaused(true);
-  return true;
-}
-
-bool GazeboRosApiPlugin::unpausePhysics(std_srvs::Empty::Request &req,std_srvs::Empty::Response &res)
-{
-  world_->SetPaused(false);
   return true;
 }
 

--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(rclcpp REQUIRED)
 find_package(gazebo_dev REQUIRED)
 find_package(gazebo_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
 find_package(tinyxml_vendor REQUIRED)
 
 include_directories(
@@ -54,6 +55,7 @@ ament_target_dependencies(gazebo_ros_init
   "builtin_interfaces"
   "gazebo_dev"
   "rclcpp"
+  "std_srvs"
 )
 target_link_libraries(gazebo_ros_init
   gazebo_ros_node

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -25,6 +25,7 @@
   <depend>gazebo_dev</depend>
   <depend>gazebo_msgs</depend>
   <depend>rclcpp</depend>
+  <depend>std_srvs</depend>
   <depend>tinyxml_vendor</depend>
 
   <build_export_depend>geometry_msgs</build_export_depend>

--- a/gazebo_ros/test/CMakeLists.txt
+++ b/gazebo_ros/test/CMakeLists.txt
@@ -4,6 +4,7 @@ find_package(gazebo_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
 
 # Plugins
 set(plugins
@@ -31,6 +32,7 @@ file(COPY worlds DESTINATION .)
 set(tests
   test_conversions
   test_gazebo_ros_factory
+  test_gazebo_ros_init
   test_gazebo_ros_state
   test_node
   test_plugins
@@ -60,6 +62,7 @@ foreach(test ${tests})
     "rclcpp"
     "sensor_msgs"
     "std_msgs"
+    "std_srvs"
   )
 endforeach()
 

--- a/gazebo_ros/test/test_gazebo_ros_init.cpp
+++ b/gazebo_ros/test/test_gazebo_ros_init.cpp
@@ -1,0 +1,146 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gazebo/test/ServerFixture.hh>
+#include <rclcpp/rclcpp.hpp>
+#include <std_srvs/srv/empty.hpp>
+#include <memory>
+
+class GazeboRosInitTest : public gazebo::ServerFixture
+{
+};
+
+// Since the plugin calls rclcpp:init, and that can be called only once, we can only run one test
+TEST_F(GazeboRosInitTest, Commands)
+{
+  // Load empty world with init plugin and start paused
+  this->LoadArgs("-u --verbose -s libgazebo_ros_init.so worlds/free_fall.world");
+
+  // World
+  auto world = gazebo::physics::get_world();
+  ASSERT_NE(nullptr, world);
+
+  // Model
+  auto model = world->ModelByName("box");
+  ASSERT_NE(nullptr, model);
+
+  // ROS node
+  auto node = std::make_shared<rclcpp::Node>("gazebo_ros_init_test");
+  ASSERT_NE(nullptr, node);
+
+  // Pause / unpause simulation
+  {
+    // Check world is paused
+    EXPECT_TRUE(world->IsPaused());
+
+    // Create unpause client
+    auto unpause_physics_client = node->create_client<std_srvs::srv::Empty>("unpause_physics");
+    ASSERT_NE(nullptr, unpause_physics_client);
+    EXPECT_TRUE(unpause_physics_client->wait_for_service(std::chrono::seconds(1)));
+
+    // Request
+    auto request = std::make_shared<std_srvs::srv::Empty::Request>();
+
+    auto response_future = unpause_physics_client->async_send_request(request);
+    EXPECT_EQ(rclcpp::executor::FutureReturnCode::SUCCESS,
+      rclcpp::spin_until_future_complete(node, response_future));
+
+    auto response = response_future.get();
+    ASSERT_NE(nullptr, response);
+
+    // Check world is unpaused
+    EXPECT_FALSE(world->IsPaused());
+
+    // Create pause client
+    auto pause_physics_client = node->create_client<std_srvs::srv::Empty>("pause_physics");
+    ASSERT_NE(nullptr, pause_physics_client);
+    EXPECT_TRUE(pause_physics_client->wait_for_service(std::chrono::seconds(1)));
+
+    // Request
+    response_future = pause_physics_client->async_send_request(request);
+    EXPECT_EQ(rclcpp::executor::FutureReturnCode::SUCCESS,
+      rclcpp::spin_until_future_complete(node, response_future));
+
+    response = response_future.get();
+    ASSERT_NE(nullptr, response);
+
+    // Check world is paused
+    EXPECT_TRUE(world->IsPaused());
+  }
+
+  // Reset
+  {
+    // Step the world so the box falls a bit
+    world->Step(1000);
+
+    // Check time increases and model moves
+    EXPECT_GE(world->SimTime(), gazebo::common::Time(1.0));
+    EXPECT_LT(model->WorldPose().Pos().Z(), 0.0);
+
+    // Create reset simulation client
+    auto reset_simulation_client = node->create_client<std_srvs::srv::Empty>("reset_simulation");
+    ASSERT_NE(nullptr, reset_simulation_client);
+    EXPECT_TRUE(reset_simulation_client->wait_for_service(std::chrono::seconds(1)));
+
+    // Request
+    auto request = std::make_shared<std_srvs::srv::Empty::Request>();
+
+    auto response_future = reset_simulation_client->async_send_request(request);
+    EXPECT_EQ(rclcpp::executor::FutureReturnCode::SUCCESS,
+      rclcpp::spin_until_future_complete(node, response_future));
+
+    auto response = response_future.get();
+    ASSERT_NE(nullptr, response);
+
+    // Check time and model pose
+    EXPECT_EQ(gazebo::common::Time(0.0), world->SimTime());
+    EXPECT_GT(model->WorldPose().Pos().Z(), 0.0);
+
+    // Step the world
+    world->Step(1000);
+
+    // Check time increases and model moves
+    EXPECT_GE(world->SimTime(), gazebo::common::Time(1.0));
+    EXPECT_LT(model->WorldPose().Pos().Z(), 0.0);
+
+    // Create reset client
+    auto reset_world_client = node->create_client<std_srvs::srv::Empty>("reset_world");
+    ASSERT_NE(nullptr, reset_world_client);
+    EXPECT_TRUE(reset_world_client->wait_for_service(std::chrono::seconds(1)));
+
+    // Request
+    request = std::make_shared<std_srvs::srv::Empty::Request>();
+
+    response_future = reset_world_client->async_send_request(request);
+    EXPECT_EQ(rclcpp::executor::FutureReturnCode::SUCCESS,
+      rclcpp::spin_until_future_complete(node, response_future));
+
+    response = response_future.get();
+    ASSERT_NE(nullptr, response);
+
+    // Check model pose was reset, but not time
+    EXPECT_GE(world->SimTime(), gazebo::common::Time(1.0));
+    EXPECT_GT(model->WorldPose().Pos().Z(), 0.0);
+  }
+
+  auto reset_world_client = node->create_client<std_srvs::srv::Empty>("reset_world");
+  ASSERT_NE(nullptr, reset_world_client);
+  EXPECT_TRUE(reset_world_client->wait_for_service(std::chrono::seconds(1)));
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/gazebo_ros/test/worlds/free_fall.world
+++ b/gazebo_ros/test/worlds/free_fall.world
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <world name="default">
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <model name="box">
+      <pose>0 0 0.5 0 0 0</pose>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
Addresses https://github.com/ros-simulation/gazebo_ros_pkgs/issues/863 and is part of https://github.com/ros-simulation/gazebo_ros_pkgs/issues/779.

Added migration / demo notes [here](https://github.com/ros-simulation/gazebo_ros_pkgs/wiki/ROS-2-Migration:-ROS-Clocks-and-sim-time) and [here](https://github.com/ros-simulation/gazebo_ros_pkgs/wiki/ROS-2-Migration:-gazebo_ros_api_plugin)
