### PR TITLE
[ros2] Add remapping tag

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_ackermann_drive.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_ackermann_drive.hpp
@@ -32,9 +32,9 @@ class GazeboRosAckermannDrivePrivate;
 
       <ros>
         <namespace>demo</namespace>
-        <argument>cmd_vel:=cmd_demo</argument>
-        <argument>odom:=odom_demo</argument>
-        <argument>distance:=distance_demo</argument>
+        <remapping>cmd_vel:=cmd_demo</remapping>
+        <remapping>odom:=odom_demo</remapping>
+        <remapping>distance:=distance_demo</remapping>
       </ros>
 
       <update_rate>100.0</update_rate>

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_bumper.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_bumper.hpp
@@ -33,7 +33,7 @@ class GazeboRosBumperPrivate;
       -->
       <ros>
         <namespace>custom_ns</namespace>
-        <argument>bumper_states:=custom_topic</argument>
+        <remapping>bumper_states:=custom_topic</remapping>
       </ros>
 
       <!-- Set TF frame name. Defaults to world -->

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera.hpp
@@ -42,9 +42,9 @@ class GazeboRosCameraPrivate;
       -->
       <ros>
         <namespace>custom_ns</namespace>
-        <argument>image_raw:=custom_img</argument>
-        <argument>camera_info:=custom_info</argument>
-        <argument>image_trigger:=custom_trigger</argument>
+        <remapping>image_raw:=custom_img</remapping>
+        <remapping>camera_info:=custom_info</remapping>
+        <remapping>image_trigger:=custom_trigger</remapping>
       </ros>
 
       <!-- Set camera name. If empty, defaults to sensor name -->

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_elevator.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_elevator.hpp
@@ -34,7 +34,7 @@ class GazeboRosElevatorPrivate;
         <namespace>demo</namespace>
 
         <!-- topic remapping -->
-        <argument>elevator:=elevator_demo</argument>
+        <remapping>elevator:=elevator_demo</remapping>
       </ros>
 
       <!-- min and max floor constraints -->

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_force.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_force.hpp
@@ -39,7 +39,7 @@ class GazeboRosForcePrivate;
         <namespace>/test</namespace>
 
         <!-- Remap the default topic -->
-        <argument>gazebo_ros_force:=force_test</argument>
+        <remapping>gazebo_ros_force:=force_test</remapping>
 
       </ros>
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_ft_sensor.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_ft_sensor.hpp
@@ -43,7 +43,7 @@ class GazeboRosFTSensorPrivate;
         <namespace>/demo</namespace>
 
         <!-- Remap the default topic -->
-        <argument>wrench:=wrench_demo</argument>
+        <remapping>wrench:=wrench_demo</remapping>
 
       </ros>
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_gps_sensor.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_gps_sensor.hpp
@@ -39,7 +39,7 @@ class GazeboRosGpsSensorPrivate;
         <ros>
           <!-- publish to /gps/data -->
           <namespace>/gps</namespace>
-          <argument>~/out:=data</argument>
+          <remapping>~/out:=data</remapping>
         </ros>
       </plugin>
     </sensor>

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_harness.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_harness.hpp
@@ -34,8 +34,8 @@ class GazeboRosHarnessPrivate;
       <ros>
         <!-- Add a namespace -->
         <namespace>demo</namespace>
-        <argument>box/harness/velocity:=velocity_demo</argument>
-        <argument>box/harness/detach:=detach_demo</argument>
+        <remapping>box/harness/velocity:=velocity_demo</remapping>
+        <remapping>box/harness/detach:=detach_demo</remapping>
       </ros>
       <!-- set initial harness velocity -->
       <!--<init_vel>-0.1</init_vel>-->

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_imu_sensor.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_imu_sensor.hpp
@@ -39,7 +39,7 @@ class GazeboRosImuSensorPrivate;
         <ros>
           <!-- publish to /imu/data -->
           <namespace>/imu</namespace>
-          <argument>~/out:=data</argument>
+          <remapping>~/out:=data</remapping>
         </ros>
       </plugin>
     </sensor>

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_joint_pose_trajectory.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_joint_pose_trajectory.hpp
@@ -37,7 +37,7 @@ class GazeboRosJointPoseTrajectoryPrivate;
         <namespace>/my_namespace</namespace>
 
         <!-- Remap the default topic -->
-        <argument>set_joint_trajectory:=my_trajectory</argument>
+        <remapping>set_joint_trajectory:=my_trajectory</remapping>
 
       </ros>
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_joint_state_publisher.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_joint_state_publisher.hpp
@@ -56,7 +56,7 @@ class GazeboRosJointStatePublisherPrivate;
         <namespace>/ny_namespace</namespace>
 
         <!-- Remap the default topic -->
-        <argument>joint_states:=my_joint_states</argument>
+        <remapping>joint_states:=my_joint_states</remapping>
 
       </ros>
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_p3d.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_p3d.hpp
@@ -37,7 +37,7 @@ class GazeboRosP3DPrivate;
         <namespace>/demo</namespace>
 
         <!-- Remap the default topic -->
-        <argument>odom:=p3d_demo</argument>
+        <remapping>odom:=p3d_demo</remapping>
 
       </ros>
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_planar_move.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_planar_move.hpp
@@ -41,8 +41,8 @@ class GazeboRosPlanarMovePrivate;
         <namespace>/demo</namespace>
 
         <!-- Remap the default topic -->
-        <argument>cmd_vel:=custom_cmd_vel</argument>
-        <argument>odom:=custom_odom</argument>
+        <remapping>cmd_vel:=custom_cmd_vel</remapping>
+        <remapping>odom:=custom_odom</remapping>
 
       </ros>
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_projector.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_projector.hpp
@@ -33,7 +33,7 @@ class GazeboRosProjectorPrivate;
         <namespace>demo</namespace>
 
         <!-- topic remapping -->
