### PR TITLE
[ros2] Conditional launch includes

### DIFF
--- a/gazebo_ros/launch/gazebo.launch.py
+++ b/gazebo_ros/launch/gazebo.launch.py
@@ -14,7 +14,6 @@
 
 """Launch Gazebo server and client with command line arguments."""
 
-from launch import Condition
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import IncludeLaunchDescription

--- a/gazebo_ros/launch/gazebo.launch.py
+++ b/gazebo_ros/launch/gazebo.launch.py
@@ -14,22 +14,32 @@
 
 """Launch Gazebo server and client with command line arguments."""
 
+from launch import Condition
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
 from launch.actions import IncludeLaunchDescription
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
 from launch.substitutions import ThisLaunchFileDir
 
 
 def generate_launch_description():
 
-    # (TODO) Allow conditional include of gzserver and gzclient, once supported
-    # https://github.com/ros2/launch/issues/303
     return LaunchDescription([
+        DeclareLaunchArgument('gui', default_value='true',
+                              description='Set to "false" to run headless.'),
+
+        DeclareLaunchArgument('server', default_value='true',
+                              description='Set to "false" not to run gzserver.'),
+
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource([ThisLaunchFileDir(), '/gzserver.launch.py']),
+            condition=IfCondition(LaunchConfiguration('server'))
         ),
 
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource([ThisLaunchFileDir(), '/gzclient.launch.py']),
+            condition=IfCondition(LaunchConfiguration('gui'))
         ),
     ])

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -29,6 +29,8 @@
   <depend>std_srvs</depend>
   <depend>tinyxml_vendor</depend>
 
+  <exec_depend>launch_ros</exec_depend>
+
   <build_export_depend>geometry_msgs</build_export_depend>
   <build_export_depend>sensor_msgs</build_export_depend>
 


### PR DESCRIPTION
Support launching only gui or server from `gazebo.launch.py`.

Headless:

`ros2 launch gazebo_ros gazebo.launch.py gui:=false`

GUI only:

`ros2 launch gazebo_ros gazebo.launch.py server:=false`

Requires https://github.com/ros2/launch/pull/304