### PR TITLE
[Gazebo9] Added reflectance callback to publish reflectance image in ROS

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
@@ -87,6 +87,10 @@ namespace gazebo
     protected: virtual void OnNewImageFrame(const unsigned char *_image,
                    unsigned int _width, unsigned int _height,
                    unsigned int _depth, const std::string &_format);
+     /// \brief Update the controller
+     protected: virtual void OnNewReflectanceFrame(const float * _reflectance,
+                    unsigned int _width, unsigned int _height,
+                    unsigned int _depth, const std::string &_format);
 
     /// \brief Put camera data to the ROS topic
     private: void FillPointdCloud(const float *_src);
@@ -98,6 +102,12 @@ namespace gazebo
     private: int point_cloud_connect_count_;
     private: void PointCloudConnect();
     private: void PointCloudDisconnect();
+
+    /// \brief Keep track of number of connctions for point clouds
+    /// \brief Keep track of number of connctions for point clouds
+    private: int reflectance_connect_count_;
+    private: void ReflectanceConnect();
+    private: void ReflectanceDisconnect();
 
     /// \brief Keep track of number of connctions for point clouds
     private: int depth_image_connect_count_;
@@ -116,15 +126,20 @@ namespace gazebo
     /// \brief A pointer to the ROS node.  A node will be instantiated if it does not exist.
     private: ros::Publisher point_cloud_pub_;
     private: ros::Publisher depth_image_pub_;
+    private: ros::Publisher reflectance_pub_;
 
     /// \brief PointCloud2 point cloud message
     private: sensor_msgs::PointCloud2 point_cloud_msg_;
     private: sensor_msgs::Image depth_image_msg_;
+    private: sensor_msgs::Image reflectance_msg_;
 
     private: double point_cloud_cutoff_;
 
     /// \brief ROS image topic name
     private: std::string point_cloud_topic_name_;
+
+    /// \brief ROS reflectance topic name
+    private: std::string reflectance_topic_name_;
 
     private: void InfoConnect();
     private: void InfoDisconnect();
@@ -148,4 +163,3 @@ namespace gazebo
 
 }
 #endif
-

--- a/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
@@ -348,8 +348,6 @@ void GazeboRosDepthCamera::OnNewReflectanceFrame(const float *_image,
     this->reflectance_msg_.header.stamp.sec = this->sensor_update_time_.sec;
     this->reflectance_msg_.header.stamp.nsec = this->sensor_update_time_.nsec;
 
-    printf("width: %d, height: %d, depth: %d\n", _width, _height, _depth);
-
     // copy from src to image_msg_
     fillImage(this->reflectance_msg_, sensor_msgs::image_encodings::TYPE_32FC1, _height, _width,
         4*_width, reinterpret_cast<const void*>(_image));

--- a/gazebo_plugins/test/test_worlds/gazebo_ros_depth_camera.world
+++ b/gazebo_plugins/test/test_worlds/gazebo_ros_depth_camera.world
@@ -104,9 +104,16 @@
                             <height>480</height>
                             <format>R8G8B8</format>
                         </image>
-                        <clip near="0.01" far="100.0" />
-                        <save enabled="false" path="/tmp" />
-                        <depth_camera output="points" />
+                        <clip>
+                          <near>0.1</near>
+                          <far>100</far>
+                        </clip>
+                        <save enabled='0'>
+                          <path>__default__</path>
+                        </save>
+                        <depth_camera>
+                          <output>points;reflectance</output>
+                        </depth_camera>
                     </camera>
                     <plugin name="plugin_1" filename="libgazebo_ros_depth_camera.so">
                         <alwaysOn>1</alwaysOn>
@@ -132,6 +139,36 @@
             </link>
             <static>false</static>
         </model>
+
+        <model  name="box_reflectance">
+          <pose>1.0 0.0 5.0 0 0 0</pose>
+          <link name="box_link">
+            <visual name="visual">
+              <geometry>
+                <box>
+                  <size>.2 .2 .2</size>
+                </box>
+              </geometry>
+              <material>
+                <script>
+                  <uri>file://media/materials/scripts/gazebo.material</uri>
+                  <name>Gazebo/Red</name>
+                </script>
+              </material>
+              <plugin filename="libReflectancePlugin.so" name="reflectance_plugin">
+                <material>terrain.png</material>
+              </plugin>
+            </visual>
+            <collision name="visual">
+              <geometry>
+                <box>
+                  <size>.2 .2 .2</size>
+                </box>
+              </geometry>
+            </collision>
+          </link>
+        </model>
+
         <model name="model_2">
             <pose>5.0 0.0 5.0 0.0 0.0 0.0</pose>
             <link name="link_1">


### PR DESCRIPTION
Refletance must be an image.

To include the reflectance:

```xml
<link>
...
  <visual name="visual">
    ...
      <plugin filename="libReflectancePlugin.so" name="reflectance_plugin">
        <material>Gazebo/Blue</material>
      </plugin>
      ...
   </visual>
...
</link>
```

