### PR TITLE
gazebo_plugins/added zero mean gaussian noise to the kinect plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@
 .DS_Store
 
 CATKIN_IGNORE
+
+# VSCode
+.vscode
+*/build/*

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_openni_kinect.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_openni_kinect.h
@@ -123,7 +123,18 @@ namespace gazebo
     /// \brief ROS image topic name
     private: std::string point_cloud_topic_name_;
 
+    /// \brief Gaussian noise
+    private: double gaussian_noise_;
 
+    /// \brief Gaussian noise generator
+    private: static double gaussianKernel(double mu, double sigma)
+    {
+      // using Box-Muller transform to generate two independent standard normally distributed normal variables
+      // see wikipedia
+      double U = (double)rand() / (double)RAND_MAX; // normalized uniform random variable
+      double V = (double)rand() / (double)RAND_MAX; // normalized uniform random variable
+      return sigma * (sqrt(-2.0 * ::log(U)) * cos(2.0 * M_PI * V)) + mu;
+    }
     /// \brief image where each pixel contains the depth data
     private: std::string depth_image_topic_name_;
     private: common::Time depth_sensor_update_time_;

--- a/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
+++ b/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
@@ -103,6 +103,13 @@ void GazeboRosOpenniKinect::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sd
   else
     this->point_cloud_cutoff_max_ = _sdf->GetElement("pointCloudCutoffMax")->Get<double>();
 
+  // noise
+    if (!_sdf->HasElement("gaussianNoise")) {
+    this->gaussian_noise_ = 0;
+  } else {
+    this->gaussian_noise_ = _sdf->GetElement("gaussianNoise")->Get<double>();
+  }
+
   load_connection_ = GazeboRosCameraUtils::OnLoad(boost::bind(&GazeboRosOpenniKinect::Advertise, this));
   GazeboRosCameraUtils::Load(_parent, _sdf);
 }
@@ -334,7 +341,7 @@ bool GazeboRosOpenniKinect::FillPointCloudHelper(
       if (cols_arg>1) yAngle = atan2( (double)i - 0.5*(double)(cols_arg-1), fl);
       else            yAngle = 0.0;
 
-      double depth = toCopyFrom[index++]; // + 0.0*this->myParent->GetNearClip();
+      double depth = toCopyFrom[index++] * ( 1 + gaussianKernel(0, this->gaussian_noise_) ); // + 0.0*this->myParent->GetNearClip();
 
       if(depth > this->point_cloud_cutoff_ &&
          depth < this->point_cloud_cutoff_max_)


### PR DESCRIPTION
### Intro
Hi, I am a developer working with a depth camera that we simulate using the kinect plugin. When simulating the depth camera, gaussian noise is useful in order to have a more realistic representation of the sensor.

### Gaussian noise
The implementation is a zero mean multiplicative Gaussian Noise. The way this is implemented was taken from the gaussian noise representation in the [velodyne_gazebo_plugins](https://bitbucket.org/DataspeedInc/velodyne_simulator/src/master/velodyne_gazebo_plugins/) package, which is under BSD license. The author does not intend to brake any Copyright; if it happened to be the case with this pull request, please decline it.

### Usage
When calling the plugin from your .xacro file, as explained in this [tutorial](http://gazebosim.org/tutorials?tut=ros_depth_camera&cat=connect_ros), simply add the parameter `<gaussianNoise>0.01</gaussianNoise>` (or whatever other value you prefer); this parameter is the standard deviation of the gaussian noise.
