### PR TITLE
[ros2] Adding GPS plugin

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -125,6 +125,18 @@ target_link_libraries(gazebo_ros_imu_sensor
 )
 ament_export_libraries(gazebo_ros_imu_sensor)
 
+
+# gazebo_ros_gps_sensor
+add_library(gazebo_ros_gps_sensor SHARED
+  src/gazebo_ros_gps_sensor.cpp
+)
+ament_target_dependencies(gazebo_ros_gps_sensor
+  "gazebo_ros"
+  "sensor_msgs"
+  "gazebo_dev"
+)
+ament_export_libraries(gazebo_ros_gps_sensor)
+
 # gazebo_ros_ray_sensor
 add_library(gazebo_ros_ray_sensor SHARED
   src/gazebo_ros_ray_sensor.cpp
@@ -342,6 +354,7 @@ install(TARGETS
     gazebo_ros_hand_of_god
     gazebo_ros_harness
     gazebo_ros_imu_sensor
+    gazebo_ros_gps_sensor
     gazebo_ros_joint_pose_trajectory
     gazebo_ros_joint_state_publisher
     gazebo_ros_planar_move

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_gps_sensor.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_gps_sensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Open Source Robotics Foundation, Inc.
+// Copyright 2019 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_gps_sensor.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_gps_sensor.hpp
@@ -1,0 +1,66 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#ifndef GAZEBO_PLUGINS__GAZEBO_ROS_GPS_SENSOR_HPP_
+#define GAZEBO_PLUGINS__GAZEBO_ROS_GPS_SENSOR_HPP_
+
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/sensors/GpsSensor.hh>
+#include <gazebo/common/Events.hh>
+
+#include <memory>
+
+namespace gazebo_plugins
+{
+
+class GazeboRosGpsSensorPrivate;
+
+/// Plugin to attach to a gazebo GPS sensor and publish ROS message of output
+/**
+  Example Usage:
+  \code{.xml}
+    <sensor name="my_gps" type="gps">
+      <!-- ensure the sensor is active (required) -->
+      <always_on>true</always_on>
+      <update_rate>30</update_rate>
+      <plugin name="my_gps_plugin" filename="libgazebo_ros_gps_sensor.so">
+        <ros>
+          <!-- publish to /gps/data -->
+          <namespace>/gps</namespace>
+          <argument>~/out:=data</argument>
+        </ros>
+      </plugin>
+    </sensor>
+  \endcode
+*/
+class GazeboRosGpsSensor : public gazebo::SensorPlugin
+{
+public:
+  /// Constructor.
+  GazeboRosGpsSensor();
+  /// Destructor.
+  virtual ~GazeboRosGpsSensor();
+
+  // Documentation Inherited
+  void Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _sdf) override;
+
+private:
+  /// Private data pointer
+  std::unique_ptr<GazeboRosGpsSensorPrivate> impl_;
+};
+
+}  // namespace gazebo_plugins
+
+#endif  // GAZEBO_PLUGINS__GAZEBO_ROS_GPS_SENSOR_HPP_

--- a/gazebo_plugins/src/gazebo_ros_gps_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_gps_sensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Open Source Robotics Foundation, Inc.
+// Copyright 2019 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ void GazeboRosGpsSensor::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPt
 
   impl_->sensor_ = std::dynamic_pointer_cast<gazebo::sensors::GpsSensor>(_sensor);
   if (!impl_->sensor_) {
-    RCLCPP_ERROR(impl_->ros_node_->get_logger(), "Parent is not an gps sensor. Exiting.");
+    RCLCPP_ERROR(impl_->ros_node_->get_logger(), "Parent is not a GPS sensor. Exiting.");
     return;
   }
 

--- a/gazebo_plugins/src/gazebo_ros_gps_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_gps_sensor.cpp
@@ -1,0 +1,112 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <builtin_interfaces/msg/time.hpp>
+#include <gazebo_plugins/gazebo_ros_gps_sensor.hpp>
+#include <gazebo_ros/conversions/builtin_interfaces.hpp>
+#include <gazebo_ros/conversions/geometry_msgs.hpp>
+#include <gazebo_ros/node.hpp>
+#include <gazebo_ros/utils.hpp>
+#include <sensor_msgs/msg/nav_sat_fix.hpp>
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+namespace gazebo_plugins
+{
+
+class GazeboRosGpsSensorPrivate
+{
+public:
+  /// Node for ros communication
+  gazebo_ros::Node::SharedPtr ros_node_;
+  /// Publish for gps message
+  rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr pub_;
+  /// GPS message modified each update
+  sensor_msgs::msg::NavSatFix::SharedPtr msg_;
+  /// GPS sensor this plugin is attached to
+  gazebo::sensors::GpsSensorPtr sensor_;
+  /// Event triggered when sensor updates
+  gazebo::event::ConnectionPtr sensor_update_event_;
+
+  /// Publish latest gps data to ROS
+  void OnUpdate();
+};
+
+GazeboRosGpsSensor::GazeboRosGpsSensor()
+: impl_(std::make_unique<GazeboRosGpsSensorPrivate>())
+{
+}
+
+GazeboRosGpsSensor::~GazeboRosGpsSensor()
+{
+}
+
+void GazeboRosGpsSensor::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _sdf)
+{
+  impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
+
+  impl_->sensor_ = std::dynamic_pointer_cast<gazebo::sensors::GpsSensor>(_sensor);
+  if (!impl_->sensor_) {
+    RCLCPP_ERROR(impl_->ros_node_->get_logger(), "Parent is not an gps sensor. Exiting.");
+    return;
+  }
+
+  impl_->pub_ = impl_->ros_node_->create_publisher<sensor_msgs::msg::NavSatFix>(
+    "~/out", rclcpp::SensorDataQoS());
+
+  // Create message to be reused
+  auto msg = std::make_shared<sensor_msgs::msg::NavSatFix>();
+
+  // Get frame for message
+  msg->header.frame_id = gazebo_ros::SensorFrameID(*_sensor, *_sdf);
+
+  // Fill covariances
+  using SNT = gazebo::sensors::SensorNoiseType;
+  msg->position_covariance[0] =
+    gazebo_ros::NoiseVariance(impl_->sensor_->Noise(SNT::GPS_POSITION_LATITUDE_NOISE_METERS));
+  msg->position_covariance[4] =
+    gazebo_ros::NoiseVariance(impl_->sensor_->Noise(SNT::GPS_POSITION_LONGITUDE_NOISE_METERS));
+  msg->position_covariance[8] =
+    gazebo_ros::NoiseVariance(impl_->sensor_->Noise(SNT::GPS_POSITION_ALTITUDE_NOISE_METERS));
+  msg->position_covariance_type = sensor_msgs::msg::NavSatFix::COVARIANCE_TYPE_DIAGONAL_KNOWN;
+
+  // Fill gps status
+  msg->status.status = sensor_msgs::msg::NavSatStatus::STATUS_FIX;
+  msg->status.service = sensor_msgs::msg::NavSatStatus::SERVICE_GPS;
+
+  impl_->msg_ = msg;
+
+  impl_->sensor_update_event_ = impl_->sensor_->ConnectUpdated(
+    std::bind(&GazeboRosGpsSensorPrivate::OnUpdate, impl_.get()));
+}
+
+void GazeboRosGpsSensorPrivate::OnUpdate()
+{
+  // Fill message with latest sensor data
+  msg_->header.stamp = gazebo_ros::Convert<builtin_interfaces::msg::Time>(
+    sensor_->LastUpdateTime());
+  msg_->latitude = sensor_->Latitude().Degree();
+  msg_->longitude = sensor_->Longitude().Degree();
+  msg_->altitude = sensor_->Altitude();
+
+  // Publish message
+  pub_->publish(*msg_);
+}
+
+GZ_REGISTER_SENSOR_PLUGIN(GazeboRosGpsSensor)
+
+}  // namespace gazebo_plugins