-        <argument>switch:=switch_demo</argument>
+        <remapping>switch:=switch_demo</remapping>
 
         <projector_link>projector_link</projector_link>
         <projector_name>my_projector</projector_name>

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_ray_sensor.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_ray_sensor.hpp
@@ -58,7 +58,7 @@ class GazeboRosRaySensorPrivate;
       <ros>
         <!-- Configure namespace and remap to publish to /ray/pointcloud2 -->
         <namespace>/ray</namespace>
-        <argument>~/out:=pointcloud2</argument>
+        <remapping>~/out:=pointcloud2</remapping>
       </ros>
       <!-- Output as a PointCloud2, see above for other types -->
       <output_type>sensor_msgs/PointCloud2</output_type>

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_tricycle_drive.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_tricycle_drive.hpp
@@ -50,8 +50,8 @@ class GazeboRosTricycleDrivePrivate;
 
     <ros>
       <namespace></namespace>
-      <argument>cmd_vel:=cmd_vel</argument>
-      <argument>odom:=odom</argument>
+      <remapping>cmd_vel:=cmd_vel</remapping>
+      <remapping>odom:=odom</remapping>
     </ros>
 
     <!-- wheels -->

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_vacuum_gripper.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_vacuum_gripper.hpp
@@ -40,8 +40,8 @@ class GazeboRosVacuumGripperPrivate;
         <namespace>/demo</namespace>
 
         <!-- Remapping service and topic names -->
-        <argument>switch:=custom_switch</argument>
-        <argument>grasping:=custom_grasping</argument>
+        <remapping>switch:=custom_switch</remapping>
+        <remapping>grasping:=custom_grasping</remapping>
       </ros>
 
       <!-- Link associated with gripper -->

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_video.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_video.hpp
@@ -45,7 +45,7 @@ class GazeboRosVideoPrivate;
         <!-- Add a namespace -->
         <namespace>/custom_ns</namespace>
         <!-- remap image subscribe topic -->
-        <argument>~/image_raw:=custom_img</argument>
+        <remapping>~/image_raw:=custom_img</remapping>
       </ros>
 
       <!-- Dimensions of image -->

--- a/gazebo_plugins/test/worlds/gazebo_ros_ackermann_drive.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_ackermann_drive.world
@@ -537,9 +537,9 @@
 
         <ros>
           <namespace>test</namespace>
-          <argument>cmd_vel:=cmd_test</argument>
-          <argument>odom:=odom_test</argument>
-          <argument>distance:=distance_test</argument>
+          <remapping>cmd_vel:=cmd_test</remapping>
+          <remapping>odom:=odom_test</remapping>
+          <remapping>distance:=distance_test</remapping>
         </ros>
 
         <update_rate>100.0</update_rate>

--- a/gazebo_plugins/test/worlds/gazebo_ros_bumper.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_bumper.world
@@ -43,7 +43,7 @@
           <plugin name="contact_sensor" filename="libgazebo_ros_bumper.so">
             <ros>
               <namespace>test</namespace>
-              <argument>bumper_states:=bumper_test</argument>
+              <remapping>bumper_states:=bumper_test</remapping>
             </ros>
             <frame_name>world</frame_name>
           </plugin>

--- a/gazebo_plugins/test/worlds/gazebo_ros_camera.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_camera.world
@@ -29,8 +29,8 @@
           <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
             <ros>
               <namespace>test_cam</namespace>
-              <argument>camera1/image_raw:=camera/image_test</argument>
-              <argument>camera_info:=camera_info_test</argument>
+              <remapping>camera1/image_raw:=camera/image_test</remapping>
+              <remapping>camera_info:=camera_info_test</remapping>
             </ros>
             <!-- camera_name>omit so it defaults to sensor name</camera_name-->
             <!-- frame_name>omit so it defaults to link name</frame_name-->

--- a/gazebo_plugins/test/worlds/gazebo_ros_camera_16bit.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_camera_16bit.world
@@ -29,8 +29,8 @@
           <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
             <ros>
               <namespace>test_cam_16bit</namespace>
-              <argument>test_camera_name/image_raw:=image_test_16bit</argument>
-              <argument>camera_info:=camera_info_test_16bit</argument>
+              <remapping>test_camera_name/image_raw:=image_test_16bit</remapping>
+              <remapping>camera_info:=camera_info_test_16bit</remapping>
             </ros>
             <camera_name>test_camera_name</camera_name>
             <!-- frame_name>omit so it defaults to link name</frame_name-->

--- a/gazebo_plugins/test/worlds/gazebo_ros_camera_distortion_barrel.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_camera_distortion_barrel.world
@@ -39,8 +39,8 @@
           </camera>
           <plugin name="camera_distorted" filename="libgazebo_ros_camera.so">
             <ros>
-              <argument>distorted_camera/image_raw:=distorted_image</argument>
-              <argument>distorted_camera/camera_info:=distorted_info</argument>
+              <remapping>distorted_camera/image_raw:=distorted_image</remapping>
+              <remapping>distorted_camera/camera_info:=distorted_info</remapping>
             </ros>
             <camera_name>distorted_camera</camera_name>
             <frame_name>frame_name</frame_name>
@@ -79,7 +79,7 @@
           </camera>
           <plugin name="camera_undistorted" filename="libgazebo_ros_camera.so">
             <ros>
-              <argument>undistorted_camera/image_raw:=undistorted_image</argument>
+              <remapping>undistorted_camera/image_raw:=undistorted_image</remapping>
             </ros>
             <camera_name>undistorted_camera</camera_name>
             <frame_name>frame_name</frame_name>

--- a/gazebo_plugins/test/worlds/gazebo_ros_camera_distortion_pincushion.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_camera_distortion_pincushion.world
@@ -39,8 +39,8 @@
           </camera>
           <plugin name="camera_distorted" filename="libgazebo_ros_camera.so">
             <ros>
-              <argument>distorted_camera/image_raw:=distorted_image</argument>
-              <argument>distorted_camera/camera_info:=distorted_info</argument>
+              <remapping>distorted_camera/image_raw:=distorted_image</remapping>
+              <remapping>distorted_camera/camera_info:=distorted_info</remapping>
             </ros>
             <camera_name>distorted_camera</camera_name>
             <frame_name>frame_name</frame_name>
