### PR TITLE
[gazebo_plugins] Add Gazebo ROS magnetometer sensor

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -115,6 +115,7 @@ catkin_package(
   gazebo_ros_planar_move
   gazebo_ros_range
   gazebo_ros_vacuum_gripper
+  gazebo_ros_magnetometer_sensor
 
   CATKIN_DEPENDS
   message_runtime
@@ -289,6 +290,9 @@ target_link_libraries(gazebo_ros_range ${catkin_LIBRARIES} ${Boost_LIBRARIES} Ra
 add_library(gazebo_ros_vacuum_gripper src/gazebo_ros_vacuum_gripper.cpp)
 target_link_libraries(gazebo_ros_vacuum_gripper ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
+add_library(gazebo_ros_magnetometer_sensor src/gazebo_ros_magnetometer_sensor.cpp)
+target_link_libraries(gazebo_ros_magnetometer_sensor ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
 ##
 ## Add your new plugin here
 ##
@@ -332,6 +336,7 @@ install(TARGETS
   gazebo_ros_video
   gazebo_ros_planar_move
   gazebo_ros_vacuum_gripper
+  gazebo_ros_magnetometer_sensor
   pub_joint_trajectory_test
   gazebo_ros_gpu_laser
   gazebo_ros_range

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_magnetometer_sensor.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_magnetometer_sensor.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+/*
+ * Desc: magnetometer ros interface.
+ * Author: Johannes Bier
+ * Date: 11 February 2020
+ */
+
+#ifndef GAZEBO_ROS_MAGNETOMETER_SENSOR_H
+#define GAZEBO_ROS_MAGNETOMETER_SENSOR_H
+
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/common/UpdateInfo.hh>
+#include <gazebo/sensors/MagnetometerSensor.hh>
+
+#include <ros/ros.h>
+#include <sensor_msgs/MagneticField.h>
+
+namespace gazebo
+{
+  namespace sensors
+  {
+    class MagnetometerSensor;
+  }
+  /**
+  @anchor GazeboRosMagnetometerSensor
+  \ref GazeboRosMagnetometerSensor is a plugin to simulate a magnetic field sensor. Some things to note:
+  - inheritance from SensorPlugin,
+  - measurements are given by gazebo MagnetometerSensor instead of being computed by the ros plugin
+  */
+  /** @brief Gazebo Ros magnetometer sensor plugin. */
+  class GazeboRosMagnetometerSensor : public SensorPlugin
+  {
+  public:
+    /// \brief Constructor.
+    GazeboRosMagnetometerSensor();
+    /// \brief Destructor.
+    virtual ~GazeboRosMagnetometerSensor();
+    /// \brief Load the sensor.
+    /// \param sensor_ pointer to the sensor.
+    /// \param sdf_ pointer to the sdf config file.
+    virtual void Load(sensors::SensorPtr sensor_, sdf::ElementPtr sdf_);
+
+  protected:
+    /// \brief Update the sensor.
+    virtual void UpdateChild(const gazebo::common::UpdateInfo &/*_info*/);
+
+  private:
+    /// \brief Load the parameters from the sdf file.
+    bool LoadParameters();
+    
+    /// \brief Ros NodeHandle pointer.
+    ros::NodeHandle* node;
+    /// \brief Ros Publisher for imu data.
+    ros::Publisher magnetometer_data_publisher;
+    /// \brief Ros IMU message.
+    sensor_msgs::MagneticField magnetometer_msg;
+
+    /// \brief last time on which the data was published.
+    common::Time last_time;
+    /// \brief Pointer to the update event connection.
+    gazebo::event::ConnectionPtr connection;
+    /// \brief Pointer to the sensor.
+    sensors::MagnetometerSensor* sensor;
+    /// \brief Pointer to the sdf config file.
+    sdf::ElementPtr sdf;
+
+    //loaded parameters
+    /// \brief The data is published on the topic named: /robot_namespace/topic_name.
+    std::string robot_namespace;
+    /// \brief The data is published on the topic named: /robot_namespace/topic_name.
+    std::string topic_name;
+    /// \brief Name of the link of the IMU.
+    std::string body_name;
+    /// \brief Sensor update rate.
+    double update_rate;
+  };
+}
+
+#endif //GAZEBO_ROS_MAGNETOMETER_SENSOR_H

--- a/gazebo_plugins/src/gazebo_ros_magnetometer_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_magnetometer_sensor.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+/*
+ * Desc: magnetometer ros interface.
+ * Author: Johannes Bier
+ * Date: 11 February 2020
+ */
+
+#include <gazebo_plugins/gazebo_ros_magnetometer_sensor.h>
+#include <gazebo/common/Events.hh>
+#include <gazebo/physics/physics.hh>
+
+GZ_REGISTER_SENSOR_PLUGIN(gazebo::GazeboRosMagnetometerSensor)
+
+gazebo::GazeboRosMagnetometerSensor::GazeboRosMagnetometerSensor(): 
+  SensorPlugin(),
+  sensor(nullptr),
+  node(nullptr)
+{}
+
+gazebo::GazeboRosMagnetometerSensor::~GazeboRosMagnetometerSensor()
+{
+  if (connection.get())
+  {
+    connection.reset();
+    connection = event::ConnectionPtr();
+  }
+
+  if (node != nullptr)
+  {
+    node->shutdown();
+    delete node;
+  }
+}
+
+void gazebo::GazeboRosMagnetometerSensor::Load(gazebo::sensors::SensorPtr sensor_, sdf::ElementPtr sdf_)
+{
+  sdf=sdf_;
+  sensor=dynamic_cast<gazebo::sensors::MagnetometerSensor*>(sensor_.get());
+
+  if(sensor==nullptr)
+  {
+    ROS_FATAL("Error: Sensor pointer is NULL!");
+    return;
+  }
+
+  sensor->SetActive(true);
+
+  if(!LoadParameters())
+  {
+    ROS_FATAL("Error Loading Parameters!");
+    return;
+  }
+
+  if (!ros::isInitialized()) //check if ros is initialized properly
+  {
+    ROS_FATAL("ROS has not been initialized!");
+    return;
+  }
+
+  node = new ros::NodeHandle(this->robot_namespace);
+
+  magnetometer_data_publisher = node->advertise<sensor_msgs::MagneticField>(topic_name,1);
+
+  connection = gazebo::event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboRosMagnetometerSensor::UpdateChild, this, _1));
+
+  last_time = sensor->LastUpdateTime();
+}
+
+void gazebo::GazeboRosMagnetometerSensor::UpdateChild(const gazebo::common::UpdateInfo &/*_info*/)
+{
+  common::Time current_time = sensor->LastUpdateTime();
+
+  if(update_rate>0 && (current_time-last_time).Double() < 1.0/update_rate) //update rate check
+    return;
+
+  if(magnetometer_data_publisher.getNumSubscribers() > 0)
+  {
+    ignition::math::Vector3d field = sensor->MagneticField();
+
+    magnetometer_msg.magnetic_field.x = field.X();
+    magnetometer_msg.magnetic_field.y = field.Y();
+    magnetometer_msg.magnetic_field.z = field.Z();
+
+    //preparing message header
+    magnetometer_msg.header.frame_id   = body_name;
+    magnetometer_msg.header.stamp.sec  = current_time.sec;
+    magnetometer_msg.header.stamp.nsec = current_time.nsec;
+
+    //publishing data
+    magnetometer_data_publisher.publish(magnetometer_msg);
+
+    ros::spinOnce();
+  }
+
+  last_time = current_time;
+}
+
+bool gazebo::GazeboRosMagnetometerSensor::LoadParameters()
+{
+  //loading parameters from the sdf file
+
+  //NAMESPACE
+  if (sdf->HasElement("robotNamespace"))
+  {
+    robot_namespace = sdf->Get<std::string>("robotNamespace") + "/";
+    ROS_INFO_STREAM("<robotNamespace> set to: " << robot_namespace);
+  }
+  else
+  {
+    std::string scoped_name = sensor->ParentName();
+    std::size_t it          = scoped_name.find("::");
+
+    robot_namespace = "/" + scoped_name.substr(0, it) + "/";
+    ROS_WARN_STREAM("missing <robotNamespace>, set to default: " << robot_namespace);
+  }
+
+  //TOPIC
+  if (sdf->HasElement("topicName"))
+  {
+    topic_name = robot_namespace + sdf->Get<std::string>("topicName");
+    ROS_INFO_STREAM("<topicName> set to: " << topic_name);
+  }
+  else
+  {
+    topic_name = robot_namespace + "/mag_data";
+    ROS_WARN_STREAM("missing <topicName>, set to /namespace/default: " << topic_name);
+  }
+
+  //BODY NAME
+  if (sdf->HasElement("frameName"))
+  {
+    body_name = sdf->Get<std::string>("frameName");
+    ROS_INFO_STREAM("<frameName> set to: " << body_name);
+  }
+  else
+  {
+    ROS_FATAL("missing <frameName>, cannot proceed");
+    return false;
+  }
+
+  //UPDATE RATE
+  if (sdf->HasElement("updateRateHZ"))
+  {
+    update_rate = sdf->Get<double>("updateRateHZ");
+    ROS_INFO_STREAM("<updateRateHZ> set to: " << update_rate);
+  }
+  else
+  {
+    update_rate = 1.0;
+    ROS_WARN_STREAM("missing <updateRateHZ>, set to default: " << update_rate);
+  }
+
+  return true;
+}


### PR DESCRIPTION
This is my followup pull request from #1043 .

To get a full simulation of our robot, we need a magnetometer sensor that publishes a `sensor_msgs/MagneticField` message. Unfortunately, there is only one magnetometer plugin out there that I know of. `gazebo_ros_magnetic` from [hector_gazebo_plugins](http://wiki.ros.org/hector_gazebo_plugins). 
The three main reasons why I don't want to use it are:

- It outputs a `geometry_msgs::Vector3Stamped` instead of `sensor_msgs/MagneticField`.
- It doesn't use gazebo world `<magnetic_field>` tag in sdf file.
- It is implemented as `ModelPlugin` and not as `SensorPlugin`.

Gazebo has a `MagnetometerSensor` since 2015 and no ROS plugin. See [this commit](https://bitbucket.org/osrf/gazebo/pull-requests/1788/add-magnetometer-sensor-redo-of-andrews/diff) and [this discussion](https://bitbucket.org/osrf/gazebo/issues/1294/inclusion-of-magnetic-field-strength).

I used `gazebo_ros_imu_sensor` as template and created [gazebo_ros_magnetometer_sensor](https://github.com/Darkproduct/gazebo_ros_magnetometer). 

**For everyone, who want to use this right now:**
Clone [gazebo_ros_magnetometer_sensor](https://github.com/Darkproduct/gazebo_ros_magnetometer_sensor) into `catkin_ws/src/` and it should work.