### PR TITLE
[ros2] Spawn <plugin> without <ros>

### DIFF
--- a/gazebo_ros/src/gazebo_ros_factory.cpp
+++ b/gazebo_ros/src/gazebo_ros_factory.cpp
@@ -318,7 +318,18 @@ void GazeboRosFactoryPrivate::AddNamespace(
     // <plugin>
     if (child_elem->GetName() == "plugin") {
       // Get / create <ros>
-      auto ros_elem = child_elem->GetElement("ros");
+      sdf::ElementPtr ros_elem;
+      if (child_elem->HasElement("ros")) {
+        ros_elem = child_elem->GetElement("ros");
+      } else {
+        // Tell SDF it's ok for <plugin> to have <ros> element
+        auto ros_desc = std::make_shared<sdf::Element>();
+        ros_desc->SetName("ros");
+        child_elem->AddElementDescription(ros_desc);
+
+        // Then we can add the element
+        ros_elem = child_elem->AddElement("ros");
+      }
 
       // Get namespace element
       sdf::ElementPtr ns_elem;

--- a/gazebo_ros/test/test_gazebo_ros_factory.cpp
+++ b/gazebo_ros/test/test_gazebo_ros_factory.cpp
@@ -108,6 +108,10 @@ TEST_F(GazeboRosFactoryTest, SpawnDelete)
       "<inertia ixx='1' ixy='0.0' ixz='0.0' iyy='1' iyz='0.0' izz='1'/>"
       "</inertial>"
       "</link>"
+      "<gazebo>"
+      "  <plugin filename='fake_plugin.so' name='fake'>"
+      "  </plugin>"
+      "</gazebo>"
       "</robot>";
 
     auto response_future = spawn_client->async_send_request(request);


### PR DESCRIPTION
The issue was brought up by @mogumbo here: https://github.com/ros-simulation/gazebo_ros_pkgs/pull/948#issuecomment-520523174 .

When traversing SDF elements, we need to add element descriptions for each element, otherwise they're not created. This is usually not an issue because SDF can tell we're dealing with a `<plugin>` tag, which accepts arbitrary elements. But in this use case, we're dealing with generic SDF elements, so we need to describe the contents.

A manual way of testing this is to create a URDF model like this:

```
<?xml version="1.0" ?>
<robot name="ball">
<link name="base_link">
<visual>
<geometry>
<sphere radius="1.0"/>
</geometry>
</visual>
<collision>
<geometry>
<sphere radius="1.0"/>
</geometry>
</collision>
<inertial>
<mass value="1"/>
<inertia ixx="1" ixy="0.0" ixz="0.0" iyy="1" iyz="0.0" izz="1"/>
</inertial>
</link>
<gazebo>
    <plugin filename="libgazebo_ros_p3d.so" name="gazebo_ros_p3d">
        <!--ros>
          <argument>odom:=ground_truth</argument>
        </ros-->
        <frame_name>world</frame_name>
        <body_name>base_link</body_name>
        <update_rate>1</update_rate>
    </plugin>
  </gazebo>
</robot>
```

And spawn it like this:

```
ros2 run gazebo_ros spawn_entity.py -entity ball -file /path/to/model.urdf
```