@@ -79,7 +79,7 @@
           </camera>
           <plugin name="camera_undistorted" filename="libgazebo_ros_camera.so">
             <ros>
-              <argument>undistorted_camera/image_raw:=undistorted_image</argument>
+              <remapping>undistorted_camera/image_raw:=undistorted_image</remapping>
             </ros>
             <camera_name>undistorted_camera</camera_name>
             <frame_name>frame_name</frame_name>

--- a/gazebo_plugins/test/worlds/gazebo_ros_camera_triggered.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_camera_triggered.world
@@ -36,8 +36,8 @@
           <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
             <ros>
               <namespace>test_triggered_cam</namespace>
-              <argument>camera1/image_raw:=image_raw_test</argument>
-              <argument>camera1/image_trigger:=image_trigger_test</argument>
+              <remapping>camera1/image_raw:=image_raw_test</remapping>
+              <remapping>camera1/image_trigger:=image_trigger_test</remapping>
             </ros>
             <triggered>true</triggered>
             <hack_baseline>0.07</hack_baseline>

--- a/gazebo_plugins/test/worlds/gazebo_ros_depth_camera.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_depth_camera.world
@@ -29,9 +29,9 @@
           <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
             <ros>
               <namespace>test_cam</namespace>
-              <argument>camera1/image_raw:=camera/raw_image_test</argument>
-              <argument>camera1/depth/image_raw:=camera/depth_image_test</argument>
-              <argument>camera1/points:=camera/points_test</argument>
+              <remapping>camera1/image_raw:=camera/raw_image_test</remapping>
+              <remapping>camera1/depth/image_raw:=camera/depth_image_test</remapping>
+              <remapping>camera1/points:=camera/points_test</remapping>
             </ros>
             <!-- camera_name>omit so it defaults to sensor name</camera_name-->
             <!-- frame_name>omit so it defaults to link name</frame_name-->

--- a/gazebo_plugins/test/worlds/gazebo_ros_diff_drive.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_diff_drive.world
@@ -201,8 +201,8 @@
       <plugin name='diff_drive' filename='libgazebo_ros_diff_drive.so'>
         <ros>
           <namespace>/test</namespace>
-          <argument>cmd_vel:=cmd_test</argument>
-          <argument>odom:=odom_test</argument>
+          <remapping>cmd_vel:=cmd_test</remapping>
+          <remapping>odom:=odom_test</remapping>
         </ros>
 
         <left_joint>left_wheel_joint</left_joint>

--- a/gazebo_plugins/test/worlds/gazebo_ros_elevator.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_elevator.world
@@ -133,7 +133,7 @@
       <plugin name="elevator" filename="libgazebo_ros_elevator.so">
         <ros>
           <namespace>test</namespace>
-          <argument>elevator:=elevator_test</argument>
+          <remapping>elevator:=elevator_test</remapping>
         </ros>
         <bottom_floor>0</bottom_floor>
         <top_floor>1</top_floor>

--- a/gazebo_plugins/test/worlds/gazebo_ros_force.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_force.world
@@ -28,7 +28,7 @@
       <plugin name="gazebo_ros_force" filename="libgazebo_ros_force.so">
         <ros>
           <namespace>/test</namespace>
-          <argument>gazebo_ros_force:=force_test</argument>
+          <remapping>gazebo_ros_force:=force_test</remapping>
         </ros>
         <link_name>box_link</link_name>
         <force_frame>world</force_frame>

--- a/gazebo_plugins/test/worlds/gazebo_ros_force_link.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_force_link.world
@@ -28,7 +28,7 @@
       <plugin name="gazebo_ros_force" filename="libgazebo_ros_force.so">
         <ros>
           <namespace>/test</namespace>
-          <argument>gazebo_ros_force:=force_test</argument>
+          <remapping>gazebo_ros_force:=force_test</remapping>
         </ros>
         <link_name>box_link</link_name>
         <force_frame>link</force_frame>

--- a/gazebo_plugins/test/worlds/gazebo_ros_ft_sensor.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_ft_sensor.world
@@ -25,7 +25,7 @@
       <plugin name="gazebo_ros_ft_sensor" filename="libgazebo_ros_ft_sensor.so">
         <ros>
           <namespace>/test</namespace>
-          <argument>wrench:=ft_sensor_test</argument>
+          <remapping>wrench:=ft_sensor_test</remapping>
         </ros>
         <body_name>link</body_name>
         <frame_name>test_world</frame_name>

--- a/gazebo_plugins/test/worlds/gazebo_ros_gps_sensor.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_gps_sensor.world
@@ -52,7 +52,7 @@
           <plugin name="my_gps_plugin" filename="libgazebo_ros_gps_sensor.so">
             <ros>
               <namespace>/gps</namespace>
-              <argument>~/out:=data</argument>
+              <remapping>~/out:=data</remapping>
             </ros>
           </plugin>
         </sensor>

--- a/gazebo_plugins/test/worlds/gazebo_ros_harness.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_harness.world
@@ -26,8 +26,8 @@
       <plugin name="harness" filename="libgazebo_ros_harness.so">
         <ros>
           <namespace>test</namespace>
-          <argument>box/harness/velocity:=velocity_test</argument>
-          <argument>box/harness/detach:=detach_test</argument>
+          <remapping>box/harness/velocity:=velocity_test</remapping>
+          <remapping>box/harness/detach:=detach_test</remapping>
         </ros>
         <joint name="joint1" type="prismatic">
           <pose>0 0 0 0 0 0</pose>

--- a/gazebo_plugins/test/worlds/gazebo_ros_imu_sensor.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_imu_sensor.world
@@ -72,7 +72,7 @@
           <plugin name="my_imu_plugin" filename="libgazebo_ros_imu_sensor.so">
             <ros>
               <namespace>/imu</namespace>
-              <argument>~/out:=data</argument>
+              <remapping>~/out:=data</remapping>
             </ros>
           </plugin>
         </sensor>

--- a/gazebo_plugins/test/worlds/gazebo_ros_joint_pose_trajectory.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_joint_pose_trajectory.world
@@ -16,7 +16,7 @@
               filename="libgazebo_ros_joint_pose_trajectory.so">
         <ros>
           <namespace>/test</namespace>
