### PR TITLE
Measure IMU orientation with respect to world

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -41,6 +41,16 @@ void gazebo::GazeboRosImuSensor::Load(gazebo::sensors::SensorPtr sensor_, sdf::E
     return;
   }
 
+  if (sdf->HasElement("initialOrientationAsReference"))
+  {
+    bool initial_orientation_as_reference = sdf->Get<bool>("initialOrientationAsReference");
+    ROS_INFO_STREAM("<initialOrientationAsReference> set to: "<< initial_orientation_as_reference);
+    if (!initial_orientation_as_reference) {
+      // This complies with REP 145
+      sensor->SetWorldToReferenceOrientation(ignition::math::Quaterniond::Identity);
+    }
+  }
+
   sensor->SetActive(true);
 
   if(!LoadParameters())


### PR DESCRIPTION
Report the IMU orientation from the sensor plugin with respect to the world frame.
This complies with convention documented in REP 145: https://www.ros.org/reps/rep-0145.html

In order to not break existing behavior, users should opt-in by adding a new SDF tag.

---

I'm open to naming suggestions for the new SDF tag.

Pending approval of this change, I will follow up with ports to Noetic and ROS 2 branches. @scpeters and I discussed this offline, specifically we propose to change the behavior as follows:

- Noetic and Foxy: Change the default behavior so that orientation is wrt the world. Log a warning if the new SDF tag is not set. Log a deprecation warning if the new SDF tag has value `false`.
- Dashing and Eloquent: Identical to the change proposed in this PR.