### PR TITLE
Fix for multiple video plugins (#898)

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_video.cpp
+++ b/gazebo_plugins/src/gazebo_ros_video.cpp
@@ -200,8 +200,8 @@ void GazeboRosVideo::Load(
 
   int width = _sdf->Get<int>("width", 320).first;
 
-  impl_->video_visual_ = std::make_shared<VideoVisual>(_parent->Name() + "::video_visual",
-      _parent, height, width);
+  impl_->video_visual_ = std::make_shared<VideoVisual>(_parent->Name() + "::video_visual::" +
+      _sdf->Get<std::string>("name"), _parent, height, width);
   _parent->GetScene()->AddVisual(impl_->video_visual_);
 
   // Subscribe to the image topic

--- a/gazebo_plugins/src/gazebo_ros_video.cpp
+++ b/gazebo_plugins/src/gazebo_ros_video.cpp
@@ -186,9 +186,6 @@ GazeboRosVideo::GazeboRosVideo()
 // Destructor
 GazeboRosVideo::~GazeboRosVideo()
 {
-  if (rclcpp::is_initialized()) {
-    rclcpp::shutdown();
-  }
   impl_->update_connection_.reset();
   impl_->rosnode_.reset();
 }

--- a/gazebo_plugins/src/gazebo_ros_video.cpp
+++ b/gazebo_plugins/src/gazebo_ros_video.cpp
@@ -186,6 +186,9 @@ GazeboRosVideo::GazeboRosVideo()
 // Destructor
 GazeboRosVideo::~GazeboRosVideo()
 {
+  if (rclcpp::is_initialized()) {
+    rclcpp::shutdown();
+  }
   impl_->update_connection_.reset();
   impl_->rosnode_.reset();
 }

--- a/gazebo_ros/src/node.cpp
+++ b/gazebo_ros/src/node.cpp
@@ -28,6 +28,7 @@ std::mutex Node::lock_;
 
 Node::~Node()
 {
+  executor_->remove_node(get_node_base_interface());
 }
 
 Node::SharedPtr Node::Get(sdf::ElementPtr sdf)


### PR DESCRIPTION
Append the name of the plugin specified in the sdf to avoid crashing when multiple video plugins are used. This connects to #898 