### PR TITLE
[Windows][melodic] restrict Windows header namespace for ros_control

### DIFF
--- a/gazebo_ros_control/CMakeLists.txt
+++ b/gazebo_ros_control/CMakeLists.txt
@@ -60,6 +60,11 @@ include_directories(include
   ${catkin_INCLUDE_DIRS}
 )
 
+## Restrict Windows header namespace usage
+if(WIN32)
+  add_definitions(-DNOGDI)
+endif()
+
 ## Libraries
 add_library(${PROJECT_NAME} src/gazebo_ros_control_plugin.cpp)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})


### PR DESCRIPTION
Recently there is a [change](https://github.com/ros-controls/ros_control/pull/391) in [`ros_control`](https://github.com/ros-controls/ros_control) which happens to use some symbols (for example, `ERROR`) colliding with ones defined in Windows header. That subsequently breaks the Windows build at compile time.

This pull request is attempting to address this namespace conflicts and use `NOGDI` to tell `Windows` header not to expose the symbols which collided with `ros_control`.

JFYI, earlier I proposed the initial [fix](https://github.com/ros-controls/ros_control/pull/397) in `ros_control`, and this alternative solution was brought up there. 