### PR TITLE
SetModelVisual service

### DIFF
--- a/gazebo_msgs/CMakeLists.txt
+++ b/gazebo_msgs/CMakeLists.txt
@@ -39,6 +39,7 @@ add_service_files(DIRECTORY srv FILES
   GetWorldProperties.srv
   SetLinkProperties.srv
   SetModelState.srv
+  SetModelVisual.srv
   BodyRequest.srv
   GetLinkProperties.srv
   GetModelState.srv

--- a/gazebo_msgs/srv/SetModelVisual.srv
+++ b/gazebo_msgs/srv/SetModelVisual.srv
@@ -1,0 +1,8 @@
+string name                   # name of model
+string parent_name            # reference frame
+float64 transparency
+bool visible
+bool is_static
+---
+bool success                  # return true if setting state successful
+string status_message         # comments if available

--- a/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
+++ b/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
@@ -65,6 +65,8 @@
 #include "gazebo_msgs/GetModelState.h"
 #include "gazebo_msgs/SetModelState.h"
 
+#include "gazebo_msgs/SetModelVisual.h"
+
 #include "gazebo_msgs/GetJointProperties.h"
 #include "gazebo_msgs/ApplyJointEffort.h"
 
@@ -196,6 +198,9 @@ public:
   bool setModelState(gazebo_msgs::SetModelState::Request &req,gazebo_msgs::SetModelState::Response &res);
 
   /// \brief
+  bool setModelVisual(gazebo_msgs::SetModelVisual::Request &req,gazebo_msgs::SetModelVisual::Response &res);
+
+  /// \brief
   void updateModelState(const gazebo_msgs::ModelState::ConstPtr& model_state);
 
   /// \brief
@@ -321,6 +326,7 @@ private:
   gazebo::transport::PublisherPtr factory_light_pub_;
   gazebo::transport::PublisherPtr light_modify_pub_;
   gazebo::transport::PublisherPtr request_pub_;
+  gazebo::transport::PublisherPtr visual_pub_;
   gazebo::transport::SubscriberPtr response_sub_;
 
   boost::shared_ptr<ros::NodeHandle> nh_;
@@ -353,6 +359,7 @@ private:
   ros::ServiceServer apply_body_wrench_service_;
   ros::ServiceServer set_joint_properties_service_;
   ros::ServiceServer set_model_state_service_;
+  ros::ServiceServer set_model_visual_service_;
   ros::ServiceServer apply_joint_effort_service_;
   ros::ServiceServer set_model_configuration_service_;
   ros::ServiceServer set_link_state_service_;


### PR DESCRIPTION
This PR implements the service `set_model_visual` for setting model visual properties, like the visibility and transperancy.
It is basically forwarding requests to Gazebo topic `~/visual` (type `gazebo::msgs::Visual`).