### PR TITLE
[Windows][ros2] Fix gazebo launch for windows

### DIFF
--- a/gazebo_ros/launch/gzclient.launch.py
+++ b/gazebo_ros/launch/gzclient.launch.py
@@ -15,6 +15,7 @@
 """Launch a Gazebo client with command line arguments."""
 
 from os import environ
+from os import pathsep
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
@@ -29,11 +30,11 @@ def generate_launch_description():
     model, plugin, media = GazeboRosPaths.get_paths()
 
     if 'GAZEBO_MODEL_PATH' in environ:
-        model += ':'+environ['GAZEBO_MODEL_PATH']
+        model += pathsep+environ['GAZEBO_MODEL_PATH']
     if 'GAZEBO_PLUGIN_PATH' in environ:
-        plugin += ':'+environ['GAZEBO_PLUGIN_PATH']
+        plugin += pathsep+environ['GAZEBO_PLUGIN_PATH']
     if 'GAZEBO_RESOURCE_PATH' in environ:
-        media += ':'+environ['GAZEBO_RESOURCE_PATH']
+        media += pathsep+environ['GAZEBO_RESOURCE_PATH']
 
     env = {'GAZEBO_MODEL_PATH': model,
            'GAZEBO_PLUGIN_PATH': plugin,

--- a/gazebo_ros/launch/gzserver.launch.py
+++ b/gazebo_ros/launch/gzserver.launch.py
@@ -15,6 +15,7 @@
 """Launch a Gazebo server with command line arguments."""
 
 from os import environ
+from os import pathsep
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
@@ -29,11 +30,11 @@ def generate_launch_description():
     model, plugin, media = GazeboRosPaths.get_paths()
 
     if 'GAZEBO_MODEL_PATH' in environ:
-        model += ':'+environ['GAZEBO_MODEL_PATH']
+        model += pathsep+environ['GAZEBO_MODEL_PATH']
     if 'GAZEBO_PLUGIN_PATH' in environ:
-        plugin += ':'+environ['GAZEBO_PLUGIN_PATH']
+        plugin += pathsep+environ['GAZEBO_PLUGIN_PATH']
     if 'GAZEBO_RESOURCE_PATH' in environ:
-        media += ':'+environ['GAZEBO_RESOURCE_PATH']
+        media += pathsep+environ['GAZEBO_RESOURCE_PATH']
 
     env = {'GAZEBO_MODEL_PATH': model,
            'GAZEBO_PLUGIN_PATH': plugin,

--- a/gazebo_ros/scripts/gazebo_ros_paths.py
+++ b/gazebo_ros/scripts/gazebo_ros_paths.py
@@ -64,8 +64,8 @@ class GazeboRosPaths:
                             xml_path = xml_path.replace('${prefix}', package_share_path)
                             gazebo_media_path.append(xml_path)
 
-        gazebo_model_path = ':'.join(gazebo_model_path)
-        gazebo_plugin_path = ':'.join(gazebo_plugin_path)
-        gazebo_media_path = ':'.join(gazebo_media_path)
+        gazebo_model_path = os.pathsep.join(gazebo_model_path)
+        gazebo_plugin_path = os.pathsep.join(gazebo_plugin_path)
+        gazebo_media_path = os.pathsep.join(gazebo_media_path)
 
         return gazebo_model_path, gazebo_plugin_path, gazebo_media_path


### PR DESCRIPTION
`gazebo.launch.py` currently fails on Windows because the path env vars use colons to separate paths. This will fix it to use the platform-specific path separator (semicolons for Windows).