--- a/gazebo_plugins/test/CMakeLists.txt
+++ b/gazebo_plugins/test/CMakeLists.txt
@@ -21,6 +21,7 @@ set(tests
   test_gazebo_ros_hand_of_god
   test_gazebo_ros_harness
   test_gazebo_ros_imu_sensor
+  test_gazebo_ros_gps_sensor
   test_gazebo_ros_joint_pose_trajectory
   test_gazebo_ros_joint_state_publisher
   test_gazebo_ros_p3d

--- a/gazebo_plugins/test/test_gazebo_ros_gps_sensor.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_gps_sensor.cpp
@@ -1,0 +1,103 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gazebo/test/ServerFixture.hh>
+#include <gazebo_ros/node.hpp>
+#include <gazebo_ros/testing_utils.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/nav_sat_fix.hpp>
+
+#include <memory>
+
+#define tol 10e-4
+
+/// Tests the gazebo_ros_gps_sensor plugin
+class GazeboRosGpsSensorTest : public gazebo::ServerFixture
+{
+};
+
+TEST_F(GazeboRosGpsSensorTest, GpsMessageCorrect)
+{
+  // Load test world and start paused
+  this->Load("worlds/gazebo_ros_gps_sensor.world", true);
+
+  // World
+  auto world = gazebo::physics::get_world();
+  ASSERT_NE(nullptr, world);
+
+  // Get the model with the attached GPS
+  auto box = world->ModelByName("box");
+  auto link = box->GetLink("link");
+  ASSERT_NE(nullptr, box);
+
+  // Make sure sensor is loaded
+  ASSERT_EQ(link->GetSensorCount(), 1u);
+
+  // Create node / executor for receiving gps message
+  auto node = std::make_shared<rclcpp::Node>("test_gazebo_ros_gps_sensor");
+  ASSERT_NE(nullptr, node);
+
+  sensor_msgs::msg::NavSatFix::SharedPtr msg = nullptr;
+  auto sub =
+    node->create_subscription<sensor_msgs::msg::NavSatFix>("/gps/data", rclcpp::SensorDataQoS(),
+      [&msg](sensor_msgs::msg::NavSatFix::SharedPtr _msg) {
+        msg = _msg;
+      });
+
+  world->Step(1);
+  EXPECT_NEAR(0.0, box->WorldPose().Pos().X(), tol);
+  EXPECT_NEAR(0.0, box->WorldPose().Pos().Y(), tol);
+  EXPECT_NEAR(0.5, box->WorldPose().Pos().Z(), tol);
+
+  // Step until an gps message will have been published
+  int sleep{0};
+  int max_sleep{1000};
+  while (sleep < max_sleep && nullptr == msg) {
+    world->Step(100);
+    rclcpp::spin_some(node);
+    gazebo::common::Time::MSleep(100);
+    sleep++;
+  }
+  EXPECT_LT(0u, sub->get_publisher_count());
+  EXPECT_LT(sleep, max_sleep);
+  ASSERT_NE(nullptr, msg);
+
+  // Get the initial gps output when the box is at rest
+  auto pre_movement_msg = std::make_shared<sensor_msgs::msg::NavSatFix>(*msg);
+  ASSERT_NE(nullptr, pre_movement_msg);
+  EXPECT_NEAR(0.0, pre_movement_msg->latitude, tol);
+  EXPECT_NEAR(0.0, pre_movement_msg->longitude, tol);
+  EXPECT_NEAR(0.5, pre_movement_msg->altitude, tol);
+
+  // Change the position of the link and step a few times to wait the ros message to be received
+  ignition::math::Pose3d box_pose;
+  box_pose.Pos() = {100.0, 200.0, 300.0};
+  link->SetWorldPose(box_pose);
+  world->Step(50);
+  rclcpp::spin_some(node);
+
+  // Check that GPS output reflects the position change
+  auto post_movement_msg = std::make_shared<sensor_msgs::msg::NavSatFix>(*msg);
+  ASSERT_NE(nullptr, post_movement_msg);
+  EXPECT_GT(post_movement_msg->latitude, 0.0);
+  EXPECT_GT(post_movement_msg->longitude, 0.0);
+  EXPECT_NEAR(300, post_movement_msg->altitude, 1);
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/gazebo_plugins/test/worlds/gazebo_ros_gps_sensor.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_gps_sensor.world
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <world name="gazebo_ros_gps_sensor_world">
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <spherical_coordinates>
+        <!-- currently gazebo has a bug: instead of outputing lat, long, altitude in ENU as the
+        default configurations, it's outputting (-E)(-N)U, therefore we rotate the default frame
+        180 so that it would go back to 180 -->
+        <heading_deg>180</heading_deg>
+    </spherical_coordinates>
+    <model name="box">
+      <pose>0 0 0.0 0 0 0</pose>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor name="my_gps" type="gps">
+          <always_on>true</always_on>
+          <update_rate>30</update_rate>
+          <gps>
+            <position_sensing>
+              <horizontal>
+                <noise type="gaussian">
+                  <mean>0.0</mean>
+                  <stddev>2e-4</stddev>
+                </noise>
+              </horizontal>
+              <vertical>
+                <noise type="gaussian">
+                  <mean>0.0</mean>
+                  <stddev>2e-4</stddev>
+                </noise>
+              </vertical>
+            </position_sensing>
+          </gps>
+          <plugin name="my_gps_plugin" filename="libgazebo_ros_gps_sensor.so">
+            <ros>
+              <namespace>/gps</namespace>
+              <argument>~/out:=data</argument>
+            </ros>
+          </plugin>
+        </sensor>
+      </link>
+    </model>
+  </world>
+</sdf>

--- a/gazebo_plugins/worlds/gazebo_ros_gps_sensor_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_gps_sensor_demo.world
@@ -1,4 +1,11 @@
 <?xml version="1.0"?>
+<!--
+  Gazebo ROS GPS plugin demo
+
+  Try for example:
+
+  ros2 topic echo /gps/data
+-->
 <sdf version="1.6">
   <world name="gazebo_ros_gps_sensor_world">
     <include>


### PR DESCRIPTION
I created the GPS sensor plugin that outputs a NavSatFix message in ros2. I used the IMU plugin as reference for the implementation.

I also added a test. First the box position acquired, then its position is set on the world (positive x, y and z), then check if the latitude, longitude and altitude are positive (positive East, North and Up).

Please take a look if it seems fine.

I have some notes:
1. P.S. Gazebo seems to be outputting ENU (the default world orientation) wrong. My take is that the C++ code shouldn't change, what should be fixed is the Gazebo code. I added a 180 deg on the heading on the .world file to make it output what it should. Later I'll take a look at the gazebo code to check the reason for this behavior.

2. The SDF has <position_sensing> and <velocity_sensing> tags, but I only implemented the <position_sensing> because the GpsSensor in Gazebo API for Gazebo 9.0 doesn't have the functions VelocityEast(), VelocityNorth() and VelocityUp(), which are available in Gazebo 9.1 and forth.