-          <argument>set_joint_trajectory:=set_trajectory_test</argument>
+          <remapping>set_joint_trajectory:=set_trajectory_test</remapping>
         </ros>
         <update_rate>2</update_rate>
       </plugin>

--- a/gazebo_plugins/test/worlds/gazebo_ros_joint_state_publisher.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_joint_state_publisher.world
@@ -69,7 +69,7 @@
           filename="libgazebo_ros_joint_state_publisher.so">
         <ros>
           <namespace>/test</namespace>
-          <argument>joint_states:=joint_states_test</argument>
+          <remapping>joint_states:=joint_states_test</remapping>
         </ros>
         <update_rate>100</update_rate>
         <joint_name>hinge</joint_name>

--- a/gazebo_plugins/test/worlds/gazebo_ros_multicamera.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_multicamera.world
@@ -49,8 +49,8 @@
           <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
             <ros>
               <namespace>test_cam</namespace>
-              <argument>camera1/left/image_raw:=camera/left/image_test</argument>
-              <argument>camera1/right/image_raw:=camera/right/image_test</argument>
+              <remapping>camera1/left/image_raw:=camera/left/image_test</remapping>
+              <remapping>camera1/right/image_raw:=camera/right/image_test</remapping>
             </ros>
             <!-- camera_name>omit so it defaults to sensor name</camera_name-->
             <!-- frame_name>omit so it defaults to link name</frame_name-->

--- a/gazebo_plugins/test/worlds/gazebo_ros_p3d.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_p3d.world
@@ -45,7 +45,7 @@
       <plugin name="gazebo_ros_p3d" filename="libgazebo_ros_p3d.so">
         <ros>
           <namespace>/test</namespace>
-          <argument>odom:=p3d_test</argument>
+          <remapping>odom:=p3d_test</remapping>
         </ros>
         <body_name>box_link</body_name>
         <frame_name>sphere_link</frame_name>

--- a/gazebo_plugins/test/worlds/gazebo_ros_planar_move.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_planar_move.world
@@ -28,8 +28,8 @@
       <plugin name='planar_move' filename='libgazebo_ros_planar_move.so'>
         <ros>
           <namespace>/test</namespace>
-          <argument>cmd_vel:=cmd_test</argument>
-          <argument>odom:=odom_test</argument>
+          <remapping>cmd_vel:=cmd_test</remapping>
+          <remapping>odom:=odom_test</remapping>
         </ros>
 
         <update_rate>100</update_rate>

--- a/gazebo_plugins/test/worlds/gazebo_ros_projector.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_projector.world
@@ -39,7 +39,7 @@
         <ros>
           <!-- Remap for switch topic to be subscribed -->
           <namespace>/test</namespace>
-          <argument>switch:=switch_test</argument>
+          <remapping>switch:=switch_test</remapping>
         </ros>
         <projector_link>projector_link</projector_link>
         <projector_name>texture_projector</projector_name>

--- a/gazebo_plugins/test/worlds/gazebo_ros_ray_sensor.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_ray_sensor.world
@@ -50,28 +50,28 @@
           <plugin name="pc2" filename="libgazebo_ros_ray_sensor.so">
             <ros>
               <namespace>/ray</namespace>
-              <argument>~/out:=pointcloud2</argument>
+              <remapping>~/out:=pointcloud2</remapping>
             </ros>
             <output_type>sensor_msgs/PointCloud2</output_type>
           </plugin>
           <plugin name="pc" filename="libgazebo_ros_ray_sensor.so">
             <ros>
               <namespace>/ray</namespace>
-              <argument>~/out:=pointcloud</argument>
+              <remapping>~/out:=pointcloud</remapping>
             </ros>
             <output_type>sensor_msgs/PointCloud</output_type>
           </plugin>
           <plugin name="ls" filename="libgazebo_ros_ray_sensor.so">
             <ros>
               <namespace>/ray</namespace>
-              <argument>~/out:=laserscan</argument>
+              <remapping>~/out:=laserscan</remapping>
             </ros>
             <output_type>sensor_msgs/LaserScan</output_type>
           </plugin>
           <plugin name="range" filename="libgazebo_ros_ray_sensor.so">
             <ros>
               <namespace>/ray</namespace>
-              <argument>~/out:=range</argument>
+              <remapping>~/out:=range</remapping>
             </ros>
             <output_type>sensor_msgs/Range</output_type>
           </plugin>
@@ -80,28 +80,28 @@
           <plugin name="pc2_gpu" filename="libgazebo_ros_ray_sensor.so">
             <ros>
               <namespace>/gpu_ray</namespace>
-              <argument>~/out:=pointcloud2</argument>
+              <remapping>~/out:=pointcloud2</remapping>
             </ros>
             <output_type>sensor_msgs/PointCloud2</output_type>
           </plugin>
           <plugin name="pc_gpu" filename="libgazebo_ros_ray_sensor.so">
             <ros>
               <namespace>/gpu_ray</namespace>
-              <argument>~/out:=pointcloud</argument>
+              <remapping>~/out:=pointcloud</remapping>
             </ros>
             <output_type>sensor_msgs/PointCloud</output_type>
           </plugin>
           <plugin name="ls_gpu" filename="libgazebo_ros_ray_sensor.so">
             <ros>
               <namespace>/gpu_ray</namespace>
-              <argument>~/out:=laserscan</argument>
+              <remapping>~/out:=laserscan</remapping>
             </ros>
             <output_type>sensor_msgs/LaserScan</output_type>
           </plugin>
           <plugin name="range_gpu" filename="libgazebo_ros_ray_sensor.so">
             <ros>
               <namespace>/gpu_ray</namespace>
-              <argument>~/out:=range</argument>
+              <remapping>~/out:=range</remapping>
             </ros>
             <output_type>sensor_msgs/Range</output_type>
           </plugin>

