### PR TITLE
Fix bug in clipping of block laser depth values

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -398,6 +398,7 @@ if (CATKIN_ENABLE_TESTING)
   target_link_libraries(set_model_state-test ${catkin_LIBRARIES})
 
   add_rostest(test/range/range_plugin.test)
+  add_rostest(test/block_laser_clipping.test)
 
   if (ENABLE_DISPLAY_TESTS)
     add_rostest_gtest(depth_camera-test

--- a/gazebo_plugins/scripts/test_block_laser_clipping.py
+++ b/gazebo_plugins/scripts/test_block_laser_clipping.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+"""
+Test plugin gazebo_ros_block_laser using gazebo_ros_block_laser_clipping.world.
+"""
+
+import math
+import rospy
+from sensor_msgs.msg import PointCloud
+
+import unittest
+
+class TestBlockLaserClippingPlugin(unittest.TestCase):
+    MIN_RANGE = 0.4
+    MAX_RANGE = 1.0
+
+    def _ranges(self):
+        msg = rospy.wait_for_message('test_block_laser', PointCloud)
+        for point in msg.points:
+            yield math.sqrt(point.x**2 + point.y**2 + point.z**2)
+
+    def test_points_at_all_depths(self):
+        # Make sure there are points at all depths
+        BIN_SIZE = 0.01
+        num_bins = int((self.MAX_RANGE - self.MIN_RANGE) / BIN_SIZE)
+        bins = [b * BIN_SIZE + self.MIN_RANGE for b in range(num_bins)]
+        bin_counts = dict(zip(bins, [0] * len(bins)))
+
+        for r in self._ranges():
+            closest_bin = None
+            closest_dist = float('inf')
+            for b in bins:
+                dist = abs(r - b)
+                if abs(r - b) < closest_dist:
+                    closest_dist = dist
+                    closest_bin = b
+            bin_counts[closest_bin] += 1
+
+        self.assertTrue(0 not in bin_counts.values(), msg=repr(bin_counts))
+
+    def test_between_min_max(self):
+        ALLOWED_ERROR = 0.00001
+        for r in self._ranges():
+            self.assertGreater(r, self.MIN_RANGE - ALLOWED_ERROR)
+            self.assertLess(r, self.MAX_RANGE + ALLOWED_ERROR)
+
+
+if __name__ == '__main__':
+    import rostest
+    PKG_NAME = 'gazebo_plugins'
+    TEST_NAME = PKG_NAME + 'block_laser_clipping'
+    rospy.init_node(TEST_NAME)
+    rostest.rosrun(PKG_NAME, TEST_NAME, TestBlockLaserClippingPlugin)

--- a/gazebo_plugins/src/gazebo_ros_block_laser.cpp
+++ b/gazebo_plugins/src/gazebo_ros_block_laser.cpp
@@ -304,15 +304,19 @@ void GazeboRosBlockLaser::PutLaserData(common::Time &_updateTime)
       j3 = hja + vjb * rayCount;
       j4 = hjb + vjb * rayCount;
       // range readings of 4 corners
-      r1 = std::min(this->parent_ray_sensor_->LaserShape()->GetRange(j1) , maxRange-minRange);
-      r2 = std::min(this->parent_ray_sensor_->LaserShape()->GetRange(j2) , maxRange-minRange);
-      r3 = std::min(this->parent_ray_sensor_->LaserShape()->GetRange(j3) , maxRange-minRange);
-      r4 = std::min(this->parent_ray_sensor_->LaserShape()->GetRange(j4) , maxRange-minRange);
+      r1 = this->parent_ray_sensor_->LaserShape()->GetRange(j1);
+      r2 = this->parent_ray_sensor_->LaserShape()->GetRange(j2);
+      r3 = this->parent_ray_sensor_->LaserShape()->GetRange(j3);
+      r4 = this->parent_ray_sensor_->LaserShape()->GetRange(j4);
 
       // Range is linear interpolation if values are close,
       // and min if they are very different
       r = (1-vb)*((1 - hb) * r1 + hb * r2)
          +   vb *((1 - hb) * r3 + hb * r4);
+
+      // clamp r to the min and max range of the sensor
+      r = std::min(r, maxRange);
+      r = std::max(r, minRange);
 
       // Intensity is averaged
       intensity = 0.25*(this->parent_ray_sensor_->LaserShape()->GetRetro(j1) +
@@ -335,29 +339,20 @@ void GazeboRosBlockLaser::PutLaserData(common::Time &_updateTime)
       /*  point scan from laser                                      */
       /*                                                             */
       /***************************************************************/
-      //compare 2 doubles
-      double diffRange = maxRange - minRange;
-      double diff  = diffRange - r;
-      if (fabs(diff) < EPSILON_DIFF)
-      {
-        // no noise if at max range
-        geometry_msgs::Point32 point;
-        //pAngle is rotated by yAngle:
-        point.x = r * cos(pAngle) * cos(yAngle);
-        point.y = r * cos(pAngle) * sin(yAngle);
-        point.z = r * sin(pAngle);
+      geometry_msgs::Point32 point;
+      //pAngle is rotated by yAngle:
+      point.x = r * cos(pAngle) * cos(yAngle);
+      point.y = r * cos(pAngle) * sin(yAngle);
+      point.z = r * sin(pAngle);
 
-        this->cloud_msg_.points.push_back(point);
-      }
-      else
+      if (fabs(maxRange - r) > EPSILON_DIFF)
       {
-        geometry_msgs::Point32 point;
-        //pAngle is rotated by yAngle:
-        point.x = r * cos(pAngle) * cos(yAngle) + this->GaussianKernel(0,this->gaussian_noise_);
-        point.y = r * cos(pAngle) * sin(yAngle) + this->GaussianKernel(0,this->gaussian_noise_);
-        point.z = r * sin(pAngle) + this->GaussianKernel(0,this->gaussian_noise_);
-        this->cloud_msg_.points.push_back(point);
-      } // only 1 channel
+        // add noise to range only if not at max range
+        point.x += this->GaussianKernel(0, this->gaussian_noise_);
+        point.y += this->GaussianKernel(0, this->gaussian_noise_);
+        point.z += this->GaussianKernel(0, this->gaussian_noise_);
+      }
+      this->cloud_msg_.points.push_back(point);
 
       this->cloud_msg_.channels[0].values.push_back(intensity + this->GaussianKernel(0,this->gaussian_noise_)) ;
     }

