### PR TITLE
Fix memory leaks in camera utils

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
@@ -107,9 +107,9 @@ namespace gazebo
 
     /// \brief A pointer to the ROS node.
     ///  A node will be instantiated if it does not exist.
-    protected: ros::NodeHandle* rosnode_;
+    protected: ros::NodeHandlePtr rosnode_;
     protected: image_transport::Publisher image_pub_;
-    private: image_transport::ImageTransport* itnode_;
+    private: boost::shared_ptr<image_transport::ImageTransport> itnode_;
 
     /// \brief ROS image message
     protected: sensor_msgs::Image image_msg_;
@@ -176,10 +176,8 @@ namespace gazebo
     // Time last published, refrain from publish unless new image has
     // been rendered
     // Allow dynamic reconfiguration of camera params
-    dynamic_reconfigure::Server<gazebo_plugins::GazeboRosCameraConfig>
-      *dyn_srv_;
-    void configCallback(gazebo_plugins::GazeboRosCameraConfig &config,
-      uint32_t level);
+    boost::shared_ptr<dynamic_reconfigure::Server<gazebo_plugins::GazeboRosCameraConfig>> dyn_srv_;
+    void configCallback(gazebo_plugins::GazeboRosCameraConfig &config, uint32_t level);
 
     protected: ros::CallbackQueue camera_queue_;
     protected: void CameraQueueThread();

--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -78,7 +78,6 @@ GazeboRosCameraUtils::~GazeboRosCameraUtils()
   this->camera_queue_.clear();
   this->camera_queue_.disable();
   this->callback_queue_thread_.join();
-  delete this->rosnode_;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -276,13 +275,13 @@ void GazeboRosCameraUtils::LoadThread()
   // associated ROS topics.
   this->parentSensor_->SetActive(false);
 
-  this->rosnode_ = new ros::NodeHandle(this->robot_namespace_ + "/" + this->camera_name_);
+  this->rosnode_ = boost::make_shared<ros::NodeHandle>(this->robot_namespace_ + "/" + this->camera_name_);
 
   // initialize camera_info_manager
   this->camera_info_manager_.reset(new camera_info_manager::CameraInfoManager(
           *this->rosnode_, this->camera_name_));
 
-  this->itnode_ = new image_transport::ImageTransport(*this->rosnode_);
+  this->itnode_ = boost::make_shared<image_transport::ImageTransport>(*this->rosnode_);
 
   // resolve tf prefix
   this->tf_prefix_ = tf::getPrefixParam(*this->rosnode_);
@@ -298,13 +297,8 @@ void GazeboRosCameraUtils::LoadThread()
 
   if (!this->camera_name_.empty())
   {
-    dyn_srv_ =
-      new dynamic_reconfigure::Server<gazebo_plugins::GazeboRosCameraConfig>
-      (*this->rosnode_);
-    dynamic_reconfigure::Server<gazebo_plugins::GazeboRosCameraConfig>
-      ::CallbackType f =
-      boost::bind(&GazeboRosCameraUtils::configCallback, this, _1, _2);
-    dyn_srv_->setCallback(f);
+    dyn_srv_ = boost::make_shared<dynamic_reconfigure::Server<gazebo_plugins::GazeboRosCameraConfig>>(*this->rosnode_);
+    dyn_srv_->setCallback(boost::bind(&GazeboRosCameraUtils::configCallback, this, _1, _2));
   }
   else
   {


### PR DESCRIPTION
Image transport and reconfigure server pointers were being created but never deleted.
I replaced the pointers in the class with shared pointers.