### PR TITLE
[Windows][ros2] fix multi_camera_plugin on windows

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -97,6 +97,15 @@ ament_export_libraries(gazebo_ros_template)
 add_library(multi_camera_plugin SHARED
   src/multi_camera_plugin.cpp
 )
+ament_target_dependencies(multi_camera_plugin
+  "gazebo_dev"
+)
+target_link_libraries(multi_camera_plugin
+  gazebo_sensors
+)
+target_compile_definitions(multi_camera_plugin
+  PRIVATE BUILDING_DLL
+)
 
 # gazebo_ros_multi_camera
 add_library(gazebo_ros_multi_camera SHARED


### PR DESCRIPTION
Another update so the latest changes are compatible with Windows. These changes should have no effect on other systems.

- Link `multi_camera_plugin` with the `gazebo_sensors` import library.
- Set `BUILDING_DLL` to correctly [assign the `GAZEBO_VISIBLE` attribute for export](https://bitbucket.org/osrf/gazebo/src/c1acd8bfc1bdd390380bdb33025de4bde0c9f458/gazebo/util/system.hh#lines-40)
  - Note this is also [used by Gazebo](https://bitbucket.org/osrf/gazebo/src/c1acd8bfc1bdd390380bdb33025de4bde0c9f458/plugins/CMakeLists.txt#lines-2) when building the built-in plugins