--- a/gazebo_plugins/test/worlds/gazebo_ros_skid_steer_drive.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_skid_steer_drive.world
@@ -323,8 +323,8 @@
       <plugin name='skid_steer_drive' filename='libgazebo_ros_diff_drive.so'>
         <ros>
           <namespace>/test</namespace>
-          <argument>cmd_vel:=cmd_test</argument>
-          <argument>odom:=odom_test</argument>
+          <remapping>cmd_vel:=cmd_test</remapping>
+          <remapping>odom:=odom_test</remapping>
         </ros>
 
         <num_wheel_pairs>2</num_wheel_pairs>

--- a/gazebo_plugins/test/worlds/gazebo_ros_tricycle_drive.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_tricycle_drive.world
@@ -398,8 +398,8 @@
 
         <ros>
           <namespace>/test</namespace>
-          <argument>cmd_vel:=cmd_test</argument>
-          <argument>odom:=odom_test</argument>
+          <remapping>cmd_vel:=cmd_test</remapping>
+          <remapping>odom:=odom_test</remapping>
         </ros>
 
         <!-- wheels -->

--- a/gazebo_plugins/test/worlds/gazebo_ros_vacuum_gripper.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_vacuum_gripper.world
@@ -29,8 +29,8 @@
 
         <ros>
           <namespace>/test</namespace>
-          <argument>switch:=switch_test</argument>
-          <argument>grasping:=grasping_test</argument>
+          <remapping>switch:=switch_test</remapping>
+          <remapping>grasping:=grasping_test</remapping>
         </ros>
 
         <link_name>link</link_name>

--- a/gazebo_plugins/test/worlds/gazebo_ros_video.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_video.world
@@ -28,7 +28,7 @@
             <ros>
               <!-- Remap for image topic to be subscribed -->
               <namespace>/test</namespace>
-              <argument>~/image_raw:=video_test</argument>
+              <remapping>~/image_raw:=video_test</remapping>
             </ros>
             <height>120</height>
             <width>160</width>

--- a/gazebo_plugins/worlds/gazebo_ros_ackermann_drive_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_ackermann_drive_demo.world
@@ -562,9 +562,9 @@
 
         <ros>
           <namespace>demo</namespace>
-          <argument>cmd_vel:=cmd_demo</argument>
-          <argument>odom:=odom_demo</argument>
-          <argument>distance:=distance_demo</argument>
+          <remapping>cmd_vel:=cmd_demo</remapping>
+          <remapping>odom:=odom_demo</remapping>
+          <remapping>distance:=distance_demo</remapping>
         </ros>
 
         <update_rate>100.0</update_rate>

--- a/gazebo_plugins/worlds/gazebo_ros_bumper_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_bumper_demo.world
@@ -112,7 +112,7 @@
           <plugin name="contact_sensor" filename="libgazebo_ros_bumper.so">
             <ros>
               <namespace>demo</namespace>
-              <argument>bumper_states:=bumper_demo</argument>
+              <remapping>bumper_states:=bumper_demo</remapping>
             </ros>
             <frame_name>world</frame_name>
           </plugin>

--- a/gazebo_plugins/worlds/gazebo_ros_camera_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_camera_demo.world
@@ -146,8 +146,8 @@
             <ros>
               <namespace>demo_cam</namespace>
               <!-- TODO(louise) Remapping not working due to https://github.com/ros-perception/image_common/issues/93 -->
-              <argument>image_raw:=image_demo</argument>
-              <argument>camera_info:=camera_info_demo</argument>
+              <remapping>image_raw:=image_demo</remapping>
+              <remapping>camera_info:=camera_info_demo</remapping>
             </ros>
             <!-- camera_name>omit so it defaults to sensor name</camera_name-->
             <!-- frame_name>omit so it defaults to link name</frame_name-->

--- a/gazebo_plugins/worlds/gazebo_ros_depth_camera_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_depth_camera_demo.world
@@ -148,11 +148,11 @@
               <namespace>demo_cam</namespace>
 
               <!-- topics need to be prefixed with camera_name for remapping -->
-              <argument>mycamera/image_raw:=mycamera/image_demo</argument>
-              <argument>mycamera/depth/image_raw:=mycamera/depth_demo</argument>
-              <argument>mycamera/camera_info:=mycamera/raw_cam_info_demo</argument>
-              <argument>mycamera/depth/camera_info:=mycamera/depth_cam_info_demo</argument>
-              <argument>mycamera/points:=mycamera/points_demo</argument>
+              <remapping>mycamera/image_raw:=mycamera/image_demo</remapping>
+              <remapping>mycamera/depth/image_raw:=mycamera/depth_demo</remapping>
+              <remapping>mycamera/camera_info:=mycamera/raw_cam_info_demo</remapping>
+              <remapping>mycamera/depth/camera_info:=mycamera/depth_cam_info_demo</remapping>
+              <remapping>mycamera/points:=mycamera/points_demo</remapping>
             </ros>
 
             <!-- omit camera_name to default to sensor name -->

--- a/gazebo_plugins/worlds/gazebo_ros_diff_drive_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_diff_drive_demo.world
@@ -223,8 +223,8 @@
 
         <ros>
           <namespace>/demo</namespace>
-          <argument>cmd_vel:=cmd_demo</argument>
-          <argument>odom:=odom_demo</argument>
+          <remapping>cmd_vel:=cmd_demo</remapping>
+          <remapping>odom:=odom_demo</remapping>
         </ros>
 
         <!-- wheels -->

--- a/gazebo_plugins/worlds/gazebo_ros_elevator_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_elevator_demo.world
@@ -149,7 +149,7 @@
       <plugin name="elevator" filename="libgazebo_ros_elevator.so">
         <ros>
           <namespace>demo</namespace>
-          <argument>elevator:=elevator_demo</argument>
+          <remapping>elevator:=elevator_demo</remapping>
         </ros>
         <bottom_floor>0</bottom_floor>
         <top_floor>1</top_floor>

--- a/gazebo_plugins/worlds/gazebo_ros_force_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_force_demo.world
@@ -44,7 +44,7 @@
       <plugin name="gazebo_ros_force" filename="libgazebo_ros_force.so">
         <ros>
           <namespace>/demo/world</namespace>
