### PR TITLE
Created a MarkerArray to publish normals in ROS

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -28,6 +28,7 @@ find_package(catkin REQUIRED COMPONENTS
   diagnostic_updater
   camera_info_manager
   std_msgs
+  visualization_msgs
 )
 
 # Through transitive dependencies in the packages above, gazebo_plugins depends
@@ -157,6 +158,7 @@ catkin_package(
   rosconsole
   camera_info_manager
   std_msgs
+  visualization_msgs
 )
 add_dependencies(${PROJECT_NAME}_gencfg ${catkin_EXPORTED_TARGETS})
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
@@ -35,6 +35,8 @@
 #include <sensor_msgs/fill_image.h>
 #include <std_msgs/Float64.h>
 #include <image_transport/image_transport.h>
+#include <visualization_msgs/MarkerArray.h>
+#include <visualization_msgs/Marker.h>
 
 // gazebo stuff
 #include <sdf/Param.hh>
@@ -88,6 +90,11 @@ namespace gazebo
                    unsigned int _width, unsigned int _height,
                    unsigned int _depth, const std::string &_format);
 
+    /// \brief Update the controller
+    protected: virtual void OnNewNormalsFrame(const float * _normals,
+                   unsigned int _width, unsigned int _height,
+                   unsigned int _depth, const std::string &_format);
+
     /// \brief Put camera data to the ROS topic
     private: void FillPointdCloud(const float *_src);
 
@@ -98,6 +105,11 @@ namespace gazebo
     private: int point_cloud_connect_count_;
     private: void PointCloudConnect();
     private: void PointCloudDisconnect();
+
+    /// \brief Keep track of number of connctions for point clouds
+    private: int normals_connect_count_;
+    private: void NormalsConnect();
+    private: void NormalsDisconnect();
 
     /// \brief Keep track of number of connctions for point clouds
     private: int depth_image_connect_count_;
@@ -116,15 +128,21 @@ namespace gazebo
     /// \brief A pointer to the ROS node.  A node will be instantiated if it does not exist.
     private: ros::Publisher point_cloud_pub_;
     private: ros::Publisher depth_image_pub_;
+    private: ros::Publisher normal_pub_;
 
     /// \brief PointCloud2 point cloud message
     private: sensor_msgs::PointCloud2 point_cloud_msg_;
     private: sensor_msgs::Image depth_image_msg_;
 
+    private: float * pcd_ = nullptr;
+
     private: double point_cloud_cutoff_;
 
     /// \brief ROS image topic name
     private: std::string point_cloud_topic_name_;
+
+    /// \brief ROS normals topic name
+    private: std::string normals_topic_name_;
 
     private: void InfoConnect();
     private: void InfoDisconnect();
@@ -148,4 +166,3 @@ namespace gazebo
 
 }
 #endif
-

--- a/gazebo_plugins/package.xml
+++ b/gazebo_plugins/package.xml
@@ -30,6 +30,7 @@
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>trajectory_msgs</depend>
+  <depend>visualization_msgs</depend>
   <depend>std_srvs</depend>
   <depend>roscpp</depend>
   <depend>rospy</depend>

--- a/gazebo_plugins/test/test_worlds/gazebo_ros_depth_camera.world
+++ b/gazebo_plugins/test/test_worlds/gazebo_ros_depth_camera.world
@@ -104,15 +104,23 @@
                             <height>480</height>
                             <format>R8G8B8</format>
                         </image>
-                        <clip near="0.01" far="100.0" />
-                        <save enabled="false" path="/tmp" />
-                        <depth_camera output="points" />
+                        <clip>
+                          <near>0.1</near>
+                          <far>100</far>
+                        </clip>
+                        <save enabled='0'>
+                          <path>__default__</path>
+                        </save>
+                        <depth_camera>
+                          <output>points;normals</output>
+                        </depth_camera>
                     </camera>
                     <plugin name="plugin_1" filename="libgazebo_ros_depth_camera.so">
                         <alwaysOn>1</alwaysOn>
                         <updateRate>10.0</updateRate>
                         <imageTopicName>image_raw</imageTopicName>
                         <pointCloudTopicName>points</pointCloudTopicName>
+                        <normalsTopicName>normals</normalsTopicName>
                         <cameraInfoTopicName>camera_info</cameraInfoTopicName>
                         <cameraName>depth_cam</cameraName>
                         <frameName>/base_link</frameName>


### PR DESCRIPTION
We are exposing [normals in Gazebo9](https://bitbucket.org/osrf/gazebo/pull-requests/3193/added-normals-in-depth-camera-sensor/diff). This PR exposes the normals as a MarkerArray and then we can visualize the normals in RVIZ


![Selección_014](https://user-images.githubusercontent.com/1933907/73742147-0aa69f80-474c-11ea-9e18-8f23d36e0293.png)

