### PR TITLE
[Gazebo 9] Created a MarkerArray to publish normals in ROS

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -28,6 +28,7 @@ find_package(catkin REQUIRED COMPONENTS
   diagnostic_updater
   camera_info_manager
   std_msgs
+  visualization_msgs
 )
 
 # Through transitive dependencies in the packages above, gazebo_plugins depends
@@ -157,6 +158,7 @@ catkin_package(
   rosconsole
   camera_info_manager
   std_msgs
+  visualization_msgs
 )
 add_dependencies(${PROJECT_NAME}_gencfg ${catkin_EXPORTED_TARGETS})
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
@@ -90,7 +90,7 @@ namespace gazebo
                    unsigned int _width, unsigned int _height,
                    unsigned int _depth, const std::string &_format);
 
-    /// \brief Update the controller
+    // Documentation inherited
     protected: virtual void OnNewNormalsFrame(const float * _normals,
                    unsigned int _width, unsigned int _height,
                    unsigned int _depth, const std::string &_format);
@@ -108,7 +108,9 @@ namespace gazebo
 
     /// \brief Keep track of number of connctions for point clouds
     private: int normals_connect_count_;
+    /// \brief Increase the counter which count the subscribers are connected
     private: void NormalsConnect();
+    /// \brief Decrease the counter which count the subscribers are connected
     private: void NormalsDisconnect();
 
     /// \brief Keep track of number of connctions for point clouds

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
@@ -35,6 +35,8 @@
 #include <sensor_msgs/fill_image.h>
 #include <std_msgs/Float64.h>
 #include <image_transport/image_transport.h>
+#include <visualization_msgs/MarkerArray.h>
+#include <visualization_msgs/Marker.h>
 
 // gazebo stuff
 #include <sdf/Param.hh>
@@ -88,6 +90,11 @@ namespace gazebo
                    unsigned int _width, unsigned int _height,
                    unsigned int _depth, const std::string &_format);
 
+    /// \brief Update the controller
+    protected: virtual void OnNewNormalsFrame(const float * _normals,
+                   unsigned int _width, unsigned int _height,
+                   unsigned int _depth, const std::string &_format);
+
     /// \brief Put camera data to the ROS topic
     private: void FillPointdCloud(const float *_src);
 
@@ -98,6 +105,11 @@ namespace gazebo
     private: int point_cloud_connect_count_;
     private: void PointCloudConnect();
     private: void PointCloudDisconnect();
+
+    /// \brief Keep track of number of connctions for point clouds
+    private: int normals_connect_count_;
+    private: void NormalsConnect();
+    private: void NormalsDisconnect();
 
     /// \brief Keep track of number of connctions for point clouds
     private: int depth_image_connect_count_;
@@ -116,15 +128,21 @@ namespace gazebo
     /// \brief A pointer to the ROS node.  A node will be instantiated if it does not exist.
     private: ros::Publisher point_cloud_pub_;
     private: ros::Publisher depth_image_pub_;
+    private: ros::Publisher normal_pub_;
 
     /// \brief PointCloud2 point cloud message
     private: sensor_msgs::PointCloud2 point_cloud_msg_;
     private: sensor_msgs::Image depth_image_msg_;
 
+    private: float * pcd_ = nullptr;
+
     private: double point_cloud_cutoff_;
 
     /// \brief ROS image topic name
     private: std::string point_cloud_topic_name_;
+
+    /// \brief ROS normals topic name
+    private: std::string normals_topic_name_;
 
     private: void InfoConnect();
     private: void InfoDisconnect();
@@ -148,4 +166,3 @@ namespace gazebo
 
 }
 #endif
-

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
@@ -140,6 +140,9 @@ namespace gazebo
 
     private: double point_cloud_cutoff_;
 
+    /// \brief adding one value each reduce_normals_ to the array marker
+    private: int reduce_normals_;
+
     /// \brief ROS image topic name
     private: std::string point_cloud_topic_name_;
 

--- a/gazebo_plugins/package.xml
+++ b/gazebo_plugins/package.xml
@@ -30,6 +30,7 @@
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>trajectory_msgs</depend>
+  <depend>visualization_msgs</depend>
   <depend>std_srvs</depend>
   <depend>roscpp</depend>
   <depend>rospy</depend>