-          <argument>gazebo_ros_force:=force_demo</argument>
+          <remapping>gazebo_ros_force:=force_demo</remapping>
         </ros>
         <link_name>link</link_name>
         <force_frame>world</force_frame>
@@ -71,7 +71,7 @@
       <plugin name="gazebo_ros_force" filename="libgazebo_ros_force.so">
         <ros>
           <namespace>/demo/link</namespace>
-          <argument>gazebo_ros_force:=force_demo</argument>
+          <remapping>gazebo_ros_force:=force_demo</remapping>
         </ros>
         <link_name>link</link_name>
         <force_frame>link</force_frame>

--- a/gazebo_plugins/worlds/gazebo_ros_ft_sensor_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_ft_sensor_demo.world
@@ -187,7 +187,7 @@
       <plugin name="gazebo_ros_ft_sensor_joint" filename="libgazebo_ros_ft_sensor.so">
         <ros>
           <namespace>/demo_joint</namespace>
-          <argument>wrench:=ft_sensor_demo</argument>
+          <remapping>wrench:=ft_sensor_demo</remapping>
         </ros>
         <update_rate>200</update_rate>
         <joint_name>lower_joint</joint_name>
@@ -197,7 +197,7 @@
       <plugin name="gazebo_ros_ft_sensor_link" filename="libgazebo_ros_ft_sensor.so">
         <ros>
           <namespace>/demo_link</namespace>
-          <argument>wrench:=ft_sensor_demo</argument>
+          <remapping>wrench:=ft_sensor_demo</remapping>
         </ros>
         <update_rate>200</update_rate>
         <body_name>upper_link</body_name>

--- a/gazebo_plugins/worlds/gazebo_ros_gps_sensor_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_gps_sensor_demo.world
@@ -59,7 +59,7 @@
           <plugin name="my_gps_plugin" filename="libgazebo_ros_gps_sensor.so">
             <ros>
               <namespace>/gps</namespace>
-              <argument>~/out:=data</argument>
+              <remapping>~/out:=data</remapping>
             </ros>
           </plugin>
         </sensor>

--- a/gazebo_plugins/worlds/gazebo_ros_harness_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_harness_demo.world
@@ -40,8 +40,8 @@
       <plugin name="harness" filename="libgazebo_ros_harness.so">
         <ros>
           <namespace>demo</namespace>
-          <argument>box/harness/velocity:=velocity_demo</argument>
-          <argument>box/harness/detach:=detach_demo</argument>
+          <remapping>box/harness/velocity:=velocity_demo</remapping>
+          <remapping>box/harness/detach:=detach_demo</remapping>
         </ros>
         <!-- set initial harness velocity -->
         <!--<init_vel>-0.1</init_vel>-->

--- a/gazebo_plugins/worlds/gazebo_ros_joint_pose_trajectory_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_joint_pose_trajectory_demo.world
@@ -21,7 +21,7 @@
           filename="libgazebo_ros_joint_pose_trajectory.so">
         <ros>
           <namespace>/demo</namespace>
-          <argument>set_joint_trajectory:=set_trajectory_demo</argument>
+          <remapping>set_joint_trajectory:=set_trajectory_demo</remapping>
         </ros>
         <update_rate>2</update_rate>
       </plugin>

--- a/gazebo_plugins/worlds/gazebo_ros_joint_state_publisher_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_joint_state_publisher_demo.world
@@ -21,7 +21,7 @@
           filename="libgazebo_ros_joint_state_publisher.so">
         <ros>
           <namespace>/demo</namespace>
-          <argument>joint_states:=joint_states_demo</argument>
+          <remapping>joint_states:=joint_states_demo</remapping>
         </ros>
         <update_rate>2</update_rate>
         <joint_name>upper_joint</joint_name>

--- a/gazebo_plugins/worlds/gazebo_ros_multicamera_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_multicamera_demo.world
@@ -165,10 +165,10 @@
             <ros>
               <namespace>demo_cam</namespace>
               <!-- topics need to be prefixed with camera_name for remapping -->
-              <argument>mycamera/left/image_raw:=mycamera/left/image_demo</argument>
-              <argument>mycamera/right/image_raw:=mycamera/right/image_demo</argument>
-              <argument>mycamera/left/camera_info:=mycamera/left/camera_info_demo</argument>
-              <argument>mycamera/right/camera_info:=mycamera/right/camera_info_demo</argument>
+              <remapping>mycamera/left/image_raw:=mycamera/left/image_demo</remapping>
+              <remapping>mycamera/right/image_raw:=mycamera/right/image_demo</remapping>
+              <remapping>mycamera/left/camera_info:=mycamera/left/camera_info_demo</remapping>
+              <remapping>mycamera/right/camera_info:=mycamera/right/camera_info_demo</remapping>
             </ros>
 
             <camera_name>mycamera</camera_name>

--- a/gazebo_plugins/worlds/gazebo_ros_p3d_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_p3d_demo.world
@@ -52,7 +52,7 @@
       <plugin name="gazebo_ros_p3d" filename="libgazebo_ros_p3d.so">
         <ros>
           <namespace>/demo</namespace>
-          <argument>odom:=p3d_demo</argument>
+          <remapping>odom:=p3d_demo</remapping>
         </ros>
         <body_name>box_link</body_name>
         <frame_name>sphere_link</frame_name>

--- a/gazebo_plugins/worlds/gazebo_ros_planar_move_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_planar_move_demo.world
@@ -49,8 +49,8 @@
       <plugin name='planar_move' filename='libgazebo_ros_planar_move.so'>
         <ros>
           <namespace>/demo</namespace>
-          <argument>cmd_vel:=cmd_demo</argument>
-          <argument>odom:=odom_demo</argument>
+          <remapping>cmd_vel:=cmd_demo</remapping>
+          <remapping>odom:=odom_demo</remapping>
         </ros>
 
         <update_rate>100</update_rate>

--- a/gazebo_plugins/worlds/gazebo_ros_projector_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_projector_demo.world
@@ -53,7 +53,7 @@
         <ros>
           <!-- Remap for switch topic to be subscribed -->
           <namespace>/demo</namespace>
