### PR TITLE
gazebo_ros: Wait spawning Gazebo Model until ros::Time::now() is not 0.

### DIFF
--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -2660,6 +2660,8 @@ bool GazeboRosApiPlugin::spawnAndConform(TiXmlDocument &gazebo_model_xml, const 
 
   /// \brief poll and wait, verify that the model is spawned within Hardcoded 10 seconds
   ros::Duration model_spawn_timeout(10.0);
+  /// Wait until time can be read.
+  while (ros::Time::now().is_zero());
   ros::Time timeout = ros::Time::now() + model_spawn_timeout;
 
   while (ros::ok())


### PR DESCRIPTION
Why:

* Plugin incorrectly sends failure status message.

This change addresses the need by:

* Looping over ros::Time::now() until non-zero is returned.