### PR TITLE
[ros2] Add support for the orientation_reference_frame SDF option for IMU sensors

### DIFF
--- a/gazebo_plugins/test/test_gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_imu_sensor.cpp
@@ -24,76 +24,148 @@
 /// Tests the gazebo_ros_imu_sensor plugin
 class GazeboRosImuSensorTest : public gazebo::ServerFixture
 {
+private:
+  gazebo::physics::WorldPtr world;
+  gazebo::physics::ModelPtr box;
+  gazebo::physics::LinkPtr link;
+  sensor_msgs::msg::Imu::SharedPtr msg;
+  rclcpp::Node::SharedPtr node;
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub;
+
+public:
+  void InitializeROS()
+  {
+    // World
+    world = gazebo::physics::get_world();
+    ASSERT_NE(nullptr, world);
+
+    // Get the model with the attached IMU
+    box = world->ModelByName("box");
+    link = box->GetLink("link");
+    ASSERT_NE(nullptr, box);
+
+    // Make sure sensor is loaded
+    ASSERT_EQ(link->GetSensorCount(), 1u);
+
+    // Create node / executor for receiving imu message
+    node = std::make_shared<rclcpp::Node>("test_gazebo_ros_imu_sensor");
+    ASSERT_NE(nullptr, node);
+
+    msg = nullptr;
+    sub =
+      node->create_subscription<sensor_msgs::msg::Imu>("/imu/data", rclcpp::SensorDataQoS(),
+        [this](sensor_msgs::msg::Imu::SharedPtr _msg) {
+          msg = _msg;
+        });
+
+    // Step until an imu message have been published
+    int sleep{0};
+    int max_sleep{30};
+    while (sleep < max_sleep && nullptr == msg) {
+      world->Step(100);
+      rclcpp::spin_some(node);
+      gazebo::common::Time::MSleep(100);
+      sleep++;
+    }
+    EXPECT_LT(0u, sub->get_publisher_count());
+    EXPECT_LT(sleep, max_sleep);
+    ASSERT_NE(nullptr, msg);
+  }
+
+  void ApplyForceTorque()
+  {
+    InitializeROS();
+
+    // Get the initial imu output when the box is at rest
+    auto pre_movement_msg = std::make_shared<sensor_msgs::msg::Imu>(*msg);
+    ASSERT_NE(nullptr, pre_movement_msg);
+    auto pre_movement_yaw =
+      gazebo_ros::Convert<ignition::math::Quaterniond>(pre_movement_msg->orientation).Euler().Z();
+    EXPECT_LT(pre_movement_yaw, 1e-4);
+    EXPECT_LT(pre_movement_msg->linear_acceleration.x, 0.5);
+    EXPECT_LT(pre_movement_msg->angular_velocity.z, 0.1);
+
+    // Apply a force + torque and collect a new message
+    for (unsigned int i = 0; i < 5; i++) {
+      // Small steps so the force is continually applied
+      link->SetForce({500.0, 0.0, 0.0});
+      link->SetTorque({0.0, 0.0, 500.0});
+      world->Step(50);
+    }
+    rclcpp::spin_some(node);
+
+    // Check that IMU output reflects state changes due to applied force
+    auto post_movement_msg = std::make_shared<sensor_msgs::msg::Imu>(*msg);
+    ASSERT_NE(nullptr, post_movement_msg);
+    auto post_movement_yaw =
+      gazebo_ros::Convert<ignition::math::Quaterniond>(post_movement_msg->orientation).Euler().Z();
+    EXPECT_GT(post_movement_yaw, 0.1);
+    // The linear acceleration reported by Gazebo flips signs, so we take the absolute value
+    EXPECT_GT(std::abs(post_movement_msg->linear_acceleration.x), 1.0);
+    EXPECT_GT(post_movement_msg->angular_velocity.z, 1.0);
+  }
+
+  void ValidateInitialOrientationFrames(
+    const ignition::math::Vector3d & rpy_imu_ref,
+    const ignition::math::Vector3d & rpy_link
+  )
+  {
+    InitializeROS();
+
+    using Quaternion = ignition::math::Quaterniond;
+    Quaternion frame_imu = Quaternion::EulerToQuaternion(rpy_imu_ref);
+    Quaternion frame_link = Quaternion::EulerToQuaternion(rpy_link);
+    Quaternion frame_imu_measurement = gazebo_ros::Convert<Quaternion>(msg->orientation);
+    Quaternion frame_imu_target_measurement = frame_imu.Inverse() * frame_link;
+    Quaternion frame_identity = frame_imu_measurement.Inverse() * frame_imu_target_measurement;
+    double tol = 1e-15;
+    EXPECT_LE(std::abs(frame_identity.X()), tol);
+    EXPECT_LE(std::abs(frame_identity.Y()), tol);
+    EXPECT_LE(std::abs(frame_identity.Z()), tol);
+  }
 };
 
 TEST_F(GazeboRosImuSensorTest, ImuMessageCorrect)
 {
   // Load test world and start paused
   this->Load("worlds/gazebo_ros_imu_sensor.world", true);
+  this->ApplyForceTorque();
+}
 
