### PR TITLE
[backport][ros2] make transient local reliable (#1033) (#1036)

### DIFF
--- a/gazebo_ros/test/entity_spawner.test.py
+++ b/gazebo_ros/test/entity_spawner.test.py
@@ -14,13 +14,9 @@
 
 import unittest
 
-import ament_index_python
-
 import launch
 import launch.actions
 
-from launch.actions import IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
 import launch_testing
 import launch_testing.asserts
 import launch_testing.markers
@@ -38,13 +34,13 @@ def generate_test_description():
         ),
         launch.actions.ExecuteProcess(
             cmd=[launch.substitutions.LaunchConfiguration('mock_robot_state_publisher')],
-            output='screen'
+            output='screen',
         ),
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([
-                ament_index_python.get_package_share_directory('gazebo_ros'),
-                '/launch', '/gzserver.launch.py'
-                ])
+        launch.actions.ExecuteProcess(
+            cmd=['gzserver', '-s', 'libgazebo_ros_factory.so'],
+            output='screen',
+            sigterm_timeout='30',
+            sigkill_timeout='30'
         ),
         launch_testing.actions.ReadyToTest()
     ])


### PR DESCRIPTION
* [ros2] make transient local reliable (#1033)

* make transient local reliable

Signed-off-by: Karsten Knese <karsten@openrobotics.org>

* fix master

Signed-off-by: Karsten Knese <karsten@openrobotics.org>

* add launch test

Signed-off-by: Karsten Knese <karsten@openrobotics.org>

* make it actual latched

Signed-off-by: Karsten Knese <karsten@openrobotics.org>

* alpha sort

Signed-off-by: Karsten Knese <karsten@openrobotics.org>

* add launch_test dependency

Signed-off-by: Karsten Knese <karsten@openrobotics.org>

* more dependencies

Signed-off-by: Karsten Knese <karsten@openrobotics.org>

* remove debug print

Signed-off-by: Karsten Knese <karsten@openrobotics.org>

* is_initialized -> ok

Signed-off-by: Karsten Knese <karsten@openrobotics.org>

* Update gazebo_ros/test/entity_spawner.test.py

Co-Authored-By: chapulina <louise@openrobotics.org>

* use erase-remove idiom

Signed-off-by: Karsten Knese <karsten@openrobotics.org>

* use ReadyToTest()

Signed-off-by: Karsten Knese <karsten@openrobotics.org>

Co-authored-by: chapulina <louise@openrobotics.org>

* Set timeout and call gzserver directly

Signed-off-by: Louise Poubel <louise@openrobotics.org>

Co-authored-by: chapulina <louise@openrobotics.org>