### PR TITLE
[Windows][melodic] Windows implementation for setenv.

### DIFF
--- a/gazebo_ros/src/gazebo_ros_paths_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_paths_plugin.cpp
@@ -27,6 +27,19 @@
 
 #include <map>
 
+#ifdef _WIN32
+int setenv(const char *name, const char *value, int overwrite)
+{
+    int errcode = 0;
+    if(!overwrite) {
+        size_t envsize = 0;
+        errcode = ::getenv_s(&envsize, NULL, 0, name);
+        if(errcode || envsize) return errcode;
+    }
+    return ::_putenv_s(name, value);
+}
+#endif
+
 namespace gazebo
 {
 


### PR DESCRIPTION
setenv is a POSIX function and which is not provided by MSVC runtime library. Here is to add an implementation for Windows build.