### PR TITLE
diffdrive - apply acceleration until both speeds reach setpoint

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
@@ -459,8 +459,8 @@ void GazeboRosDiffDrivePrivate::OnUpdate(const gazebo::common::UpdateInfo & _inf
   // If max_accel == 0, or target speed is reached
   for (unsigned int i = 0; i < num_wheel_pairs_; ++i) {
     if (max_wheel_accel_ == 0 ||
-      (fabs(desired_wheel_speed_[2 * i + LEFT] - current_speed[2 * i + LEFT]) < 0.01) ||
-      (fabs(desired_wheel_speed_[2 * i + RIGHT] - current_speed[2 * i + RIGHT]) < 0.01))
+      ((fabs(desired_wheel_speed_[2 * i + LEFT] - current_speed[2 * i + LEFT]) < 0.01) &&
+      (fabs(desired_wheel_speed_[2 * i + RIGHT] - current_speed[2 * i + RIGHT]) < 0.01)))
     {
       joints_[2 * i + LEFT]->SetParam(
         "vel", 0, desired_wheel_speed_[2 * i + LEFT] / (wheel_diameter_[i] / 2.0));


### PR DESCRIPTION
Currently acceleration is no longer applied as soon as one of the wheel reach the target velocity. The other wheel is then also directly set to the set point, causing weird behavior.

By checking if both wheel speeds reached the target velocity this behavior is fixed.