### PR TITLE
Made the MultiCameraPlugin really multi-camera.

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -406,6 +406,10 @@ if (CATKIN_ENABLE_TESTING)
                       test/camera/multicamera.test
                       test/camera/multicamera.cpp)
     target_link_libraries(multicamera-test ${catkin_LIBRARIES})
+    add_rostest_gtest(multimulticamera-test
+                      test/camera/multimulticamera.test
+                      test/camera/multimulticamera.cpp)
+    target_link_libraries(multimulticamera-test ${catkin_LIBRARIES})
     add_rostest_gtest(camera-test
                       test/camera/camera.test
                       test/camera/camera.cpp)

--- a/gazebo_plugins/include/gazebo_plugins/MultiCameraPlugin.h
+++ b/gazebo_plugins/include/gazebo_plugins/MultiCameraPlugin.h
@@ -36,10 +36,7 @@ namespace gazebo
 
     public: virtual void Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf);
 
-    public: virtual void OnNewFrameLeft(const unsigned char *_image,
-                              unsigned int _width, unsigned int _height,
-                              unsigned int _depth, const std::string &_format);
-    public: virtual void OnNewFrameRight(const unsigned char *_image,
+    public: virtual void OnNewFrame(const unsigned char *_image, size_t _camNumber,
                               unsigned int _width, unsigned int _height,
                               unsigned int _depth, const std::string &_format);
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_multicamera.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_multicamera.h
@@ -42,14 +42,9 @@ namespace gazebo
 
     std::vector<GazeboRosCameraUtils*> utils;
 
-    protected: void OnNewFrame(const unsigned char *_image,
-                   GazeboRosCameraUtils* util);
     /// \brief Update the controller
-    /// FIXME: switch to function vectors
-    protected: virtual void OnNewFrameLeft(const unsigned char *_image,
-                   unsigned int _width, unsigned int _height,
-                   unsigned int _depth, const std::string &_format);
-    protected: virtual void OnNewFrameRight(const unsigned char *_image,
+    protected: virtual void OnNewFrame(const unsigned char *_image,
+                   size_t _camNumber,
                    unsigned int _width, unsigned int _height,
                    unsigned int _depth, const std::string &_format);
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_triggered_multicamera.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_triggered_multicamera.h
@@ -43,11 +43,8 @@ namespace gazebo
     std::vector<GazeboRosTriggeredCamera *> triggered_cameras;
 
     /// \brief Update the controller
-    /// FIXME: switch to function vectors
-    protected: virtual void OnNewFrameLeft(const unsigned char *_image,
-                   unsigned int _width, unsigned int _height,
-                   unsigned int _depth, const std::string &_format);
-    protected: virtual void OnNewFrameRight(const unsigned char *_image,
+    protected: virtual void OnNewFrame(const unsigned char *_image,
+                   size_t _camNumber,
                    unsigned int _width, unsigned int _height,
                    unsigned int _depth, const std::string &_format);
 

--- a/gazebo_plugins/src/MultiCameraPlugin.cpp
+++ b/gazebo_plugins/src/MultiCameraPlugin.cpp
@@ -60,7 +60,8 @@ void MultiCameraPlugin::Load(sensors::SensorPtr _sensor,
     return;
   }
 
-  for (unsigned int i = 0; i < this->parentSensor->CameraCount(); ++i)
+  for (size_t i = 0;
+       i < static_cast<size_t>(this->parentSensor->CameraCount()); ++i)
   {
     this->camera.push_back(this->parentSensor->Camera(i));
 
@@ -73,39 +74,17 @@ void MultiCameraPlugin::Load(sensors::SensorPtr _sensor,
     std::string cameraName = this->parentSensor->Camera(i)->Name();
     // gzdbg << "camera(" << i << ") name [" << cameraName << "]\n";
 
-    // FIXME: hardcoded 2 camera support only
-    if (cameraName.find("left") != std::string::npos)
-    {
-      this->newFrameConnection.push_back(this->camera[i]->ConnectNewImageFrame(
-        boost::bind(&MultiCameraPlugin::OnNewFrameLeft,
-        this, _1, _2, _3, _4, _5)));
-    }
-    else if (cameraName.find("right") != std::string::npos)
-    {
-      this->newFrameConnection.push_back(this->camera[i]->ConnectNewImageFrame(
-        boost::bind(&MultiCameraPlugin::OnNewFrameRight,
-        this, _1, _2, _3, _4, _5)));
-    }
+    this->newFrameConnection.push_back(this->camera[i]->ConnectNewImageFrame(
+      boost::bind(&MultiCameraPlugin::OnNewFrame,
+      this, _1, i, _2, _3, _4, _5)));
   }
 
   this->parentSensor->SetActive(true);
 }
 
 /////////////////////////////////////////////////
-void MultiCameraPlugin::OnNewFrameLeft(const unsigned char * /*_image*/,
-                              unsigned int /*_width*/,
-                              unsigned int /*_height*/,
-                              unsigned int /*_depth*/,
-                              const std::string &/*_format*/)
-{
-  /*rendering::Camera::SaveFrame(_image, this->width,
-    this->height, this->depth, this->format,
-    "/tmp/camera/me.jpg");
-    */
-}
-
-/////////////////////////////////////////////////
-void MultiCameraPlugin::OnNewFrameRight(const unsigned char * /*_image*/,
+void MultiCameraPlugin::OnNewFrame(const unsigned char * /*_image*/,
+                              const size_t /*_camNumber*/,
                               unsigned int /*_width*/,
                               unsigned int /*_height*/,
                               unsigned int /*_depth*/,

--- a/gazebo_plugins/src/gazebo_ros_multicamera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_multicamera.cpp
@@ -63,6 +63,52 @@ void GazeboRosMultiCamera::Load(sensors::SensorPtr _parent,
   this->image_connect_count_lock_ = boost::shared_ptr<boost::mutex>(new boost::mutex);
   this->was_active_ = boost::shared_ptr<bool>(new bool(false));
 
+  const double hackBaselineSdf = (_sdf->HasElement("hackBaseline") ?
+      _sdf->Get<double>("hackBaseline") : 0);
+
+  std::vector<std::string> cameraSuffixes;
+  if (_sdf->HasElement("cameraSuffixes"))
+  {
+    const auto suffixes = _sdf->Get<std::string>("cameraSuffixes");
+    if (!suffixes.empty())
+    {
+      boost::split(cameraSuffixes, suffixes, boost::is_any_of(","));
+      if (cameraSuffixes.size() != this->camera.size())
+      {
+        ROS_FATAL_STREAM_NAMED("multicamera", "The multicamera plugin "
+          " has different number of cameras than there are items in "
+          "<cameraSuffixes>. Either leave <cameraSuffixes> empty, or put there "
+          "the same number of comma-delimited strings as there are cameras.");
+        return;
+      }
+    }
+  }
+  // backwards compatibility with the two-camera-only version
+  else if (this->camera.size() == 2 &&
+    this->camera[0]->Name().find("left") != std::string::npos &&
+    this->camera[1]->Name().find("right") != std::string::npos)
+  {
+    cameraSuffixes = { "/left", "/right" };
+  }
+  else if (this->camera.size() == 2 &&
+    this->camera[0]->Name().find("right") != std::string::npos &&
+    this->camera[1]->Name().find("left") != std::string::npos)
+  {
+    cameraSuffixes = { "/right", "/left" };
+  }
+
+  std::vector<std::string> frameNames;
+  const auto frameName = (_sdf->HasElement("frameName") ?
+      _sdf->Get<std::string>("frameName") : "world");
+  // read <frameName> as a comma-separated list of camera frames
+  boost::split(frameNames, frameName, boost::is_any_of(","));
+  // if only one frame name was entered, use it for all cameras
+  if (this->camera.size() > 1 && frameNames.size() == 1)
+  {
+    for (size_t i = 0; i < this->camera.size() - 1; ++i)
+      frameNames.push_back(frameNames[0]);
+  }
+
   // copying from CameraPlugin into GazeboRosCameraUtils
   for (unsigned i = 0; i < this->camera.size(); ++i)
   {
@@ -77,27 +123,29 @@ void GazeboRosMultiCamera::Load(sensors::SensorPtr _parent,
     util->image_connect_count_ = this->image_connect_count_;
     util->image_connect_count_lock_ = this->image_connect_count_lock_;
     util->was_active_ = this->was_active_;
-    if (this->camera[i]->Name().find("left") != std::string::npos)
-    {
-      // FIXME: hardcoded, left hack_baseline_ 0
-      util->Load(_parent, _sdf, "/left", 0.0);
-    }
-    else if (this->camera[i]->Name().find("right") != std::string::npos)
-    {
-      double hackBaseline = 0.0;
-      if (_sdf->HasElement("hackBaseline"))
-        hackBaseline = _sdf->Get<double>("hackBaseline");
-      util->Load(_parent, _sdf, "/right", hackBaseline);
-    }
+
+    double hackBaseline = 0.0;
+    if (this->camera[i]->Name().find("right") != std::string::npos)
+      hackBaseline = hackBaselineSdf;
+
+    const auto cameraSuffix = (cameraSuffixes.empty() ?
+      ("/" + this->camera[i]->Name()) : cameraSuffixes[i]);
+
+    util->Load(_parent, _sdf, cameraSuffix, hackBaseline);
+    util->frame_name_ = frameNames[i]; // overwrite the SDF-parsed frame name
+
     this->utils.push_back(util);
   }
 }
 
-////////////////////////////////////////////////////////////////////////////////
-
+// Update the controller
 void GazeboRosMultiCamera::OnNewFrame(const unsigned char *_image,
-    GazeboRosCameraUtils* util)
+    const size_t _camNumber,
+    unsigned int /*_width*/, unsigned int /*_height*/, unsigned int /*_depth*/,
+    const std::string &/*_format*/)
 {
+  GazeboRosCameraUtils* util = this->utils[_camNumber];
+
 # if GAZEBO_MAJOR_VERSION >= 7
   common::Time sensor_update_time = util->parentSensor_->LastMeasurementTime();
 # else
@@ -113,22 +161,5 @@ void GazeboRosMultiCamera::OnNewFrame(const unsigned char *_image,
       util->last_update_time_ = sensor_update_time;
     }
   }
-}
-
-// Update the controller
-void GazeboRosMultiCamera::OnNewFrameLeft(const unsigned char *_image,
-    unsigned int _width, unsigned int _height, unsigned int _depth,
-    const std::string &_format)
-{
-  OnNewFrame(_image, this->utils[0]);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Update the controller
-void GazeboRosMultiCamera::OnNewFrameRight(const unsigned char *_image,
-    unsigned int _width, unsigned int _height, unsigned int _depth,
-    const std::string &_format)
-{
-  OnNewFrame(_image, this->utils[1]);
 }
 }

--- a/gazebo_plugins/test/camera/multimulticamera.cpp
+++ b/gazebo_plugins/test/camera/multimulticamera.cpp
@@ -1,0 +1,120 @@
+#include <gtest/gtest.h>
+#include <message_filters/subscriber.h>
+#include <message_filters/time_synchronizer.h>
+#include <ros/ros.h>
+#include <sensor_msgs/Image.h>
+
+class MultiMultiCameraTest : public testing::Test
+{
+protected:
+  virtual void SetUp()
+  {
+    has_new_image_ = false;
+  }
+
+  ros::NodeHandle nh_;
+  message_filters::Subscriber<sensor_msgs::Image> cam1_sub_;
+  message_filters::Subscriber<sensor_msgs::Image> cam2_sub_;
+  message_filters::Subscriber<sensor_msgs::Image> cam3_sub_;
+
+  bool has_new_image_;
+  ros::Time image1_stamp_;
+  ros::Time image2_stamp_;
+  ros::Time image3_stamp_;
+  std::string frame1_, frame2_, frame3_;
+
+public:
+  void imageCallback(
+      const sensor_msgs::ImageConstPtr& msg1,
+      const sensor_msgs::ImageConstPtr& msg2,
+      const sensor_msgs::ImageConstPtr& msg3)
+  {
+    image1_stamp_ = msg1->header.stamp;
+    image2_stamp_ = msg2->header.stamp;
+    image3_stamp_ = msg3->header.stamp;
+    frame1_ = msg1->header.frame_id;
+    frame2_ = msg2->header.frame_id;
+    frame3_ = msg3->header.frame_id;
+    has_new_image_ = true;
+  }
+};
+
+// Test if the camera image is published at all, and that the timestamp
+// is not too long in the past.
+TEST_F(MultiMultiCameraTest, cameraSubscribeTest)
+{
+  // image_transport::ImageTransport it(nh_);
+  // cam_left_sub_.subscribe(it, "stereo/camera/left/image_raw", 1);
+  // cam_right_sub_.subscribe(it, "stereo/camera/right/image_raw", 1);
+  // sync_ = message_filters::Synchronizer<MySyncPolicy>(
+  //     MySyncPolicy(4), cam_left_sub_, cam_right_sub_);
+  cam1_sub_.subscribe(nh_, "multi/camera_1/image_raw", 1);
+  cam2_sub_.subscribe(nh_, "multi/camera_2/image_raw", 1);
+  cam3_sub_.subscribe(nh_, "multi/camera_3/image_raw", 1);
+  message_filters::TimeSynchronizer<sensor_msgs::Image, sensor_msgs::Image, sensor_msgs::Image> sync(
+      cam1_sub_, cam2_sub_, cam3_sub_, 4);
+  sync.registerCallback(boost::bind(&MultiMultiCameraTest::imageCallback,
+      dynamic_cast<MultiMultiCameraTest*>(this), _1, _2, _3));
+#if 0
+  // wait for gazebo to start publishing
+  // TODO(lucasw) this isn't really necessary since this test
+  // is purely passive
+  bool wait_for_topic = true;
+  while (wait_for_topic)
+  {
+    // @todo this fails without the additional 0.5 second sleep after the
+    // publisher comes online, which means on a slower or more heavily
+    // loaded system it may take longer than 0.5 seconds, and the test
+    // would hang until the timeout is reached and fail.
+    if (cam_sub_.getNumPublishers() > 0)
+       wait_for_topic = false;
+    ros::Duration(0.5).sleep();
+  }
+#endif
+
+  while (!has_new_image_)
+  {
+    ros::spinOnce();
+    ros::Duration(0.1).sleep();
+  }
+
+  double sync_diff1 = (image1_stamp_ - image2_stamp_).toSec();
+  double sync_diff2 = (image2_stamp_ - image3_stamp_).toSec();
+  EXPECT_EQ(sync_diff1, 0.0);
+  EXPECT_EQ(sync_diff2, 0.0);
+
+  EXPECT_EQ("cam1", frame1_);
+  EXPECT_EQ("cam2", frame2_);
+  EXPECT_EQ("cam3", frame3_);
+
+  // This check depends on the update period being much longer
+  // than the expected difference between now and the received image time
+  // TODO(lucasw)
+  // this likely isn't that robust - what if the testing system is really slow?
+  double time_diff = (ros::Time::now() - image1_stamp_).toSec();
+  ROS_INFO_STREAM(time_diff);
+  EXPECT_LT(time_diff, 1.0);
+  // cam_sub_.shutdown();
+
+  // make sure nothing is subscribing to image_trigger topic
+  // there is no easy API, so call getSystemState
+  XmlRpc::XmlRpcValue args, result, payload;
+  args[0] = ros::this_node::getName();
+  EXPECT_TRUE(ros::master::execute("getSystemState", args, result, payload, true));
+  // [publishers, subscribers, services]
+  // subscribers in index 1 of payload
+  for (int i = 0; i < payload[1].size(); ++i)
+  {
+    // [ [topic1, [topic1Subscriber1...topic1SubscriberN]] ... ]
+    // topic name i is in index 0
+    std::string topic = payload[1][i][0];
+    EXPECT_EQ(topic.find("image_trigger"), std::string::npos);
+  }
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "gazebo_multimulticamera_test");
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/gazebo_plugins/test/camera/multimulticamera.test
+++ b/gazebo_plugins/test/camera/multimulticamera.test
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<launch>
+  <param name="/use_sim_time" value="true" />
+
+  <node name="gazebo" pkg="gazebo_ros" type="gzserver"
+      respawn="false" output="screen"
+      args="--verbose $(find gazebo_plugins)/test/camera/multimulticamera.world" />
+
+  <test test-name="multimulticamera" pkg="gazebo_plugins" type="multimulticamera-test"
+      clear_params="true" time-limit="15.0" />
+</launch>

--- a/gazebo_plugins/test/camera/multimulticamera.world
+++ b/gazebo_plugins/test/camera/multimulticamera.world
@@ -1,0 +1,163 @@
+<?xml version="1.0" ?>
+<sdf version="1.4">
+
+  <world name="default">
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+
+    <!-- Global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <!-- Focus camera on tall pendulum -->
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose>4.927360 -4.376610 3.740080 0.000000 0.275643 2.356190</pose>
+        <view_controller>orbit</view_controller>
+      </camera>
+    </gui>
+
+  <model name="model_1">
+    <static>false</static>
+    <pose>0.0 2.0 2.0 0.0 0.0 0.0</pose>
+    <link name="link_1">
+      <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+      <inertial>
+        <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+        <inertia>
+          <ixx>1.0</ixx>
+          <ixy>0.0</ixy>
+          <ixz>0.0</ixz>
+          <iyy>1.0</iyy>
+          <iyz>0.0</iyz>
+          <izz>1.0</izz>
+        </inertia>
+        <mass>10.0</mass>
+      </inertial>
+      <visual name="visual_sphere">
+        <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+        <geometry>
+          <sphere>
+            <radius>0.5</radius>
+          </sphere>
+        </geometry>
+        <material>
+          <ambient>0.03 0.5 0.5 1.0</ambient>
+          <script>Gazebo/Green</script>
+        </material>
+        <cast_shadows>true</cast_shadows>
+        <laser_retro>100.0</laser_retro>
+      </visual>
+      <collision name="collision_sphere">
+        <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+        <max_contacts>250</max_contacts>
+        <geometry>
+          <sphere>
+            <radius>0.5</radius>
+          </sphere>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>0.5</mu>
+              <mu2>0.2</mu2>
+              <fdir1>1.0 0 0</fdir1>
+              <slip1>0</slip1>
+              <slip2>0</slip2>
+            </ode>
+          </friction>
+          <bounce>
+            <restitution_coefficient>0</restitution_coefficient>
+            <threshold>1000000.0</threshold>
+          </bounce>
+          <contact>
+            <ode>
+              <soft_cfm>0</soft_cfm>
+              <soft_erp>0.2</soft_erp>
+              <kp>1e15</kp>
+              <kd>1e13</kd>
+              <max_vel>100.0</max_vel>
+              <min_depth>0.0001</min_depth>
+            </ode>
+          </contact>
+        </surface>
+        <laser_retro>100.0</laser_retro>
+      </collision>
+
+      <sensor type="multicamera" name="multi_camera">
+        <update_rate>0.1</update_rate>
+        <camera name="cam1">
+          <horizontal_fov>1.3962634</horizontal_fov>
+          <image>
+            <width>640</width>
+            <height>480</height>
+            <format>R8G8B8</format>
+          </image>
+          <clip>
+            <near>0.02</near>
+            <far>300</far>
+          </clip>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.007</stddev>
+          </noise>
+        </camera>
+        <camera name="cam2">
+          <pose>0 -0.07 0 0 0 0</pose>
+          <horizontal_fov>1.3962634</horizontal_fov>
+          <image>
+            <width>640</width>
+            <height>480</height>
+            <format>R8G8B8</format>
+          </image>
+          <clip>
+            <near>0.02</near>
+            <far>300</far>
+          </clip>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.007</stddev>
+          </noise>
+        </camera>
+        <camera name="cam3">
+          <pose>0 0.07 0 0 0 0</pose>
+          <horizontal_fov>1.3962634</horizontal_fov>
+          <image>
+            <width>640</width>
+            <height>480</height>
+            <format>R8G8B8</format>
+          </image>
+          <clip>
+            <near>0.02</near>
+            <far>300</far>
+          </clip>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.007</stddev>
+          </noise>
+        </camera>
+        <plugin name="multi_camera_controller" filename="libgazebo_ros_multicamera.so">
+          <alwaysOn>true</alwaysOn>
+          <updateRate>0.0</updateRate>
+          <cameraName>multi/camera</cameraName>
+          <imageTopicName>image_raw</imageTopicName>
+          <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+          <frameName>cam1,cam2,cam3</frameName>
+          <cameraSuffixes>_1,_2,_3</cameraSuffixes>
+          <distortionK1>0.0</distortionK1>
+          <distortionK2>0.0</distortionK2>
+          <distortionK3>0.0</distortionK3>
+          <distortionT1>0.0</distortionT1>
+          <distortionT2>0.0</distortionT2>
+        </plugin>
+      </sensor>
+    </link>
+  </model>
+
+  </world>
+</sdf>


### PR DESCRIPTION
Backwards compatibility on SDF/functional level should be retained. One virtual method was removed and one was removed in gazebo_ros_multicamera.cpp, gazebo_ros_triggered_multicamera.cpp and MultiCameraPlugin.cpp.

SDF parameter <frameName> became optionally a comma-separated list specifying a different frame for each camera.

Optional SDF parameter <cameraSuffixes> was added. If empty or non-present, "/<sdf_camera_name>" is used as the suffix. If nonempty, it is treated as a comma-separated list of camera suffixes. This list has to have the same lengths as the number of cameras. Any separators (like "/") should be part of the specified suffixes.