### PR TITLE
Declare parameters and use overrides

### DIFF
--- a/gazebo_ros/include/gazebo_ros/node.hpp
+++ b/gazebo_ros/include/gazebo_ros/node.hpp
@@ -141,6 +141,7 @@ Node::SharedPtr Node::CreateWithArgs(Args && ... args)
     RCLCPP_INFO(internal_logger(), "ROS was initialized without arguments.");
   }
   node = std::make_shared<Node>(std::forward<Args>(args) ...);
+  node->set_parameter(rclcpp::Parameter("use_sim_time", true));
 
   // Store shared pointer to static executor in this object
   node->executor_ = static_executor_.lock();

--- a/gazebo_ros/src/gazebo_ros_init.cpp
+++ b/gazebo_ros/src/gazebo_ros_init.cpp
@@ -66,20 +66,12 @@ void GazeboRosInit::Load(int argc, char ** argv)
     "/clock",
     rclcpp::QoS(rclcpp::KeepLast(10)).transient_local());
 
-  // Get publish rate from parameter if set
-  rclcpp::Parameter rate_param;
-  if (impl_->ros_node_->get_parameter("publish_rate", rate_param)) {
-    if (rclcpp::ParameterType::PARAMETER_DOUBLE == rate_param.get_type()) {
-      impl_->throttler_ = Throttler(rate_param.as_double());
-    } else if (rclcpp::ParameterType::PARAMETER_INTEGER == rate_param.get_type()) {
-      impl_->throttler_ = Throttler(rate_param.as_int());
-    } else {
-      RCLCPP_WARN(impl_->ros_node_->get_logger(),
-        "Could not read value of param publish_rate [%s] as double/int, using default %ghz.",
-        rate_param.value_to_string().c_str(),
-        GazeboRosInitPrivate::DEFAULT_PUBLISH_FREQUENCY);
-    }
-  }
+  // Publish rate parameter
+  impl_->ros_node_->declare_parameter("publish_rate",
+    rclcpp::ParameterValue(GazeboRosInitPrivate::DEFAULT_PUBLISH_FREQUENCY));
+
+  auto rate_param = impl_->ros_node_->get_parameter("publish_rate");
+  impl_->throttler_ = Throttler(rate_param.as_double());
 
   impl_->world_update_event_ = gazebo::event::Events::ConnectWorldUpdateBegin(
     std::bind(&GazeboRosInitPrivate::PublishSimTime, impl_.get(), std::placeholders::_1));

--- a/gazebo_ros/src/gazebo_ros_init.cpp
+++ b/gazebo_ros/src/gazebo_ros_init.cpp
@@ -67,10 +67,10 @@ void GazeboRosInit::Load(int argc, char ** argv)
     rclcpp::QoS(rclcpp::KeepLast(10)).transient_local());
 
   // Publish rate parameter
-  double rate = impl_->ros_node_->declare_parameter(
+  auto rate_param = impl_->ros_node_->declare_parameter(
     "publish_rate",
-    GazeboRosInitPrivate::DEFAULT_PUBLISH_FREQUENCY);
-  impl_->throttler_ = Throttler(rate);
+    rclcpp::ParameterValue(GazeboRosInitPrivate::DEFAULT_PUBLISH_FREQUENCY));
+  impl_->throttler_ = Throttler(rate_param.get<double>());
 
   impl_->world_update_event_ = gazebo::event::Events::ConnectWorldUpdateBegin(
     std::bind(&GazeboRosInitPrivate::PublishSimTime, impl_.get(), std::placeholders::_1));

--- a/gazebo_ros/src/gazebo_ros_init.cpp
+++ b/gazebo_ros/src/gazebo_ros_init.cpp
@@ -67,11 +67,10 @@ void GazeboRosInit::Load(int argc, char ** argv)
     rclcpp::QoS(rclcpp::KeepLast(10)).transient_local());
 
   // Publish rate parameter
-  impl_->ros_node_->declare_parameter("publish_rate",
-    rclcpp::ParameterValue(GazeboRosInitPrivate::DEFAULT_PUBLISH_FREQUENCY));
-
-  auto rate_param = impl_->ros_node_->get_parameter("publish_rate");
-  impl_->throttler_ = Throttler(rate_param.as_double());
+  double rate = impl_->ros_node_->declare_parameter(
+    "publish_rate",
+    GazeboRosInitPrivate::DEFAULT_PUBLISH_FREQUENCY);
+  impl_->throttler_ = Throttler(rate);
 
   impl_->world_update_event_ = gazebo::event::Events::ConnectWorldUpdateBegin(
     std::bind(&GazeboRosInitPrivate::PublishSimTime, impl_.get(), std::placeholders::_1));

