### PR TITLE
Remove extra angle bracket

### DIFF
--- a/gazebo_ros_pkgs/package.xml
+++ b/gazebo_ros_pkgs/package.xml
@@ -12,7 +12,7 @@
   <url type="bugtracker">https://github.com/ros-simulation/gazebo_ros_pkgs/issues</url>
   <url type="repository">https://github.com/ros-simulation/gazebo_ros_pkgs</url>
 
-  <author>John Hsu, Nate Koenig, Dave Coleman</author>>
+  <author>John Hsu, Nate Koenig, Dave Coleman</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 


### PR DESCRIPTION
Don't know why no one has cared in the past 6 years that this angle bracket makes invalid XML, but here's the fix anyway. 