### PR TITLE
Measure IMU orientation with respect to world

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -66,6 +66,16 @@ void GazeboRosImuSensor::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPt
     return;
   }
 
+  if (sdf->HasElement("initial_orientation_as_reference"))
+  {
+    bool initial_orientation_as_reference = sdf->Get<bool>("initial_orientation_as_reference");
+    ROS_INFO_STREAM("<initial_orientation_as_reference> set to: "<< initial_orientation_as_reference);
+    if (!initial_orientation_as_reference) {
+      // This complies with REP 145
+      sensor->SetWorldToReferenceOrientation(ignition::math::Quaterniond::Identity);
+    }
+  }
+
   impl_->pub_ =
     impl_->ros_node_->create_publisher<sensor_msgs::msg::Imu>("~/out", rclcpp::SensorDataQoS());
 

--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -68,7 +68,8 @@ void GazeboRosImuSensor::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPt
 
   if (_sdf->HasElement("initial_orientation_as_reference")) {
     bool initial_orientation_as_reference = _sdf->Get<bool>("initial_orientation_as_reference");
-    RCLCPP_INFO_STREAM("<initial_orientation_as_reference> set to: "<< initial_orientation_as_reference);
+    RCLCPP_INFO_STREAM(impl_->ros_node_->get_logger(),
+        "<initial_orientation_as_reference> set to: "<< initial_orientation_as_reference);
     if (!initial_orientation_as_reference) {
       // This complies with REP 145
       impl_->sensor_->SetWorldToReferenceOrientation(ignition::math::Quaterniond::Identity);

--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -72,7 +72,7 @@ void GazeboRosImuSensor::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPt
     ROS_INFO_STREAM("<initial_orientation_as_reference> set to: "<< initial_orientation_as_reference);
     if (!initial_orientation_as_reference) {
       // This complies with REP 145
-      sensor->SetWorldToReferenceOrientation(ignition::math::Quaterniond::Identity);
+      impl_->sensor_->SetWorldToReferenceOrientation(ignition::math::Quaterniond::Identity);
     }
   }
 

--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -69,7 +69,7 @@ void GazeboRosImuSensor::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPt
   if (_sdf->HasElement("initial_orientation_as_reference")) {
     bool initial_orientation_as_reference = _sdf->Get<bool>("initial_orientation_as_reference");
     RCLCPP_INFO_STREAM(impl_->ros_node_->get_logger(),
-        "<initial_orientation_as_reference> set to: "<< initial_orientation_as_reference);
+      "<initial_orientation_as_reference> set to: " << initial_orientation_as_reference);
     if (!initial_orientation_as_reference) {
       // This complies with REP 145
       impl_->sensor_->SetWorldToReferenceOrientation(ignition::math::Quaterniond::Identity);

--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -66,10 +66,9 @@ void GazeboRosImuSensor::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPt
     return;
   }
 
-  if (sdf->HasElement("initial_orientation_as_reference"))
-  {
-    bool initial_orientation_as_reference = sdf->Get<bool>("initial_orientation_as_reference");
-    ROS_INFO_STREAM("<initial_orientation_as_reference> set to: "<< initial_orientation_as_reference);
+  if (_sdf->HasElement("initial_orientation_as_reference")) {
+    bool initial_orientation_as_reference = _sdf->Get<bool>("initial_orientation_as_reference");
+    RCLCPP_INFO_STREAM("<initial_orientation_as_reference> set to: "<< initial_orientation_as_reference);
     if (!initial_orientation_as_reference) {
       // This complies with REP 145
       impl_->sensor_->SetWorldToReferenceOrientation(ignition::math::Quaterniond::Identity);


### PR DESCRIPTION
Report the IMU orientation from the sensor plugin with respect to the world frame.
This complies with convention documented in REP 145: https://www.ros.org/reps/rep-0145.html

In order to not break existing behavior, users should opt-in by adding a new SDF tag.

This ports #1051 to eloquent, changing the sdf parameter name from `initialOrientationAsReference ` to `initial_orientation_as_reference`.

cc @jacobperron