### PR TITLE
Measure IMU orientation with respect to the world (noetic)

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -41,6 +41,16 @@ void gazebo::GazeboRosImuSensor::Load(gazebo::sensors::SensorPtr sensor_, sdf::E
     return;
   }
 
+  if (sdf->HasElement("initialOrientationAsReference"))
+  {
+    bool initial_orientation_as_reference = sdf->Get<bool>("initialOrientationAsReference");
+    ROS_INFO_STREAM("<initialOrientationAsReference> set to: "<< initial_orientation_as_reference);
+    if (!initial_orientation_as_reference) {
+      // This complies with REP 145
+      sensor->SetWorldToReferenceOrientation(ignition::math::Quaterniond::Identity);
+    }
+  }
+
   sensor->SetActive(true);
 
   if(!LoadParameters())

--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -41,14 +41,26 @@ void gazebo::GazeboRosImuSensor::Load(gazebo::sensors::SensorPtr sensor_, sdf::E
     return;
   }
 
-  if (sdf->HasElement("initialOrientationAsReference"))
+  bool initial_orientation_as_reference = false;
+  if (!sdf->HasElement("initialOrientationAsReference"))
   {
-    bool initial_orientation_as_reference = sdf->Get<bool>("initialOrientationAsReference");
-    ROS_INFO_STREAM("<initialOrientationAsReference> set to: "<< initial_orientation_as_reference);
-    if (!initial_orientation_as_reference) {
-      // This complies with REP 145
-      sensor->SetWorldToReferenceOrientation(ignition::math::Quaterniond::Identity);
-    }
+    ROS_INFO("<initialOrientationAsReference> is unset, using default value of false "
+             "to comply with REP 145 (world as orientation reference)");
+  }
+  else
+  {
+    initial_orientation_as_reference = sdf->Get<bool>("initialOrientationAsReference");
+  }
+
+  if (initial_orientation_as_reference)
+  {
+    ROS_WARN("<initialOrientationAsReference> set to true, this behavior is deprecated "
+             "as it does not comply with REP 145.");
+  }
+  else
+  {
+    // This complies with REP 145
+    sensor->SetWorldToReferenceOrientation(ignition::math::Quaterniond::Identity);
   }
 
   sensor->SetActive(true);


### PR DESCRIPTION
Report the IMU orientation from the sensor plugin with respect to the world frame.
This complies with convention documented in REP 145: https://www.ros.org/reps/rep-0145.html

This ports #1051 from Melodic forward to Noetic and changes the default from retaining the legacy behavior (initialOrientationAsReference  == true) to complying with REP 145 by default (initialOrientationAsReference == false). It also prints a deprecation warning if the user explicitly sets `initialOrientationAsReference` to true.

cc @jacobperron