### PR TITLE
[Gazebo9] Added reflectance callback to publish reflectance image in ROS 

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
@@ -70,34 +70,35 @@ namespace gazebo
 
     /// \brief Load the plugin
     /// \param take in SDF root element
-    public: virtual void Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf);
+    public: virtual void Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf) override;
 
-    /// \brief Advertise point cloud and depth image
+    /// \brief Advertise point cloud, depth image, normals and reflectance
     public: virtual void Advertise();
 
     /// \brief Update the controller
     protected: virtual void OnNewDepthFrame(const float *_image,
                    unsigned int _width, unsigned int _height,
-                   unsigned int _depth, const std::string &_format);
+                   unsigned int _depth, const std::string &_format) override;
 
     /// \brief Update the controller
     protected: virtual void OnNewRGBPointCloud(const float *_pcd,
                     unsigned int _width, unsigned int _height,
-                    unsigned int _depth, const std::string &_format);
+                    unsigned int _depth, const std::string &_format) override;
 
     /// \brief Update the controller
     protected: virtual void OnNewImageFrame(const unsigned char *_image,
                    unsigned int _width, unsigned int _height,
-                   unsigned int _depth, const std::string &_format);
-     /// \brief Update the controller
+                   unsigned int _depth, const std::string &_format) override;
+
+     /// \brief Update the reflectance frame
      protected: virtual void OnNewReflectanceFrame(const float * _reflectance,
                     unsigned int _width, unsigned int _height,
-                    unsigned int _depth, const std::string &_format);
+                    unsigned int _depth, const std::string &_format) override;
 
-    // Documentation inherited
+    /// \brief Update the normals frame
     protected: virtual void OnNewNormalsFrame(const float * _normals,
                    unsigned int _width, unsigned int _height,
-                   unsigned int _depth, const std::string &_format);
+                   unsigned int _depth, const std::string &_format) override;
 
     /// \brief Put camera data to the ROS topic
     private: void FillPointdCloud(const float *_src);
@@ -116,7 +117,7 @@ namespace gazebo
     private: void ReflectanceConnect();
     /// \brief Decrease the counter which count the subscribers are connected
     private: void ReflectanceDisconnect();
-    
+
     /// \brief Keep track of number of connections for normals
     private: int normals_connect_count_;
     /// \brief Increase the counter which count the subscribers are connected
@@ -149,6 +150,7 @@ namespace gazebo
     private: sensor_msgs::Image depth_image_msg_;
     private: sensor_msgs::Image reflectance_msg_;
 
+    /// \brief copy of the pointcloud data, used to place normals in the world
     private: float * pcd_ = nullptr;
 
     private: double point_cloud_cutoff_;
@@ -161,6 +163,7 @@ namespace gazebo
 
     /// \brief ROS reflectance topic name
     private: std::string reflectance_topic_name_;
+
     /// \brief ROS normals topic name
     private: std::string normals_topic_name_;
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
@@ -87,6 +87,10 @@ namespace gazebo
     protected: virtual void OnNewImageFrame(const unsigned char *_image,
                    unsigned int _width, unsigned int _height,
                    unsigned int _depth, const std::string &_format);
+     /// \brief Update the controller
+     protected: virtual void OnNewReflectanceFrame(const float * _reflectance,
+                    unsigned int _width, unsigned int _height,
+                    unsigned int _depth, const std::string &_format);
 
     /// \brief Put camera data to the ROS topic
     private: void FillPointdCloud(const float *_src);
@@ -98,6 +102,12 @@ namespace gazebo
     private: int point_cloud_connect_count_;
     private: void PointCloudConnect();
     private: void PointCloudDisconnect();
+
+    /// \brief Keep track of number of connctions for point clouds
+    /// \brief Keep track of number of connctions for point clouds
+    private: int reflectance_connect_count_;
+    private: void ReflectanceConnect();
+    private: void ReflectanceDisconnect();
 
     /// \brief Keep track of number of connctions for point clouds
     private: int depth_image_connect_count_;
@@ -116,15 +126,20 @@ namespace gazebo
     /// \brief A pointer to the ROS node.  A node will be instantiated if it does not exist.
     private: ros::Publisher point_cloud_pub_;
     private: ros::Publisher depth_image_pub_;
+    private: ros::Publisher reflectance_pub_;
 
     /// \brief PointCloud2 point cloud message
     private: sensor_msgs::PointCloud2 point_cloud_msg_;
     private: sensor_msgs::Image depth_image_msg_;
+    private: sensor_msgs::Image reflectance_msg_;
 
     private: double point_cloud_cutoff_;
 
     /// \brief ROS image topic name
     private: std::string point_cloud_topic_name_;
+
+    /// \brief ROS reflectance topic name
+    private: std::string reflectance_topic_name_;
 
     private: void InfoConnect();
     private: void InfoDisconnect();
@@ -148,4 +163,3 @@ namespace gazebo
 
 }
 #endif
-

--- a/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
@@ -348,8 +348,6 @@ void GazeboRosDepthCamera::OnNewReflectanceFrame(const float *_image,
     this->reflectance_msg_.header.stamp.sec = this->sensor_update_time_.sec;
     this->reflectance_msg_.header.stamp.nsec = this->sensor_update_time_.nsec;
 
-    printf("width: %d, height: %d, depth: %d\n", _width, _height, _depth);
-
     // copy from src to image_msg_
     fillImage(this->reflectance_msg_, sensor_msgs::image_encodings::TYPE_32FC1, _height, _width,
         4*_width, reinterpret_cast<const void*>(_image));

--- a/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
@@ -181,6 +181,7 @@ void GazeboRosDepthCamera::PointCloudConnect()
   (*this->image_connect_count_)++;
   this->parentSensor->SetActive(true);
 }
