### PR TITLE
Remove ROS-specific arguments before passing to argparse

### DIFF
--- a/gazebo_ros/scripts/spawn_entity.py
+++ b/gazebo_ros/scripts/spawn_entity.py
@@ -340,7 +340,8 @@ def quaternion_from_euler(roll, pitch, yaw):
 
 def main(args=sys.argv):
     rclpy.init(args=args)
-    spawn_entity_node = SpawnEntityNode(args)
+    args_without_ros = rclpy.utilities.remove_ros_args(args)
+    spawn_entity_node = SpawnEntityNode(args_without_ros)
     spawn_entity_node.get_logger().info('Spawn Entity started')
     exit_code = spawn_entity_node.run()
     sys.exit(exit_code)


### PR DESCRIPTION
This resolves argparse errors when trying to launch the spawn_entity script as a ROS node.

For example, a launch file like the following wouldn't work without this change:

    <launch>
      <arg name="model_urdf" default="$(find-pkg-share mymodels)/urdf/ball.urdf" />
      <node
        pkg="gazebo_ros"
        exec="spawn_entity.py"
        name="spawner"
        args="-entity foo -file /path/to/my/model/foo.urdf" />
    </launch>