### PR TITLE
[ros2] Fix diff_drive error message

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
@@ -237,7 +237,8 @@ void GazeboRosDiffDrive::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr 
     !impl_->joints_[GazeboRosDiffDrivePrivate::RIGHT])
   {
     RCLCPP_ERROR(impl_->ros_node_->get_logger(),
-      "Joint [%s] or [%s] not found, plugin will not work.", left_joint, right_joint);
+      "Joint [%s] or [%s] not found, plugin will not work.", left_joint.c_str(),
+      right_joint.c_str());
 
     impl_->ros_node_.reset();
     return;


### PR DESCRIPTION
Small fix to add missing `c_str()` method of `std::string` in printf style log.