--- a/gazebo_ros/src/node.cpp
+++ b/gazebo_ros/src/node.cpp
@@ -36,7 +36,7 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf)
   std::string name = "";
   std::string ns = "";
   std::vector<std::string> arguments;
-  std::vector<rclcpp::Parameter> initial_parameters;
+  std::vector<rclcpp::Parameter> parameter_overrides;
 
   // Get the name of the plugin as the name for the node.
   if (!sdf->HasAttribute("name")) {
@@ -71,23 +71,18 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf)
     while (parameter_sdf) {
       auto param = sdf_to_ros_parameter(parameter_sdf);
       if (rclcpp::ParameterType::PARAMETER_NOT_SET != param.get_type()) {
-        initial_parameters.push_back(param);
+        parameter_overrides.push_back(param);
       }
       parameter_sdf = parameter_sdf->GetNextElement("parameter");
     }
   }
 
   rclcpp::NodeOptions node_options;
-  node_options.allow_undeclared_parameters(true);
   node_options.arguments(arguments);
-  // TODO(anyone) can't set at construction, see
-  // https://github.com/ros2/rclcpp/issues/730
-  // node_options.initial_parameters(initial_parameters);
+  node_options.parameter_overrides(parameter_overrides);
 
   // Create node with parsed arguments
-  auto node = CreateWithArgs(name, ns, node_options);
-  node->set_parameters(initial_parameters);
-  return node;
+  return CreateWithArgs(name, ns, node_options);
 }
 
 Node::SharedPtr Node::Get()

--- a/gazebo_ros/test/plugins/sdf_node.cpp
+++ b/gazebo_ros/test/plugins/sdf_node.cpp
@@ -16,8 +16,10 @@
 
 #include <std_msgs/msg/string.hpp>
 #include <gazebo_ros/node.hpp>
+#include <rclcpp/exceptions.hpp>
 
 #include <memory>
+#include <string>
 
 /// Simple example of a gazebo world plugin which uses a ROS2 node with gazebo_ros::Node.
 class SDFNode : public gazebo::WorldPlugin
@@ -39,43 +41,79 @@ void SDFNode::Load(gazebo::physics::WorldPtr, sdf::ElementPtr _sdf)
   auto node = gazebo_ros::Node::Get(_sdf);
   assert(nullptr != node);
 
+  node->declare_parameter("declared_string", rclcpp::ParameterValue("overridden"));
+  node->declare_parameter("declared_int", rclcpp::ParameterValue(123));
+  node->declare_parameter("missing_type", rclcpp::ParameterValue("declared"));
+
   const char * node_name = node->get_name();
   if (strcmp("sdf_node_name", node_name)) {
     RCLCPP_ERROR(node->get_logger(), "Node name not taken from SDF");
     return;
   }
 
+  // Attempt to get the parameters set by the SDF.
+  // If any of them fail, messages will not publish so test will fail
+
   // Create a publisher
   auto pub = node->create_publisher<std_msgs::msg::String>("test", rclcpp::SystemDefaultsQoS());
 
