### PR TITLE
Reorder fields initialization to match initialization order in .h file

### DIFF
--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -28,13 +28,13 @@ namespace gazebo
 {
 
 GazeboRosApiPlugin::GazeboRosApiPlugin() :
-  physics_reconfigure_initialized_(false),
-  world_created_(false),
-  stop_(false),
   plugin_loaded_(false),
+  stop_(false),
   pub_link_states_connection_count_(0),
   pub_model_states_connection_count_(0),
-  pub_clock_frequency_(0)
+  physics_reconfigure_initialized_(false),
+  pub_clock_frequency_(0),
+  world_created_(false)
 {
   robot_namespace_.clear();
 }


### PR DESCRIPTION
This change fixes -Wreorder warnings. More on -Wreorder:
https://stackoverflow.com/questions/1828037/whats-the-point-of-g-wreorder