### PR TITLE
Fix default principal point offset

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -506,11 +506,11 @@ void GazeboRosCameraUtils::Init()
 
   /// Compute camera_ parameters if set to 0
   if (this->cx_prime_ == 0)
-    this->cx_prime_ = (static_cast<double>(this->width_) + 1.0) /2.0;
+    this->cx_prime_ = (static_cast<double>(this->width_) - 1.0) /2.0;
   if (this->cx_ == 0)
-    this->cx_ = (static_cast<double>(this->width_) + 1.0) /2.0;
+    this->cx_ = (static_cast<double>(this->width_) - 1.0) /2.0;
   if (this->cy_ == 0)
-    this->cy_ = (static_cast<double>(this->height_) + 1.0) /2.0;
+    this->cy_ = (static_cast<double>(this->height_) - 1.0) /2.0;
 
 
   double hfov = this->camera_->HFOV().Radian();


### PR DESCRIPTION
There is an offset in the calculation of the principal point for the intrinsic camera calibration.

Assuming the pixels in the image are **zero-indexed** it has to be `- 1.0` instead of `+`.

E.g. image width of `4 px`:
`0 1 2 3` -> center is `1.5 = (width - 1) / 2.0 ` 

`5 px`:
`0 1 2 3 4` -> center is `2 = (width - 1) / 2.0 ` 