-  // Attempt to get the parameters set by the SDF.
-  // If any of them fail, messages will not publish so test will fail
-  #define SDF_NODE_PARAM_CHECK(param, expected) \
-  if (expected != node->get_parameter(param).get_value<decltype(expected)>()) { \
-    RCLCPP_ERROR(node->get_logger(), "Wrong value for parameter."); \
-    return; \
+  {
+    auto param = node->get_parameter("declared_string");
+    if (rclcpp::PARAMETER_STRING != param.get_type()) {
+      RCLCPP_ERROR(node->get_logger(), "Wrong parameter type, not string");
+      return;
+    }
+    if ("from SDF" != param.get_value<std::string>()) {
+      RCLCPP_ERROR(node->get_logger(), "Wrong parameter value");
+      return;
+    }
   }
 
-  SDF_NODE_PARAM_CHECK("my_string", "str");
-  SDF_NODE_PARAM_CHECK("my_bool_false", false);
-  SDF_NODE_PARAM_CHECK("my_bool_true", true);
-  SDF_NODE_PARAM_CHECK("my_int", 42);
-  SDF_NODE_PARAM_CHECK("my_double", 13.37);
-
-  // Return if the given parameter is set
-  #define SDF_NODE_PARAM_UNSET(param) \
-  { \
-    rclcpp::Parameter dummy; \
-    if (node->get_parameter(param, dummy)) { \
-      RCLCPP_ERROR(node->get_logger(), "Invalid parameter should not be set [%s]", \
-        param); \
-      return; \
-    } \
+  {
+    auto param = node->get_parameter("declared_int");
+    if (rclcpp::PARAMETER_INTEGER != param.get_type()) {
+      RCLCPP_ERROR(node->get_logger(), "Wrong parameter type, not int");
+      return;
+    }
+    if (42 != param.get_value<int>()) {
+      RCLCPP_ERROR(node->get_logger(), "Wrong parameter value");
+      return;
+    }
   }
 
-  // Check that the invalid parameter sdfs don't get set
-  SDF_NODE_PARAM_UNSET("invalid_type")
-  SDF_NODE_PARAM_UNSET("missing_type")
+  bool caught{false};
+  try {
+    node->get_parameter("non_declared_bool");
+  } catch (rclcpp::exceptions::ParameterNotDeclaredException) {
+    caught = true;
+  }
+  if (!caught) {
+    RCLCPP_ERROR(node->get_logger(), "Failed to throw exception");
+    return;
+  }
+
+  caught = false;
+  try {
+    node->get_parameter("non_declared_double");
+  } catch (rclcpp::exceptions::ParameterNotDeclaredException) {
+    caught = true;
+  }
+  if (!caught) {
+    RCLCPP_ERROR(node->get_logger(), "Failed to throw exception");
+    return;
+  }
+
+  {
+    auto param = node->get_parameter("missing_type");
+    if (rclcpp::PARAMETER_STRING != param.get_type()) {
+      RCLCPP_ERROR(node->get_logger(), "Wrong parameter type, not int");
+      return;
+    }
+    if ("declared" != param.get_value<std::string>()) {
+      RCLCPP_ERROR(node->get_logger(), "Wrong parameter value");
+      return;
+    }
+  }
 
   // Run lambda every 1 second
   using namespace std::chrono_literals;

--- a/gazebo_ros/test/plugins/sdf_node.cpp
+++ b/gazebo_ros/test/plugins/sdf_node.cpp
@@ -41,9 +41,9 @@ void SDFNode::Load(gazebo::physics::WorldPtr, sdf::ElementPtr _sdf)
   auto node = gazebo_ros::Node::Get(_sdf);
   assert(nullptr != node);
 
-  node->declare_parameter("declared_string", rclcpp::ParameterValue("overridden"));
-  node->declare_parameter("declared_int", rclcpp::ParameterValue(123));
-  node->declare_parameter("missing_type", rclcpp::ParameterValue("declared"));
+  node->declare_parameter("declared_string", "overridden");
+  node->declare_parameter("declared_int", 123);
+  node->declare_parameter("missing_type", "declared");
 
   const char * node_name = node->get_name();
   if (strcmp("sdf_node_name", node_name)) {

--- a/gazebo_ros/test/test_sim_time.cpp
+++ b/gazebo_ros/test/test_sim_time.cpp
@@ -21,6 +21,8 @@
 #include <string>
 #include <vector>
 
+using namespace std::literals::chrono_literals; // NOLINT
+
 /// Tests the simtime published to /clock by gazebo_ros_init
 class TestSimTime : public ::testing::Test
 {
@@ -51,35 +53,48 @@ TEST_F(TestSimTime, TestClock)
   using ClockMsg = rosgraph_msgs::msg::Clock;
 
   // Create a node which will use sim time
-  std::vector<std::string> args;
-  std::vector<rclcpp::Parameter> params = {rclcpp::Parameter("use_sim_time", true)};
-  rclcpp::NodeOptions node_options;
-  node_options.arguments(args);
-  node_options.initial_parameters(params);
-  auto node = std::make_shared<rclcpp::Node>("test_sim_time", "", node_options);
+  auto node = std::make_shared<rclcpp::Node>("test_sim_time");
+  node->set_parameter(rclcpp::Parameter("use_sim_time", true));
 
-  // Get two clock messages, caching the ROS time once each is received
-  auto first_msg =
-    gazebo_ros::get_message_or_timeout<ClockMsg>(node, "/clock", rclcpp::Duration(5, 0));
-  ASSERT_NE(first_msg, nullptr);
-  auto first_msg_time = node->now();
-  auto second_msg =
-    gazebo_ros::get_message_or_timeout<ClockMsg>(node, "/clock", rclcpp::Duration(1, 0));
-  ASSERT_NE(second_msg, nullptr);
-  auto second_msg_time = node->now();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
 
-  // The SIM time should be close to zero (start of simulation)
-  EXPECT_LT(rclcpp::Time(first_msg->clock), rclcpp::Time(1, 0, RCL_ROS_TIME));
-  EXPECT_LT(rclcpp::Time(second_msg->clock), rclcpp::Time(1, 0, RCL_ROS_TIME));
-  // Time should go forward
-  EXPECT_GT(rclcpp::Time(second_msg->clock), rclcpp::Time(first_msg->clock)) <<
-    rclcpp::Time(second_msg->clock).nanoseconds() << "    " <<
-    rclcpp::Time(first_msg->clock).nanoseconds();
-  // The message from the clock should be the node's time
-  EXPECT_EQ(first_msg_time, rclcpp::Time(first_msg->clock)) << first_msg_time.nanoseconds() <<
-    "    " << rclcpp::Time(first_msg->clock).nanoseconds();
-  EXPECT_EQ(second_msg_time, rclcpp::Time(second_msg->clock)) << second_msg_time.nanoseconds() <<
-    "    " << rclcpp::Time(second_msg->clock).nanoseconds();
+  std::vector<ClockMsg::SharedPtr> msgs;
+  std::vector<rclcpp::Time> times;
+  auto sub = node->create_subscription<ClockMsg>("/clock", rclcpp::SystemDefaultsQoS(),
+      [&](ClockMsg::SharedPtr _msg) {
+        msgs.push_back(_msg);
+        times.push_back(node->now());
+      });
+
+  unsigned int sleep{0};
+  unsigned int max_sleep{30};
+  while (msgs.size() < 5 && sleep++ < max_sleep) {
+    executor.spin_once(200ms);
+  }
+  EXPECT_LT(sleep, max_sleep);
+  EXPECT_EQ(5u, msgs.size());
+  EXPECT_EQ(5u, times.size());
+
+  // Check node starts at time zero
+  for (int i = 0; i < 5; ++i) {
+    // The SIM time should be close to zero (start of simulation)
+    EXPECT_LT(rclcpp::Time(msgs[i]->clock), rclcpp::Time(1, 0, RCL_ROS_TIME));
+    EXPECT_LT(times[i], rclcpp::Time(1, 0, RCL_ROS_TIME));
+
+    // Time should go forward
+    if (i > 0) {
+      EXPECT_GT(rclcpp::Time(msgs[i]->clock), rclcpp::Time(msgs[i - 1]->clock)) <<
+        rclcpp::Time(msgs[i]->clock).nanoseconds() << "    " <<
+        rclcpp::Time(msgs[i - 1]->clock).nanoseconds();
+      EXPECT_GT(times[i], times[i - 1]) << times[i].nanoseconds() << "    " <<
+        times[i - 1].nanoseconds();
+
+      // The message from the clock should be close to the node's time
+      // We can't guarantee they match exactly because the node may process clock messages late
+      EXPECT_NEAR(times[i].nanoseconds(), rclcpp::Time(msgs[i]->clock).nanoseconds(), 150000000);
+    }
+  }
 }
 
 int main(int argc, char ** argv)

--- a/gazebo_ros/test/test_sim_time.cpp
+++ b/gazebo_ros/test/test_sim_time.cpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <vector>
 
-using namespace std::literals::chrono_literals; // NOLINT
+using namespace std::literals::chrono_literals;
 
 /// Tests the simtime published to /clock by gazebo_ros_init
 class TestSimTime : public ::testing::Test
@@ -54,7 +54,7 @@ TEST_F(TestSimTime, TestClock)
 
   // Create a node which will use sim time
   auto node = std::make_shared<rclcpp::Node>("test_sim_time");
-  node->set_parameter(rclcpp::Parameter("use_sim_time", true));
+  node->set_parameter({"use_sim_time", true});
 
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(node);

--- a/gazebo_ros/test/worlds/sdf_node_plugin.world
+++ b/gazebo_ros/test/worlds/sdf_node_plugin.world
@@ -5,11 +5,14 @@
       <ros>
         <namespace>/foo</namespace>
         <argument>test:=my_topic</argument>
-        <parameter name="my_string" type="string">str</parameter>
-        <parameter name="my_bool_true" type="bool">True</parameter>
-        <parameter name="my_bool_false" type="bool">false</parameter>
-        <parameter name="my_int" type="int">42</parameter>
-        <parameter name="my_double" type="double">13.37</parameter>
+
+        <!-- Declared parameters, should go through -->
+        <parameter name="declared_string" type="string">from SDF</parameter>
+        <parameter name="declared_int" type="int">42</parameter>
+
+        <!-- Undeclared parameters, throw on get -->
+        <parameter name="non_declared_bool" type="bool">True</parameter>
+        <parameter name="non_declared_double" type="double">13.37</parameter>
 
         <!-- Missing 'name', should be rejected -->
         <parameter type="int">52</parameter>


### PR DESCRIPTION
From Dashing, parameters need to be [explicitly declared](https://index.ros.org/doc/ros2/Releases/Release-Dashing-Diademata/#declaring-parameters).

This PR changes the usage of the `<parameter>` SDF tag to match the behaviour of parameters passed by the command line through a yaml file. This means they're overriding the default value, but will have no effect unless the node has declared the parameters.

See relevant discussion on https://github.com/ros2/rclcpp/issues/730.

This PR should substitute #930.

FYI @wjwwood 

 