--- a/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
@@ -114,6 +114,11 @@ void GazeboRosDepthCamera::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf
   else
     this->point_cloud_cutoff_ = _sdf->GetElement("pointCloudCutoff")->Get<double>();
 
+  if (!_sdf->HasElement("reduceNormals"))
+    this->reduce_normals_ = 50;
+  else
+    this->reduce_normals_ = _sdf->GetElement("reduceNormals")->Get<int>();
+
   load_connection_ = GazeboRosCameraUtils::OnLoad(boost::bind(&GazeboRosDepthCamera::Advertise, this));
   GazeboRosCameraUtils::Load(_parent, _sdf);
 }
@@ -430,7 +435,7 @@ void GazeboRosDepthCamera::OnNewNormalsFrame(const float * _normals,
             m.pose.orientation.w = q.w();
 
             // plotting some of the normals, otherwise rviz will block it
-            if (index % 50 == 0)
+            if (index % this->reduce_normals_ == 0)
               m_array.markers.push_back(m);
           }
         }

--- a/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
@@ -394,48 +394,48 @@ void GazeboRosDepthCamera::OnNewNormalsFrame(const float * _normals,
         {
           for (unsigned int j = 0; j < _height; j++)
           {
-            visualization_msgs::Marker m;
-            m.type = visualization_msgs::Marker::ARROW;
-            m.header.frame_id = this->frame_name_;
-            m.header.stamp.sec = this->depth_sensor_update_time_.sec;
-            m.header.stamp.nsec = this->depth_sensor_update_time_.nsec;
-            m.action = visualization_msgs::Marker::ADD;
-
-            m.color.r = 1.0;
-            m.color.g = 0.0;
-            m.color.b = 0.0;
-            m.color.a = 1.0;
-            m.scale.x = 1;
-            m.scale.y = 0.01;
-            m.scale.z = 0.01;
-            m.lifetime.sec = 1;
-            m.lifetime.nsec = 0;
-
-            unsigned int index = (j * _width) + i;
-            m.id = index;
-            float x = _normals[4 * index];
-            float y = _normals[4 * index + 1];
-            float z = _normals[4 * index + 2];
-
-            m.pose.position.x = pcd_[4 * index];
-            m.pose.position.y = pcd_[4 * index + 1];
-            m.pose.position.z = pcd_[4 * index + 2];
-
-            // calculating the angle of the normal with the world
-            tf::Vector3 axis_vector(x, y, z);
-            tf::Vector3 vector(1.0, 0.0, 0.0);
-            tf::Vector3 right_vector = axis_vector.cross(vector);
-            right_vector.normalized();
-            tf::Quaternion q(right_vector, -1.0*acos(axis_vector.dot(vector)));
-            q.normalize();
-
-            m.pose.orientation.x = q.x();
-            m.pose.orientation.y = q.y();
-            m.pose.orientation.z = q.z();
-            m.pose.orientation.w = q.w();
-
             // plotting some of the normals, otherwise rviz will block it
             if (index % this->reduce_normals_ == 0)
+              visualization_msgs::Marker m;
+              m.type = visualization_msgs::Marker::ARROW;
+              m.header.frame_id = this->frame_name_;
+              m.header.stamp.sec = this->depth_sensor_update_time_.sec;
+              m.header.stamp.nsec = this->depth_sensor_update_time_.nsec;
+              m.action = visualization_msgs::Marker::ADD;
+
+              m.color.r = 1.0;
+              m.color.g = 0.0;
+              m.color.b = 0.0;
+              m.color.a = 1.0;
+              m.scale.x = 1;
+              m.scale.y = 0.01;
+              m.scale.z = 0.01;
+              m.lifetime.sec = 1;
+              m.lifetime.nsec = 0;
+
+              unsigned int index = (j * _width) + i;
+              m.id = index;
+              float x = _normals[4 * index];
+              float y = _normals[4 * index + 1];
+              float z = _normals[4 * index + 2];
+
+              m.pose.position.x = pcd_[4 * index];
+              m.pose.position.y = pcd_[4 * index + 1];
+              m.pose.position.z = pcd_[4 * index + 2];
+
+              // calculating the angle of the normal with the world
+              tf::Vector3 axis_vector(x, y, z);
+              tf::Vector3 vector(1.0, 0.0, 0.0);
+              tf::Vector3 right_vector = axis_vector.cross(vector);
+              right_vector.normalized();
+              tf::Quaternion q(right_vector, -1.0*acos(axis_vector.dot(vector)));
+              q.normalize();
+
+              m.pose.orientation.x = q.x();
+              m.pose.orientation.y = q.y();
+              m.pose.orientation.z = q.z();
+              m.pose.orientation.w = q.w();
+
               m_array.markers.push_back(m);
           }
         }

--- a/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
@@ -277,7 +277,7 @@ void GazeboRosDepthCamera::OnNewRGBPointCloud(const float *_pcd,
   }
   else
   {
-    if (this->point_cloud_connect_count_ > 0)
+    if (this->point_cloud_connect_count_ > 0 || this->normals_connect_count_ > 0)
     {
       this->lock_.lock();
 

--- a/gazebo_plugins/test/test_worlds/gazebo_ros_depth_camera.world
+++ b/gazebo_plugins/test/test_worlds/gazebo_ros_depth_camera.world
@@ -108,9 +108,6 @@
                           <near>0.1</near>
                           <far>100</far>
                         </clip>
-                        <save enabled='0'>
-                          <path>__default__</path>
-                        </save>
                         <depth_camera>
                           <output>points;normals</output>
                         </depth_camera>

--- a/gazebo_plugins/test/test_worlds/gazebo_ros_depth_camera.world
+++ b/gazebo_plugins/test/test_worlds/gazebo_ros_depth_camera.world
@@ -104,15 +104,23 @@
                             <height>480</height>
                             <format>R8G8B8</format>
                         </image>
-                        <clip near="0.01" far="100.0" />
-                        <save enabled="false" path="/tmp" />
-                        <depth_camera output="points" />
+                        <clip>
+                          <near>0.1</near>
+                          <far>100</far>
+                        </clip>
+                        <save enabled='0'>
+                          <path>__default__</path>
+                        </save>
+                        <depth_camera>
+                          <output>points;normals</output>
+                        </depth_camera>
                     </camera>
                     <plugin name="plugin_1" filename="libgazebo_ros_depth_camera.so">
                         <alwaysOn>1</alwaysOn>
                         <updateRate>10.0</updateRate>
                         <imageTopicName>image_raw</imageTopicName>
                         <pointCloudTopicName>points</pointCloudTopicName>
+                        <normalsTopicName>normals</normalsTopicName>
                         <cameraInfoTopicName>camera_info</cameraInfoTopicName>
                         <cameraName>depth_cam</cameraName>
                         <frameName>/base_link</frameName>

--- a/gazebo_plugins/test/test_worlds/gazebo_ros_depth_camera.world
+++ b/gazebo_plugins/test/test_worlds/gazebo_ros_depth_camera.world
@@ -121,6 +121,7 @@
                         <cameraInfoTopicName>camera_info</cameraInfoTopicName>
                         <cameraName>depth_cam</cameraName>
                         <frameName>/base_link</frameName>
+                        <reduceNormals>50</reduceNormals>
                         <pointCloudCutoff>0.001</pointCloudCutoff>
                         <distortionK1>0.00000001</distortionK1>
                         <distortionK2>0.00000001</distortionK2>


### PR DESCRIPTION
Moved this PR #1038 to `noetic-devel` to avoid ABI changes in `melodic`

We are exposing [normals in Gazebo9](https://bitbucket.org/osrf/gazebo/pull-requests/3193/added-normals-in-depth-camera-sensor/diff). This PR exposes the normals as a MarkerArray and then we can visualize the normals in RVIZ


![Selección_014](https://user-images.githubusercontent.com/1933907/73742147-0aa69f80-474c-11ea-9e18-8f23d36e0293.png)

Steps to reproduce it:

 - Launch the test world: 
`rosrun gazebo_ros gazebo test_worlds/gazebo_ros_depth_camera.world`
 - Create the tf between the world and the camera: 
`rosrun tf2_ros static_transform_publisher 0 0 5 0 0 -1.57 world base_link`
 - Open RVIZ