### PR TITLE
generate a .dsv file for the environment hook

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -352,6 +352,17 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
+if(NOT WIN32)
+  if(NOT APPLE)
+    set(
+      AMENT_CMAKE_ENVIRONMENT_HOOKS_DESC_gazebo_plugins
+      "prepend-non-duplicate;LD_LIBRARY_PATH;${GAZEBO_PLUGIN_PATH}")
+  else()
+    set(
+      AMENT_CMAKE_ENVIRONMENT_HOOKS_DESC_gazebo_plugins
+      "prepend-non-duplicate;DYLD_LIBRARY_PATH;${GAZEBO_PLUGIN_PATH}")
+  endif()
+endif()
 ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/env-hooks/gazebo_plugins.sh.in")
 
 ament_package()


### PR DESCRIPTION
Follow up of #974. Fixes #1003.

This also needs to be applied to the `eloquent` branch and released there.