### PR TITLE
Fix a problem twice named with ros namespace.

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -153,12 +153,12 @@ bool gazebo::GazeboRosImuSensor::LoadParameters()
   //TOPIC
   if (sdf->HasElement("topicName"))
   {
-    topic_name =  robot_namespace + sdf->Get<std::string>("topicName");
+    topic_name =  sdf->Get<std::string>("topicName");
     ROS_INFO_STREAM("<topicName> set to: "<<topic_name);
   }
   else
   {
-    topic_name = robot_namespace + "/imu_data";
+    topic_name = "imu_data";
     ROS_WARN_STREAM("missing <topicName>, set to /namespace/default: " << topic_name);
   }
 


### PR DESCRIPTION
# Occured problem:
I insert gazebo_ros_imu_sensor plugin my robot.
```xml my_robot.urdf
<plugin filename="libgazebo_ros_imu_sensor.so" name="imu_plugin">
  <robotNamespace>robotNamespace</robotNamespace>
  <topicName>imu</topicName>
  ...
</plugin>
```
and launch file is 
```xml
<node pkg="gazebo_ros" type="spawn_model" name="spawn_robot" args="
  -urdf
  ...
  -robot_namespace robotNamespace
</node>
```
then, gazebo was published ROS topic is named `/robotNamespace/robotNamespace/imu`