--- a/gazebo_plugins/src/gazebo_ros_block_laser.cpp
+++ b/gazebo_plugins/src/gazebo_ros_block_laser.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <assert.h>
+#include <limits>
 
 #include <gazebo_plugins/gazebo_ros_block_laser.h>
 #include <gazebo_plugins/gazebo_ros_utils.h>
@@ -314,9 +315,15 @@ void GazeboRosBlockLaser::PutLaserData(common::Time &_updateTime)
       r = (1-vb)*((1 - hb) * r1 + hb * r2)
          +   vb *((1 - hb) * r3 + hb * r4);
 
-      // clamp r to the min and max range of the sensor
-      r = std::min(r, maxRange);
-      r = std::max(r, minRange);
+      // REP 117 says readings too close to the sensor become -inf, and too far away +inf
+      if (r < minRange)
+      {
+        r = -std::numeric_limits<double>::infinity();
+      }
+      else if ( r > maxRange)
+      {
+        r = std::numeric_limits<double>::infinity();
+      }
 
       // Intensity is averaged
       intensity = 0.25*(this->parent_ray_sensor_->LaserShape()->GetRetro(j1) +

--- a/gazebo_plugins/test/block_laser_clipping.test
+++ b/gazebo_plugins/test/block_laser_clipping.test
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<launch>
+  <param name="/use_sim_time" value="true" />
+
+  <node name="gazebo" pkg="gazebo_ros" type="gzserver"
+      respawn="false" output="screen"
+      args="--verbose $(find gazebo_plugins)/test/test_worlds/gazebo_ros_block_laser_clipping.world" />
+
+  <test test-name="block_laser_clipping" pkg="gazebo_plugins" type="test_block_laser_clipping.py"
+      clear_params="true" time-limit="30.0" />
+</launch>

--- a/gazebo_plugins/test/test_worlds/gazebo_ros_block_laser_clipping.world
+++ b/gazebo_plugins/test/test_worlds/gazebo_ros_block_laser_clipping.world
@@ -1,0 +1,90 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <world name="default">
+    <model name="test_block_laser">
+      <pose>0 0 0.8 0.0 1.5707 0.0</pose>
+      <static>true</static>
+      <link name="link">
+        <visual name="visual">
+          <pose>0.007 0 -0.033 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.07 0.065 0.065</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.07 0.065 0.065</size>
+            </box>
+          </geometry>
+        </collision>
+        <sensor name="laser_profiler" type="ray">
+          <update_rate>5</update_rate>
+          <pose>0 0 0.0 0 0 0</pose>
+          <plugin name="proximity_ray_plugin" filename="libgazebo_ros_block_laser.so" >
+            <robotNamespace>/</robotNamespace>
+            <frameName>test_block_laser_frame</frameName>
+            <topicName>test_block_laser</topicName>
+            <alwaysOn>true</alwaysOn>
+          </plugin>
+          <ray>
+            <range>
+              <min>0.4</min>
+              <max>1.0</max>
+              <resolution>0.001</resolution>
+            </range>
+            <scan>
+              <horizontal>
+                <samples>50</samples>
+                <resolution>1</resolution>
+                <min_angle>-0.3</min_angle>
+                <max_angle>0.3</max_angle>
+              </horizontal>
+              <vertical>
+                <samples>50</samples>
+                <resolution>1</resolution>
+                <min_angle>-0.4</min_angle>
+                <max_angle>0.4</max_angle>
+              </vertical>
+            </scan>
+            <noise>
+              <type>gaussian</type>
+              <mean>0.0</mean>
+              <stddev>0.001</stddev>
+            </noise>
+          </ray>
+
+          <always_on>1</always_on>
+          <visualize>True</visualize>
+        </sensor>
+        <gravity>false</gravity>
+        <inertial>
+          <mass>0.1</mass>
+        </inertial>
+      </link>
+    </model>
+
+    <model name="slope">
+      <static>true</static>
+      <pose>0.0991 -0.002 0.0909 -0.239 0.789 0</pose>
+      <link name="link">
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+  </world>
+</sdf>

--- a/gazebo_plugins/test/test_worlds/gazebo_ros_block_laser_clipping.world
+++ b/gazebo_plugins/test/test_worlds/gazebo_ros_block_laser_clipping.world
@@ -68,7 +68,7 @@
 
     <model name="slope">
       <static>true</static>
-      <pose>0.0991 -0.002 0.0909 -0.239 0.789 0</pose>
+      <pose>0.0991 -0.002 0.0909 -0.254819 0.847737 -0.021658</pose>
       <link name="link">
         <visual name="visual">
           <geometry>


### PR DESCRIPTION
This fixes a bug where range values near the max range of a depth camera are incorrectly reported as max range. The range value was being clipped to `(-infinity, maxRange-minRange]`, but it should be clipped to `[minRange, maxRange]`. Range readings past `maxRange - minRange` were reported as `maxRange`.

Before this pull request the range visualization in gazebo is correct, but the published point cloud in RViz shows all max range.

![gazebo_ros_depth_max_range_issue](https://user-images.githubusercontent.com/4175662/53926183-6269f180-4037-11e9-9110-3600597ae17d.png)

After this pull request the point cloud in RViz shows the correct depths.
![gazebo_ros_depth_max_range_issue_with_fix](https://user-images.githubusercontent.com/4175662/53926191-672ea580-4037-11e9-9570-4136260e9c21.png)

I'd like to add a test, but I haven't looked through the test code in this repo yet so I'm not yet sure where to add it.