### PR TITLE
gazebo_plugins: export plugin path in package.xml

### DIFF
--- a/gazebo_plugins/package.xml
+++ b/gazebo_plugins/package.xml
@@ -25,6 +25,7 @@
   -->
   <exec_depend>gazebo_dev</exec_depend>
 
+  <depend>gazebo_ros</depend>
   <depend>gazebo_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>
@@ -52,4 +53,7 @@
 
   <test_depend>rostest</test_depend>
 
+  <export>
+    <gazebo_ros plugin_path="${prefix}/../../lib" gazebo_media_path="${prefix}" />
+  </export>
 </package>


### PR DESCRIPTION
`gazebo_plugins` does not have a `gazebo_ros` export in its package.xml, so it is not picked up by `gazebo_ros_paths_plugin`. This PR adds the necessary export tag and adds `gazebo_ros` as a dependency so that pluginlib processes this tag correctly.