### PR TITLE
Plugin openni kinect now uses image_transport for depth image (#909)

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
@@ -109,7 +109,7 @@ namespace gazebo
     ///  A node will be instantiated if it does not exist.
     protected: ros::NodeHandle* rosnode_;
     protected: image_transport::Publisher image_pub_;
-    private: image_transport::ImageTransport* itnode_;
+    protected: image_transport::ImageTransport* itnode_;
 
     /// \brief ROS image message
     protected: sensor_msgs::Image image_msg_;

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_openni_kinect.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_openni_kinect.h
@@ -109,7 +109,7 @@ namespace gazebo
 
     /// \brief A pointer to the ROS node.  A node will be instantiated if it does not exist.
     private: ros::Publisher point_cloud_pub_;
-    private: ros::Publisher depth_image_pub_;
+    private: image_transport::Publisher depth_image_pub_;
 
     /// \brief PointCloud2 point cloud message
     private: sensor_msgs::PointCloud2 point_cloud_msg_;

--- a/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
+++ b/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
@@ -117,13 +117,11 @@ void GazeboRosOpenniKinect::Advertise()
       ros::VoidPtr(), &this->camera_queue_);
   this->point_cloud_pub_ = this->rosnode_->advertise(point_cloud_ao);
 
-  ros::AdvertiseOptions depth_image_ao =
-    ros::AdvertiseOptions::create< sensor_msgs::Image >(
-      this->depth_image_topic_name_,1,
-      boost::bind( &GazeboRosOpenniKinect::DepthImageConnect,this),
-      boost::bind( &GazeboRosOpenniKinect::DepthImageDisconnect,this),
-      ros::VoidPtr(), &this->camera_queue_);
-  this->depth_image_pub_ = this->rosnode_->advertise(depth_image_ao);
+  this->depth_image_pub_ = this->itnode_->advertise(
+      this->depth_image_topic_name_, 1,
+      boost::bind(&GazeboRosOpenniKinect::DepthImageConnect, this),
+      boost::bind(&GazeboRosOpenniKinect::DepthImageDisconnect, this),
+      ros::VoidPtr(), true);
 
   ros::AdvertiseOptions depth_image_camera_info_ao =
     ros::AdvertiseOptions::create<sensor_msgs::CameraInfo>(


### PR DESCRIPTION
I made some modifications to the source code so that it now publishes depth image via image_transport. But gazebo_ros_camera_utils needs to be recompiled.