-  // World
-  auto world = gazebo::physics::get_world();
-  ASSERT_NE(nullptr, world);
+TEST_F(GazeboRosImuSensorTest, ImuOrientationCustom)
+{
+  // Load test world and start paused
+  this->Load("worlds/gazebo_ros_imu_sensor_frame_custom.world", true);
 
-  // Get the model with the attached IMU
-  auto box = world->ModelByName("box");
-  auto link = box->GetLink("link");
-  ASSERT_NE(nullptr, box);
+  using ignition::math::Vector3d;
+  this->ValidateInitialOrientationFrames({0.1, 0.2, 0.3}, {0.4, 0.5, 0.6});
+}
 
-  // Make sure sensor is loaded
-  ASSERT_EQ(link->GetSensorCount(), 1u);
+TEST_F(GazeboRosImuSensorTest, ImuOrientationNED)
+{
+  // Load test world and start paused
+  this->Load("worlds/gazebo_ros_imu_sensor_frame_ned.world", true);
 
-  // Create node / executor for receiving imu message
-  auto node = std::make_shared<rclcpp::Node>("test_gazebo_ros_imu_sensor");
-  ASSERT_NE(nullptr, node);
+  using ignition::math::Vector3d;
+  this->ValidateInitialOrientationFrames({M_PI, 0, M_PI / 2}, {0.4, 0.5, 0.6});
+}
 
-  sensor_msgs::msg::Imu::SharedPtr msg = nullptr;
-  auto sub =
-    node->create_subscription<sensor_msgs::msg::Imu>("/imu/data", rclcpp::SensorDataQoS(),
-      [&msg](sensor_msgs::msg::Imu::SharedPtr _msg) {
-        msg = _msg;
-      });
+TEST_F(GazeboRosImuSensorTest, ImuOrientationENU)
+{
+  // Load test world and start paused
+  this->Load("worlds/gazebo_ros_imu_sensor_frame_enu.world", true);
 
-  // Step until an imu message will have been published
-  int sleep{0};
-  int max_sleep{30};
-  while (sleep < max_sleep && nullptr == msg) {
-    world->Step(100);
-    rclcpp::spin_some(node);
-    gazebo::common::Time::MSleep(100);
-    sleep++;
-  }
-  EXPECT_LT(0u, sub->get_publisher_count());
-  EXPECT_LT(sleep, max_sleep);
-  ASSERT_NE(nullptr, msg);
+  using ignition::math::Vector3d;
+  this->ValidateInitialOrientationFrames({0, 0, 0}, {0.4, 0.5, 0.6});
+}
 
-  // Get the initial imu output when the box is at rest
-  auto pre_movement_msg = std::make_shared<sensor_msgs::msg::Imu>(*msg);
-  ASSERT_NE(nullptr, pre_movement_msg);
-  auto pre_movement_yaw =
-    gazebo_ros::Convert<ignition::math::Quaterniond>(pre_movement_msg->orientation).Euler().Z();
-  EXPECT_LT(pre_movement_yaw, 0.1);
-  EXPECT_LT(pre_movement_msg->linear_acceleration.x, 0.5);
-  EXPECT_LT(pre_movement_msg->angular_velocity.z, 0.1);
+TEST_F(GazeboRosImuSensorTest, ImuOrientationNWU)
+{
+  // Load test world and start paused
+  this->Load("worlds/gazebo_ros_imu_sensor_frame_nwu.world", true);
 
-  // Apply a force + torque and collect a new message
-  for (unsigned int i = 0; i < 5; i++) {
-    // Small steps so the force is continually applied
-    link->SetForce({500.0, 0.0, 0.0});
-    link->SetTorque({0.0, 0.0, 500.0});
-    world->Step(50);
-  }
-  rclcpp::spin_some(node);
-
-  // Check that IMU output reflects state changes due to applied force
-  auto post_movement_msg = std::make_shared<sensor_msgs::msg::Imu>(*msg);
-  ASSERT_NE(nullptr, post_movement_msg);
-  auto post_movement_yaw =
-    gazebo_ros::Convert<ignition::math::Quaterniond>(post_movement_msg->orientation).Euler().Z();
-  EXPECT_GT(post_movement_yaw, 0.1);
-  // The linear acceleration reported by Gazebo flips signs, so we take the absolute value
-  EXPECT_GT(std::abs(post_movement_msg->linear_acceleration.x), 1.0);
-  EXPECT_GT(post_movement_msg->angular_velocity.z, 1.0);
+  using ignition::math::Vector3d;
+  this->ValidateInitialOrientationFrames({0, 0, M_PI / 2}, {0.4, 0.5, 0.6});
 }
 
 int main(int argc, char ** argv)

