### PR TITLE
Fix destructor of gazebo_ros_diff_drive.cpp

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
@@ -71,7 +71,10 @@ enum {
 GazeboRosDiffDrive::GazeboRosDiffDrive() {}
 
 // Destructor
-GazeboRosDiffDrive::~GazeboRosDiffDrive() {}
+GazeboRosDiffDrive::~GazeboRosDiffDrive() 
+{
+	FiniChild();
+}
 
 // Load the controller
 void GazeboRosDiffDrive::Load ( physics::ModelPtr _parent, sdf::ElementPtr _sdf )


### PR DESCRIPTION
Fix issue referenced in #123 where the destructor of ROS DiffDrive plugin causes `gzserver` to crash on model deletion.