### PR TITLE
Make pid init quiet

### DIFF
--- a/gazebo_ros_control/src/default_robot_hw_sim.cpp
+++ b/gazebo_ros_control/src/default_robot_hw_sim.cpp
@@ -219,7 +219,7 @@ bool DefaultRobotHWSim::initSim(
       // joint->SetParam("vel") to control the joint.
       const ros::NodeHandle nh(robot_namespace + "/gazebo_ros_control/pid_gains/" +
                                joint_names_[j]);
-      if (pid_controllers_[j].init(nh))
+      if (pid_controllers_[j].init(nh, true))
       {
         switch (joint_control_methods_[j])
         {


### PR DESCRIPTION
With position and velocity controllers, when you don't upload pid gains, you get an error msg

```
No p gain specified for pid...
```

That's leaving you with the impression that you have to specify the pid. It wasn't until I looked inside the default robot hw sim that I realized not using a pid is a valid control method.

I changed the pid init to quiet so the error is not printed anymore.