--- a/gazebo_plugins/test/worlds/gazebo_ros_imu_sensor_frame_custom.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_imu_sensor_frame_custom.world
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <world name="gazebo_ros_imu_sensor_world">
+    <gravity>0 0 0</gravity>
+    <model name="box">
+      <pose>0 0 0 0.4 0.5 0.6</pose>
+      <link name="link">
+        <sensor name="my_imu" type="imu">
+          <always_on>true</always_on>
+          <update_rate>30</update_rate>
+          <imu>
+            <orientation_reference_frame>
+              <localization>CUSTOM</localization>
+              <custom_rpy>0.1 0.2 0.3</custom_rpy>
+            </orientation_reference_frame>
+            <angular_velocity>
+              <x></x>
+              <y></y>
+              <z></z>
+            </angular_velocity>
+            <linear_acceleration>
+              <x></x>
+              <y></y>
+              <z></z>
+            </linear_acceleration>
+          </imu>
+          <plugin name="my_imu_plugin" filename="libgazebo_ros_imu_sensor.so">
+            <ros>
+              <namespace>/imu</namespace>
+              <argument>~/out:=data</argument>
+            </ros>
+          </plugin>
+        </sensor>
+      </link>
+    </model>
+  </world>
+</sdf>

--- a/gazebo_plugins/test/worlds/gazebo_ros_imu_sensor_frame_enu.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_imu_sensor_frame_enu.world
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <world name="gazebo_ros_imu_sensor_world">
+    <gravity>0 0 0</gravity>
+    <model name="box">
+      <pose>0 0 0 0.4 0.5 0.6</pose>
+      <link name="link">
+        <sensor name="my_imu" type="imu">
+          <always_on>true</always_on>
+          <update_rate>30</update_rate>
+          <imu>
+            <orientation_reference_frame>
+              <localization>ENU</localization>
+            </orientation_reference_frame>
+            <angular_velocity>
+              <x></x>
+              <y></y>
+              <z></z>
+            </angular_velocity>
+            <linear_acceleration>
+              <x></x>
+              <y></y>
+              <z></z>
+            </linear_acceleration>
+          </imu>
+          <plugin name="my_imu_plugin" filename="libgazebo_ros_imu_sensor.so">
+            <ros>
+              <namespace>/imu</namespace>
+              <argument>~/out:=data</argument>
+            </ros>
+          </plugin>
+        </sensor>
+      </link>
+    </model>
+  </world>
+</sdf>

--- a/gazebo_plugins/test/worlds/gazebo_ros_imu_sensor_frame_ned.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_imu_sensor_frame_ned.world
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <world name="gazebo_ros_imu_sensor_world">
+    <gravity>0 0 0</gravity>
+    <model name="box">
+      <pose>0 0 0 0.4 0.5 0.6</pose>
+      <link name="link">
+        <sensor name="my_imu" type="imu">
+          <always_on>true</always_on>
+          <update_rate>30</update_rate>
+          <imu>
+            <orientation_reference_frame>
+              <localization>NED</localization>
+            </orientation_reference_frame>
+            <angular_velocity>
+              <x></x>
+              <y></y>
+              <z></z>
+            </angular_velocity>
+            <linear_acceleration>
+              <x></x>
+              <y></y>
+              <z></z>
+            </linear_acceleration>
+          </imu>
+          <plugin name="my_imu_plugin" filename="libgazebo_ros_imu_sensor.so">
+            <ros>
+              <namespace>/imu</namespace>
+              <argument>~/out:=data</argument>
+            </ros>
+          </plugin>
+        </sensor>
+      </link>
+    </model>
+  </world>
+</sdf>

--- a/gazebo_plugins/test/worlds/gazebo_ros_imu_sensor_frame_nwu.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_imu_sensor_frame_nwu.world
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <world name="gazebo_ros_imu_sensor_world">
+    <gravity>0 0 0</gravity>
+    <model name="box">
+      <pose>0 0 0 0.4 0.5 0.6</pose>
+      <link name="link">
+        <sensor name="my_imu" type="imu">
+          <always_on>true</always_on>
+          <update_rate>30</update_rate>
+          <imu>
+            <orientation_reference_frame>
+              <localization>NWU</localization>
+            </orientation_reference_frame>
+            <angular_velocity>
+              <x></x>
+              <y></y>
+              <z></z>
+            </angular_velocity>
+            <linear_acceleration>
+              <x></x>
+              <y></y>
+              <z></z>
+            </linear_acceleration>
+          </imu>
+          <plugin name="my_imu_plugin" filename="libgazebo_ros_imu_sensor.so">
+            <ros>
+              <namespace>/imu</namespace>
+              <argument>~/out:=data</argument>
+            </ros>
+          </plugin>
+        </sensor>
+      </link>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
It is now possible to change the IMU reference frame instead of always acquiring data with respect to the initial IMU pose.

I wrote unit tests for all supported (based on the current SDF spec) use cases.

Besides, it looks like this feature should be added to the Gazebo IMU sensor class, but I found it easier and faster to do it here.