-          <argument>switch:=switch_demo</argument>
+          <remapping>switch:=switch_demo</remapping>
         </ros>
         <projector_link>projector_link</projector_link>
         <projector_name>texture_projector</projector_name>

--- a/gazebo_plugins/worlds/gazebo_ros_ray_sensor_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_ray_sensor_demo.world
@@ -82,28 +82,28 @@
           <plugin name="pc2" filename="libgazebo_ros_ray_sensor.so">
             <ros>
               <namespace>/ray</namespace>
-              <argument>~/out:=pointcloud2</argument>
+              <remapping>~/out:=pointcloud2</remapping>
             </ros>
             <output_type>sensor_msgs/PointCloud2</output_type>
           </plugin>
           <plugin name="pc" filename="libgazebo_ros_ray_sensor.so">
             <ros>
               <namespace>/ray</namespace>
-              <argument>~/out:=pointcloud</argument>
+              <remapping>~/out:=pointcloud</remapping>
             </ros>
             <output_type>sensor_msgs/PointCloud</output_type>
           </plugin>
           <plugin name="laserscan" filename="libgazebo_ros_ray_sensor.so">
             <ros>
               <namespace>/ray</namespace>
-              <argument>~/out:=laserscan</argument>
+              <remapping>~/out:=laserscan</remapping>
             </ros>
             <output_type>sensor_msgs/LaserScan</output_type>
           </plugin>
           <plugin name="range" filename="libgazebo_ros_ray_sensor.so">
             <ros>
               <namespace>/ray</namespace>
-              <argument>~/out:=range</argument>
+              <remapping>~/out:=range</remapping>
             </ros>
             <output_type>sensor_msgs/Range</output_type>
           </plugin>
@@ -139,28 +139,28 @@
           <plugin name="pc2_gpu" filename="libgazebo_ros_ray_sensor.so">
             <ros>
               <namespace>/gpu_ray</namespace>
-              <argument>~/out:=pointcloud2</argument>
+              <remapping>~/out:=pointcloud2</remapping>
             </ros>
             <output_type>sensor_msgs/PointCloud2</output_type>
           </plugin>
           <plugin name="pc_gpu" filename="libgazebo_ros_ray_sensor.so">
             <ros>
               <namespace>/gpu_ray</namespace>
-              <argument>~/out:=pointcloud</argument>
+              <remapping>~/out:=pointcloud</remapping>
             </ros>
             <output_type>sensor_msgs/PointCloud</output_type>
           </plugin>
           <plugin name="laserscan_gpu" filename="libgazebo_ros_ray_sensor.so">
             <ros>
               <namespace>/gpu_ray</namespace>
-              <argument>~/out:=laserscan</argument>
+              <remapping>~/out:=laserscan</remapping>
             </ros>
             <output_type>sensor_msgs/LaserScan</output_type>
           </plugin>
           <plugin name="range_gpu" filename="libgazebo_ros_ray_sensor.so">
             <ros>
               <namespace>/gpu_ray</namespace>
-              <argument>~/out:=range</argument>
+              <remapping>~/out:=range</remapping>
             </ros>
             <output_type>sensor_msgs/Range</output_type>
           </plugin>

--- a/gazebo_plugins/worlds/gazebo_ros_skid_steer_drive_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_skid_steer_drive_demo.world
@@ -349,8 +349,8 @@
 
         <ros>
           <namespace>/demo</namespace>
-          <argument>cmd_vel:=cmd_demo</argument>
-          <argument>odom:=odom_demo</argument>
+          <remapping>cmd_vel:=cmd_demo</remapping>
+          <remapping>odom:=odom_demo</remapping>
         </ros>
 
         <!-- Number of wheel pairs -->

--- a/gazebo_plugins/worlds/gazebo_ros_tricycle_drive_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_tricycle_drive_demo.world
@@ -413,8 +413,8 @@
 
         <ros>
           <namespace>/demo</namespace>
-          <argument>cmd_vel:=cmd_demo</argument>
-          <argument>odom:=odom_demo</argument>
+          <remapping>cmd_vel:=cmd_demo</remapping>
+          <remapping>odom:=odom_demo</remapping>
         </ros>
 
         <!-- wheels -->

--- a/gazebo_plugins/worlds/gazebo_ros_vacuum_gripper_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_vacuum_gripper_demo.world
@@ -45,8 +45,8 @@
 
         <ros>
           <namespace>/demo</namespace>
-          <argument>switch:=switch_demo</argument>
-          <argument>grasping:=grasping_demo</argument>
+          <remapping>switch:=switch_demo</remapping>
+          <remapping>grasping:=grasping_demo</remapping>
         </ros>
 
         <link_name>link</link_name>

--- a/gazebo_plugins/worlds/gazebo_ros_video_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_video_demo.world
@@ -142,7 +142,7 @@
           <plugin name="display_video_controller" filename="libgazebo_ros_video.so">
             <ros>
               <!-- Remap for image topic to be subscribed -->
-              <argument>~/image_raw:=/camera1/image_raw</argument>
+              <remapping>~/image_raw:=/camera1/image_raw</remapping>
             </ros>
             <height>120</height>
             <width>160</width>