+
 ////////////////////////////////////////////////////////////////////////////////
 // Decrement count
 void GazeboRosDepthCamera::PointCloudDisconnect()
@@ -201,7 +202,7 @@ void GazeboRosDepthCamera::ReflectanceConnect()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Increment count 
+// Increment count
 void GazeboRosDepthCamera::NormalsConnect()
 {
   this->normals_connect_count_++;
@@ -236,6 +237,7 @@ void GazeboRosDepthCamera::DepthImageConnect()
   this->depth_image_connect_count_++;
   this->parentSensor->SetActive(true);
 }
+
 ////////////////////////////////////////////////////////////////////////////////
 // Decrement count
 void GazeboRosDepthCamera::DepthImageDisconnect()
@@ -456,14 +458,16 @@ void GazeboRosDepthCamera::OnNewNormalsFrame(const float * _normals,
     if (this->normals_connect_count_ > 0)
     {
       this->lock_.lock();
-      if (this->point_cloud_msg_.data.size() > 0){
-
+      if (this->point_cloud_msg_.data.size() > 0)
+      {
         for (unsigned int i = 0; i < _width; i++)
         {
           for (unsigned int j = 0; j < _height; j++)
           {
             // plotting some of the normals, otherwise rviz will block it
+            unsigned int index = (j * _width) + i;
             if (index % this->reduce_normals_ == 0)
+            {
               visualization_msgs::Marker m;
               m.type = visualization_msgs::Marker::ARROW;
               m.header.frame_id = this->frame_name_;
@@ -481,7 +485,6 @@ void GazeboRosDepthCamera::OnNewNormalsFrame(const float * _normals,
               m.lifetime.sec = 1;
               m.lifetime.nsec = 0;
 
-              unsigned int index = (j * _width) + i;
               m.id = index;
               float x = _normals[4 * index];
               float y = _normals[4 * index + 1];
@@ -505,6 +508,7 @@ void GazeboRosDepthCamera::OnNewNormalsFrame(const float * _normals,
               m.pose.orientation.w = q.w();
 
               m_array.markers.push_back(m);
+            }
           }
         }
       }

--- a/gazebo_plugins/test/test_worlds/gazebo_ros_depth_camera.world
+++ b/gazebo_plugins/test/test_worlds/gazebo_ros_depth_camera.world
@@ -156,7 +156,7 @@
                 </script>
               </material>
               <plugin filename="libReflectancePlugin.so" name="reflectance_plugin">
-                <material>terrain.png</material>
+                <reflectance_map>terrain.png</reflectance_map>
               </plugin>
             </visual>
             <collision name="visual">

--- a/gazebo_plugins/test/test_worlds/gazebo_ros_depth_camera.world
+++ b/gazebo_plugins/test/test_worlds/gazebo_ros_depth_camera.world
@@ -155,7 +155,10 @@
                 </script>
               </material>
               <plugin filename="libReflectancePlugin.so" name="reflectance_plugin">
-                <reflectance_map>terrain.png</reflectance_map>
+                <reflectance_map>
+                  <uri>model://suv/materials/textures/</uri>
+                  <name>wheels_01.png</name>
+                </reflectance_map>
               </plugin>
             </visual>
             <collision name="visual">

--- a/gazebo_plugins/test/test_worlds/gazebo_ros_depth_camera.world
+++ b/gazebo_plugins/test/test_worlds/gazebo_ros_depth_camera.world
@@ -104,9 +104,16 @@
                             <height>480</height>
                             <format>R8G8B8</format>
                         </image>
-                        <clip near="0.01" far="100.0" />
-                        <save enabled="false" path="/tmp" />
-                        <depth_camera output="points" />
+                        <clip>
+                          <near>0.1</near>
+                          <far>100</far>
+                        </clip>
+                        <save enabled='0'>
+                          <path>__default__</path>
+                        </save>
+                        <depth_camera>
+                          <output>points;reflectance</output>
+                        </depth_camera>
                     </camera>
                     <plugin name="plugin_1" filename="libgazebo_ros_depth_camera.so">
                         <alwaysOn>1</alwaysOn>
@@ -132,6 +139,36 @@
             </link>
             <static>false</static>
         </model>
+
+        <model  name="box_reflectance">
+          <pose>1.0 0.0 5.0 0 0 0</pose>
+          <link name="box_link">
+            <visual name="visual">
+              <geometry>
+                <box>
+                  <size>.2 .2 .2</size>
+                </box>
+              </geometry>
+              <material>
+                <script>
+                  <uri>file://media/materials/scripts/gazebo.material</uri>
+                  <name>Gazebo/Red</name>
+                </script>
+              </material>
+              <plugin filename="libReflectancePlugin.so" name="reflectance_plugin">
+                <material>terrain.png</material>
+              </plugin>
+            </visual>
+            <collision name="visual">
+              <geometry>
+                <box>
+                  <size>.2 .2 .2</size>
+                </box>
+              </geometry>
+            </collision>
+          </link>
+        </model>
+
         <model name="model_2">
             <pose>5.0 0.0 5.0 0.0 0.0 0.0</pose>
             <link name="link_1">


### PR DESCRIPTION
Moved this PR https://github.com/ros-simulation/gazebo_ros_pkgs/pull/1044 to `noetic-devel` to avoid ABI changes in melodic

Refletance must be an image.

To include the reflectance:

```
<link>
...
  <visual name="visual">
    ...
      <plugin filename="libReflectancePlugin.so" name="reflectance_plugin">
        <reflectance_map>your_reflectance_map.png</reflectance_map>
      </plugin>
      ...
   </visual>
...
</link>
```