### PR TITLE
Add option to rename the tf published by gazebo

### DIFF
--- a/gazebo_ros/launch/empty_world.launch
+++ b/gazebo_ros/launch/empty_world.launch
@@ -7,6 +7,7 @@
   <arg name="extra_gazebo_args" default=""/>
   <arg name="gui" default="true"/>
   <arg name="recording" default="false"/>
+  <arg name="publish_tf" default="true"/>
   <!-- Note that 'headless' is currently non-functional.  See gazebo_ros_pkgs issue #491 (-r arg does not disable
        rendering, but instead enables recording). The arg definition has been left here to prevent breaking downstream
        launch files, but it does nothing. -->
@@ -38,7 +39,9 @@
     <param name="gazebo/pub_clock_frequency" value="$(arg pub_clock_frequency)" />
   </group>
   <node name="gazebo" pkg="gazebo_ros" type="$(arg script_type)" respawn="$(arg respawn_gazebo)" output="$(arg output)"
-  args="$(arg command_arg1) $(arg command_arg2) $(arg command_arg3) -e $(arg physics) $(arg extra_gazebo_args) $(arg world_name)" />
+  args="$(arg command_arg1) $(arg command_arg2) $(arg command_arg3) -e $(arg physics) $(arg extra_gazebo_args) $(arg world_name)" >
+    <remap unless="$(arg publish_tf)" from="tf" to="gazebo_tf"/>
+  </node>
 
   <!-- start gazebo client -->
   <group if="$(arg gui)">


### PR DESCRIPTION
Currently, it's possible for tf published by gazebo to conflict with tf published by other packages. This PR ensure that it is possible to separate the simulation ground truth from the internal tf belief of the robot.