### PR TITLE
[ros2] make transient local reliable

### DIFF
--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -13,11 +13,11 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
-find_package(rcl REQUIRED)
-find_package(rclcpp REQUIRED)
 find_package(gazebo_dev REQUIRED)
 find_package(gazebo_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(rcl REQUIRED)
+find_package(rclcpp REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(tinyxml_vendor REQUIRED)
 

--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(gazebo_ros)
 
-
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
@@ -22,10 +21,6 @@ find_package(geometry_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(tinyxml_vendor REQUIRED)
 
-include_directories(
-  include
-  ${gazebo_dev_INCLUDE_DIRS}
-)
 link_directories(
   ${gazebo_dev_LIBRARY_DIRS}
 )
@@ -37,6 +32,13 @@ add_library(gazebo_ros_node SHARED
   src/executor.cpp
   src/node.cpp
 )
+target_include_directories(gazebo_ros_node
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    ${gazebo_dev_INCLUDE_DIRS}
+)
+
 ament_target_dependencies(gazebo_ros_node
   "gazebo_dev"
   "rclcpp"
@@ -47,6 +49,11 @@ ament_export_libraries(gazebo_ros_node)
 # gazebo_ros_utils
 add_library(gazebo_ros_utils SHARED
   src/utils.cpp
+)
+target_include_directories(gazebo_ros_utils
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
 ament_target_dependencies(gazebo_ros_utils
   "gazebo_dev"

--- a/gazebo_ros/include/gazebo_ros/node.hpp
+++ b/gazebo_ros/include/gazebo_ros/node.hpp
@@ -138,7 +138,7 @@ Node::SharedPtr Node::CreateWithArgs(Args && ... args)
   // TODO(chapulina): use rclcpp::is_initialized() once that's available, see
   // https://github.com/ros2/rclcpp/issues/518
   Node::SharedPtr node;
-  if (!rclcpp::is_initialized()) {
+  if (!rclcpp::ok()) {
     rclcpp::init(0, nullptr);
     RCLCPP_INFO(internal_logger(), "ROS was initialized without arguments.");
   }

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -41,6 +41,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>geometry_msgs</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>ros2run</test_depend>
   <test_depend>sensor_msgs</test_depend>
   <test_depend>std_msgs</test_depend>
 

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -40,6 +40,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>geometry_msgs</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>sensor_msgs</test_depend>
   <test_depend>std_msgs</test_depend>
 

--- a/gazebo_ros/scripts/spawn_entity.py
+++ b/gazebo_ros/scripts/spawn_entity.py
@@ -159,9 +159,12 @@ class SpawnEntityNode(Node):
                 nonlocal entity_xml
                 entity_xml = msg.data
 
+            custom_qos = QoSProfile(
+                depth=1,
+                durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
+                reliability=QoSReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_RELIABLE)
             self.subscription = self.create_subscription(
-                String, self.args.topic, entity_xml_cb,
-                QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL)
+                String, self.args.topic, entity_xml_cb, custom_qos)
 
             while rclpy.ok() and entity_xml == '':
                 self.get_logger().info('Waiting for entity xml on %s' % self.args.topic)

--- a/gazebo_ros/scripts/spawn_entity.py
+++ b/gazebo_ros/scripts/spawn_entity.py
@@ -32,6 +32,8 @@ from geometry_msgs.msg import Pose
 import rclpy
 from rclpy.node import Node
 from rclpy.qos import QoSDurabilityPolicy
+from rclpy.qos import QoSProfile
+from rclpy.qos import QoSReliabilityPolicy
 from std_msgs.msg import String
 from std_srvs.srv import Empty
 

--- a/gazebo_ros/scripts/spawn_entity.py
+++ b/gazebo_ros/scripts/spawn_entity.py
@@ -33,7 +33,6 @@ import rclpy
 from rclpy.node import Node
 from rclpy.qos import QoSDurabilityPolicy
 from rclpy.qos import QoSProfile
-# from rclpy.qos import QoSReliabilityPolicy
 from std_msgs.msg import String
 from std_srvs.srv import Empty
 
@@ -161,11 +160,11 @@ class SpawnEntityNode(Node):
                 nonlocal entity_xml
                 entity_xml = msg.data
 
-            custom_qos = QoSProfile(
+            latched_qos = QoSProfile(
                 depth=1,
                 durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL)
             self.subscription = self.create_subscription(
-                String, self.args.topic, entity_xml_cb, custom_qos)
+                String, self.args.topic, entity_xml_cb, latched_qos)
 
             while rclpy.ok() and entity_xml == '':
                 self.get_logger().info('Waiting for entity xml on %s' % self.args.topic)

--- a/gazebo_ros/scripts/spawn_entity.py
+++ b/gazebo_ros/scripts/spawn_entity.py
@@ -33,7 +33,7 @@ import rclpy
 from rclpy.node import Node
 from rclpy.qos import QoSDurabilityPolicy
 from rclpy.qos import QoSProfile
-from rclpy.qos import QoSReliabilityPolicy
+# from rclpy.qos import QoSReliabilityPolicy
 from std_msgs.msg import String
 from std_srvs.srv import Empty
 
@@ -163,8 +163,7 @@ class SpawnEntityNode(Node):
 
             custom_qos = QoSProfile(
                 depth=1,
-                durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
-                reliability=QoSReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_RELIABLE)
+                durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL)
             self.subscription = self.create_subscription(
                 String, self.args.topic, entity_xml_cb, custom_qos)
 

--- a/gazebo_ros/src/gazebo_ros_force_system.cpp
+++ b/gazebo_ros/src/gazebo_ros_force_system.cpp
@@ -354,18 +354,15 @@ void GazeboRosForceSystemPrivate::ClearLinkWrenches(
   gazebo_msgs::srv::LinkRequest::Request::SharedPtr _req,
   gazebo_msgs::srv::LinkRequest::Response::SharedPtr /*_res*/)
 {
-  bool found = false;
   std::lock_guard<std::mutex> scoped_lock(lock_);
-  for (auto link_wrench_task = link_wrench_tasks_.begin();
-    link_wrench_task != link_wrench_tasks_.end(); ++link_wrench_task)
-  {
-    if ((*link_wrench_task)->link->GetScopedName() == _req->link_name) {
-      link_wrench_tasks_.erase(link_wrench_task--);
-      RCLCPP_INFO(ros_node_->get_logger(), "Deleted wrench on [%s]", _req->link_name.c_str());
-      found = true;
-    }
-  }
-  if (!found) {
+  auto it = std::find_if(link_wrench_tasks_.begin(), link_wrench_tasks_.end(),
+      [_req](auto & link_wrench_task) {
+        return link_wrench_task->link->GetScopedName() == _req->link_name;
+      });
+  if (it != link_wrench_tasks_.end()) {
+    link_wrench_tasks_.erase(it);
+    RCLCPP_INFO(ros_node_->get_logger(), "Deleted wrench on [%s]", _req->link_name.c_str());
+  } else {
     RCLCPP_WARN(ros_node_->get_logger(), "No applied wrenches on [%s]", _req->link_name.c_str());
   }
 }
@@ -401,18 +398,15 @@ void GazeboRosForceSystemPrivate::ClearJointEfforts(
   gazebo_msgs::srv::JointRequest::Request::SharedPtr _req,
   gazebo_msgs::srv::JointRequest::Response::SharedPtr /*_res*/)
 {
-  bool found = false;
   std::lock_guard<std::mutex> scoped_lock(lock_);
-  for (auto joint_effort_task = joint_effort_tasks_.begin();
-    joint_effort_task != joint_effort_tasks_.end(); ++joint_effort_task)
-  {
-    if ((*joint_effort_task)->joint->GetName() == _req->joint_name) {
-      joint_effort_tasks_.erase(joint_effort_task--);
-      RCLCPP_INFO(ros_node_->get_logger(), "Deleted effort on [%s]", _req->joint_name.c_str());
-      found = true;
-    }
-  }
-  if (!found) {
+  auto it = std::find_if(joint_effort_tasks_.begin(), joint_effort_tasks_.end(),
+      [_req](auto & joint_effort_task) {
+        return joint_effort_task->joint->GetName() == _req->joint_name;
+      });
+  if (it != joint_effort_tasks_.end()) {
+    joint_effort_tasks_.erase(it);
+    RCLCPP_INFO(ros_node_->get_logger(), "Deleted effort on [%s]", _req->joint_name.c_str());
+  } else {
     RCLCPP_WARN(ros_node_->get_logger(), "No applied efforts on [%s]", _req->joint_name.c_str());
   }
 }

--- a/gazebo_ros/src/gazebo_ros_init.cpp
+++ b/gazebo_ros/src/gazebo_ros_init.cpp
@@ -119,7 +119,7 @@ GazeboRosInit::~GazeboRosInit()
 void GazeboRosInit::Load(int argc, char ** argv)
 {
   // Initialize ROS with arguments
-  if (!rclcpp::is_initialized()) {
+  if (!rclcpp::ok()) {
     rclcpp::init(argc, argv);
     impl_->ros_node_ = gazebo_ros::Node::Get();
   } else {

--- a/gazebo_ros/test/CMakeLists.txt
+++ b/gazebo_ros/test/CMakeLists.txt
@@ -76,7 +76,6 @@ ament_target_dependencies(mock_robot_state_publisher
   "rclcpp"
   "std_msgs"
 )
-message("full path of mock ${CMAKE_CURRENT_BINARY_DIR}")
 add_launch_test(entity_spawner.test.py
   ARGS "mock_robot_state_publisher:=${CMAKE_CURRENT_BINARY_DIR}/mock_robot_state_publisher"
 )

--- a/gazebo_ros/test/CMakeLists.txt
+++ b/gazebo_ros/test/CMakeLists.txt
@@ -2,6 +2,7 @@ find_package(ament_cmake_gtest REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(gazebo_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(launch_testing_ament_cmake REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
@@ -68,3 +69,14 @@ foreach(test ${tests})
   )
 endforeach()
 
+add_executable(mock_robot_state_publisher
+  mock_robot_state_publisher/robot_state_publisher.cpp
+)
+ament_target_dependencies(mock_robot_state_publisher
+  "rclcpp"
+  "std_msgs"
+)
+message("full path of mock ${CMAKE_CURRENT_BINARY_DIR}")
+add_launch_test(entity_spawner.test.py
+  ARGS "mock_robot_state_publisher:=${CMAKE_CURRENT_BINARY_DIR}/mock_robot_state_publisher"
+)

--- a/gazebo_ros/test/entity_spawner.test.py
+++ b/gazebo_ros/test/entity_spawner.test.py
@@ -1,0 +1,67 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import ament_index_python
+
+import launch
+import launch.actions
+
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+import launch_testing
+import launch_testing.asserts
+import launch_testing.markers
+import launch_testing.tools
+import pytest
+
+
+@pytest.mark.launch_test
+@launch_testing.markers.keep_alive
+def generate_test_description(ready_fn):
+    return launch.LaunchDescription([
+        launch.actions.DeclareLaunchArgument(
+            'mock_robot_state_publisher',
+            description='Path to mock robot state publisher executable',
+        ),
+        launch.actions.ExecuteProcess(
+            cmd=[launch.substitutions.LaunchConfiguration('mock_robot_state_publisher')],
+            output='screen'
+        ),
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([
+                ament_index_python.get_package_share_directory('gazebo_ros'),
+                '/launch', '/gzserver.launch.py'
+                ])
+        ),
+        launch.actions.OpaqueFunction(function=lambda context: ready_fn())
+        # launch_testing.actions.ReadyToTest()
+    ])
+
+
+class TestTerminatingProc(unittest.TestCase):
+
+    def test_spawn_entity(self, launch_service, proc_info, proc_output):
+        """Test terminating_proc without command line arguments."""
+        print('Running spawn entity test on /mock_robot_description topic')
+        entity_spawner_action = launch.actions.ExecuteProcess(
+            cmd=['ros2', 'run', 'gazebo_ros', 'spawn_entity.py', '-entity',
+                 'mock_robot_state_entity', '-topic', '/mock_robot_description'],
+            output='screen'
+        )
+        with launch_testing.tools.launch_process(
+              launch_service, entity_spawner_action, proc_info, proc_output) as command:
+            assert command.wait_for_shutdown(timeout=10)
+        assert command.exit_code == launch_testing.asserts.EXIT_OK

--- a/gazebo_ros/test/entity_spawner.test.py
+++ b/gazebo_ros/test/entity_spawner.test.py
@@ -30,7 +30,7 @@ import pytest
 
 @pytest.mark.launch_test
 @launch_testing.markers.keep_alive
-def generate_test_description(ready_fn):
+def generate_test_description():
     return launch.LaunchDescription([
         launch.actions.DeclareLaunchArgument(
             'mock_robot_state_publisher',
@@ -46,8 +46,7 @@ def generate_test_description(ready_fn):
                 '/launch', '/gzserver.launch.py'
                 ])
         ),
-        launch.actions.OpaqueFunction(function=lambda context: ready_fn())
-        # launch_testing.actions.ReadyToTest()
+        launch_testing.actions.ReadyToTest()
     ])
 
 

--- a/gazebo_ros/test/entity_spawner.test.py
+++ b/gazebo_ros/test/entity_spawner.test.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2020 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gazebo_ros/test/mock_robot_state_publisher/robot_state_publisher.cpp
+++ b/gazebo_ros/test/mock_robot_state_publisher/robot_state_publisher.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <iostream>
 #include <chrono>
+#include <iostream>
 
 #include "rclcpp/rclcpp.hpp"
 

--- a/gazebo_ros/test/mock_robot_state_publisher/robot_state_publisher.cpp
+++ b/gazebo_ros/test/mock_robot_state_publisher/robot_state_publisher.cpp
@@ -1,0 +1,51 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <chrono>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "std_msgs/msg/string.hpp"
+
+using namespace std::chrono_literals;
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("mock_robot_state_publisher");
+  auto publisher = node->create_publisher<std_msgs::msg::String>(
+    "/mock_robot_description", rclcpp::QoS(1).transient_local());
+
+  std_msgs::msg::String message;
+  message.data = "<?xml version='1.0' ?>"
+    "<sdf version='1.5'>"
+    "<model name='ignored'>"
+    "<static>true</static>"
+    "<link name='link'>"
+    "<visual name='visual'>"
+    "<geometry>"
+    "<sphere><radius>1.0</radius></sphere>"
+    "</geometry>"
+    "</visual>"
+    "</link>"
+    "</model>"
+    "</sdf>";
+
+  RCLCPP_INFO(node->get_logger(), "Publishing on /mock_robot_description");
+  publisher->publish(message);
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/gazebo_ros/test/test_conversions.cpp
+++ b/gazebo_ros/test/test_conversions.cpp
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <gtest/gtest.h>
+
 #include <gazebo_ros/conversions/builtin_interfaces.hpp>
 #include <gazebo_ros/conversions/geometry_msgs.hpp>
-#include <gtest/gtest.h>
 
 TEST(TestConversions, Vector3)
 {
@@ -116,10 +117,4 @@ TEST(TestConversions, Time)
     EXPECT_EQ(200, gazebo_time.sec);
     EXPECT_EQ(100, gazebo_time.nsec);
   }
-}
-
-int main(int argc, char ** argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
 }

--- a/gazebo_ros/test/test_plugins.cpp
+++ b/gazebo_ros/test/test_plugins.cpp
@@ -76,6 +76,7 @@ INSTANTIATE_TEST_CASE_P(Plugins, TestPlugins, ::testing::Values(
     TestParams({{"-s", "libgazebo_ros_init.so", "-s", "libgazebo_ros_factory.so",
       "worlds/ros_world_plugin.world"}, {"test"}}),
     TestParams({{"-s", "libgazebo_ros_init.so", "worlds/sdf_node_plugin.world"}, {"/foo/my_topic"}})
+    // cppcheck-suppress syntaxError
   ), );
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
When using the robot state publisher topic (`robot_description`) to spawn an entity into Gazebo, the topics don't match because the subscription reliability QoS don't match the publisher.

I am wondering whether there is a mismatch between Python and C++ that by default a Python subscription is best effort whereas in C++ it's reliable. 

Both, in Dashing as well as Eloquent, we weren't able to spawn objects correctly with the `spawn_entity.py` script.

/cc @clalancette @relffok

Signed-off-by: Karsten Knese <karsten@openrobotics.org>