### PR TITLE
moved node initialization to beginning of the program

### DIFF
--- a/gazebo_ros/scripts/spawn_model
+++ b/gazebo_ros/scripts/spawn_model
@@ -202,9 +202,6 @@ class SpawnModel():
 
     def callSpawnService(self):
 
-        # wait for model to exist
-        rospy.init_node('spawn_model')
-
         if not self.wait_for_model == "":
           rospy.Subscriber("%s/model_states"%(self.gazebo_namespace), ModelStates, self.checkForModel)
           r= rospy.Rate(10)
@@ -307,7 +304,7 @@ if __name__ == "__main__":
     if len(sys.argv) < 2:
         print(usage())
     else:
-        print("SpawnModel script started") # make this a print incase roscore has not been started
+        rospy.init_node('spawn_model')
         sm = SpawnModel()
         sm.parseUserInputs()
         sm.callSpawnService()


### PR DESCRIPTION
Before the node was started in the function `callSpawnService()` which occurs **after** `parseUserInputs`, however in this method there are many `rospy.logXXX` such as [this one](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/kinetic-devel/gazebo_ros/scripts/spawn_model#L104). Besides the reason for not having it at the very beginning is to (as said in the comment):

> print("SpawnModel script started") # make this a print incase roscore has not been started

But when you start the node there, if there is no roscore a message with:

> Unable to register with master node [http://localhost:11311]: master may not be running yet. Will keep trying.

will be printed. The user also gets information about the roscore not being started in a standard way.

This PR puts the node at the beginning of the program to ensure that all the parsing messages are logged.