### PR TITLE
added noise and outlier for the openni kinect plugin for ros melodic

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_openni_kinect.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_openni_kinect.h
@@ -123,6 +123,24 @@ namespace gazebo
     /// \brief ROS image topic name
     private: std::string point_cloud_topic_name_;
 
+    /// \brief Gaussian noise standard deviation
+    private: double gaussian_noise_;
+
+    /// \brief Gaussian noise generator
+    private: static double gaussianKernel(double mu, double sigma)
+    {
+      // using Box-Muller transform to generate two independent standard normally distributed normal variables
+      // see wikipedia
+      double U = (double)rand() / (double)RAND_MAX; // normalized uniform random variable
+      double V = (double)rand() / (double)RAND_MAX; // normalized uniform random variable
+      return sigma * (sqrt(-2.0 * ::log(U)) * cos(2.0 * M_PI * V)) + mu;
+    }
+
+    /// \brief outlier distance in meters from nominal point
+    private: double outlier_magnitude_;
+
+    /// \brief the index of the point which will become the outlier
+    private: int outlier_index_;
 
     /// \brief image where each pixel contains the depth data
     private: std::string depth_image_topic_name_;


### PR DESCRIPTION
### Intro

Hi, I am a developer working with a depth camera that we simulate using the kinect plugin. When simulating the depth camera, outliers and gaussian noise are useful in order to have a more realistic representation of the sensor.
### Gaussian noise

The implementation is a zero mean multiplicative Gaussian Noise, where the standard deviation can be set by the user. The way this is implemented was taken from the gaussian noise representation in the [velodyne_gazebo_plugins](https://bitbucket.org/DataspeedInc/velodyne_simulator/src/master/velodyne_gazebo_plugins/) package, which is under BSD license. The author does not intend to brake any Copyright; if it happened to be the case with this pull request, please decline it.

### Outliers

Also the outliers are implemented to act on the depth value of each point. In particular, the outlier magnitude is the percentage ( [-1, +1] ) that we want the outlier points to deviate from the nominal ones, while the outlier index is the position we want the outlier to be in (zero for random).


### Usage

When calling the plugin from your .xacro file, as explained in this [tutorial](http://gazebosim.org/tutorials?tut=ros_depth_camera&cat=connect_ros), simply add the parameters

- `<gaussianNoise>0.01</gaussianNoise>` 
- `<outlierMagnitude>0.4</outlierMagnitude>`
- `<outlierIndex>5000</outlierIndex>`
(or whatever other value you prefer).