### PR TITLE
[ros2] catch const ref to fix -Wcatch-value warnings

### DIFF
--- a/gazebo_ros/test/plugins/sdf_node.cpp
+++ b/gazebo_ros/test/plugins/sdf_node.cpp
@@ -84,7 +84,7 @@ void SDFNode::Load(gazebo::physics::WorldPtr, sdf::ElementPtr _sdf)
   bool caught{false};
   try {
     node->get_parameter("non_declared_bool");
-  } catch (rclcpp::exceptions::ParameterNotDeclaredException) {
+  } catch (const rclcpp::exceptions::ParameterNotDeclaredException &) {
     caught = true;
   }
   if (!caught) {
@@ -95,7 +95,7 @@ void SDFNode::Load(gazebo::physics::WorldPtr, sdf::ElementPtr _sdf)
   caught = false;
   try {
     node->get_parameter("non_declared_double");
-  } catch (rclcpp::exceptions::ParameterNotDeclaredException) {
+  } catch (const rclcpp::exceptions::ParameterNotDeclaredException &) {
     caught = true;
   }
   if (!caught) {


### PR DESCRIPTION
This warning appears on GCC8 and higher.

```
/tmp/src/gazebo_ros_pkgs/gazebo_ros/test/plugins/sdf_node.cpp:98:32: warning: catching polymorphic type ‘class rclcpp::exceptions::ParameterNotDeclaredException’ by value [-Wcatch-value=]
   98 |   } catch (rclcpp::exceptions::ParameterNotDeclaredException) {
```

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>