### PR TITLE
[gazebo_plugins] fix Issue #243: Use x-forward z-up frame for pointcloud

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
+++ b/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
@@ -343,9 +343,9 @@ bool GazeboRosOpenniKinect::FillPointCloudHelper(
         // hardcoded rotation rpy(-M_PI/2, 0, -M_PI/2) is built-in
         // to urdf, where the *_optical_frame should have above relative
         // rotation from the physical camera *_frame
-        *iter_x = depth * tan(yAngle);
-        *iter_y = depth * tan(pAngle);
-        *iter_z = depth;
+        *iter_x = depth;
+        *iter_y = -depth * tan(yAngle);
+        *iter_z = -depth * tan(pAngle);
       }
       else //point in the unseeable range
       {


### PR DESCRIPTION
I've observed issue #243 on a melodic-based robot simulation I ran yesterday. Using the ROS body frame convention (x-forward, z-up), solved the issue for me (cf attached screenshot)
![Screenshot from 2020-01-03 15-18-13](https://user-images.githubusercontent.com/618189/71748629-26631100-2e41-11ea-9d42-c0ab1e1bf22e.png)