--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
+find_package(rcl REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(gazebo_dev REQUIRED)
 find_package(gazebo_msgs REQUIRED)
@@ -39,6 +40,7 @@ add_library(gazebo_ros_node SHARED
 ament_target_dependencies(gazebo_ros_node
   "gazebo_dev"
   "rclcpp"
+  "rcl"
 )
 ament_export_libraries(gazebo_ros_node)
 

--- a/gazebo_ros/include/gazebo_ros/node.hpp
+++ b/gazebo_ros/include/gazebo_ros/node.hpp
@@ -65,11 +65,13 @@ public:
    *    <!-- Namespace of the node -->
    *    <namespace>/my_ns</namespace>
    *    <!-- Command line arguments sent to Node's constructor for remappings -->
-   *    <argument>my_topic:=new_topic</argument>
    *    <argument>__name:=super_cool_node</argument>
+   *    <argument>__log_level:=debug</argument>
    *    <!-- Initial ROS params set for node -->
    *    <parameter name="max_velocity" type="int">55</parameter>
    *    <parameter name="publish_odom" type="bool">True</parameter>
+   *    <!-- Remapping rules for node -->
+   *    <remapping>my_topic:=new_topic</remapping>
    *   </ros>
    * </plugin>
    * \endcode

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -25,6 +25,7 @@
   <depend>builtin_interfaces</depend>
   <depend>gazebo_dev</depend>
   <depend>gazebo_msgs</depend>
+  <depend>rcl</depend>
   <depend>rclcpp</depend>
   <depend>rclpy</depend>
   <depend>std_srvs</depend>

--- a/gazebo_ros/src/node.cpp
+++ b/gazebo_ros/src/node.cpp
@@ -19,6 +19,8 @@
 #include <string>
 #include <vector>
 
+#include <rcl/arguments.h>
+
 namespace gazebo_ros
 {
 
@@ -48,6 +50,7 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf)
   // Get inner <ros> element if full plugin sdf was passed in
   if (sdf->HasElement("ros")) {
     sdf = sdf->GetElement("ros");
+    arguments.push_back(RCL_ROS_ARGS_FLAG);
   }
 
   // Set namespace if tag is present
@@ -63,6 +66,18 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf)
       std::string argument = argument_sdf->Get<std::string>();
       arguments.push_back(argument);
       argument_sdf = argument_sdf->GetNextElement("argument");
+    }
+  }
+
+  // Get list of remapping rules from SDF
+  if (sdf->HasElement("remapping")) {
+    sdf::ElementPtr argument_sdf = sdf->GetElement("remapping");
+
+    while (argument_sdf) {
+      std::string argument = argument_sdf->Get<std::string>();
+      arguments.push_back(RCL_REMAP_FLAG);
+      arguments.push_back(argument);
+      argument_sdf = argument_sdf->GetNextElement("remapping");
     }
   }
 

--- a/gazebo_ros/src/node.cpp
+++ b/gazebo_ros/src/node.cpp
@@ -13,13 +13,14 @@
 // limitations under the License.
 
 #include <gazebo_ros/node.hpp>
+
+#include <rcl/arguments.h>
+
 #include <sdf/Param.hh>
 
 #include <memory>
 #include <string>
 #include <vector>
-
-#include <rcl/arguments.h>
 
 namespace gazebo_ros
 {
@@ -50,7 +51,6 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf)
   // Get inner <ros> element if full plugin sdf was passed in
   if (sdf->HasElement("ros")) {
     sdf = sdf->GetElement("ros");
-    arguments.push_back(RCL_ROS_ARGS_FLAG);
   }
 
   // Set namespace if tag is present
@@ -73,6 +73,7 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf)
   if (sdf->HasElement("remapping")) {
     sdf::ElementPtr argument_sdf = sdf->GetElement("remapping");
 
+    arguments.push_back(RCL_ROS_ARGS_FLAG);
     while (argument_sdf) {
       std::string argument = argument_sdf->Get<std::string>();
       arguments.push_back(RCL_REMAP_FLAG);

--- a/gazebo_ros/test/worlds/gazebo_ros_state_test.world
+++ b/gazebo_ros/test/worlds/gazebo_ros_state_test.world
@@ -4,7 +4,7 @@
     <plugin name="gazebo_ros_state" filename="libgazebo_ros_state.so">
       <ros>
         <namespace>/test</namespace>
-        <argument>model_states:=model_states_test</argument>
+        <remapping>model_states:=model_states_test</remapping>
       </ros>
     </plugin>
 

--- a/gazebo_ros/test/worlds/sdf_node_plugin.world
+++ b/gazebo_ros/test/worlds/sdf_node_plugin.world
@@ -5,6 +5,7 @@
       <ros>
         <namespace>/foo</namespace>
         <remapping>test:=my_topic</remapping>
+        <!-- Deprecated syntax, should still be accepted -->
         <argument>from:=to</argument>
 
         <!-- Declared parameters, should go through -->

--- a/gazebo_ros/test/worlds/sdf_node_plugin.world
+++ b/gazebo_ros/test/worlds/sdf_node_plugin.world
@@ -4,7 +4,8 @@
     <plugin name="sdf_node_name" filename="./libsdf_node.so">
       <ros>
         <namespace>/foo</namespace>
-        <argument>test:=my_topic</argument>
+        <remapping>test:=my_topic</remapping>
+        <argument>from:=to</argument>
 
         <!-- Declared parameters, should go through -->
         <parameter name="declared_string" type="string">from SDF</parameter>

--- a/gazebo_ros/worlds/gazebo_ros_state_demo.world
+++ b/gazebo_ros/worlds/gazebo_ros_state_demo.world
@@ -41,8 +41,8 @@
     <plugin name="gazebo_ros_state" filename="libgazebo_ros_state.so">
       <ros>
         <namespace>/demo</namespace>
-        <argument>model_states:=model_states_demo</argument>
-        <argument>link_states:=link_states_demo</argument>
+        <remapping>model_states:=model_states_demo</remapping>
+        <remapping>link_states:=link_states_demo</remapping>
       </ros>
 
       <update_rate>1.0</update_rate>


### PR DESCRIPTION
Fix for https://github.com/ros-simulation/gazebo_ros_pkgs/issues/991

I originally added the `--ros-args` for any argument in the `ros` tag, but this breaks the current deprecated use of specifying remapping rules in the `argument` tag.

So this PR just adds `--ros-args` in front of the remapping rules and `-r` in front of each remap rule. This allows to get rid of warnings by modifying users sdf as below

```xml
<argument>from:=to</argument>
[gazebo-1] [WARN] [rcl]: Found remap rule '~/from:=to'. This syntax is deprecated. Use '--ros-args --remap ~/from:=to' instead.

```
becomes
```xml
<remapping>~/from:=to</remapping>
```

Note: tests worlds have been updated accordingly but I'm not sure there is coverage for topics being remapped