### PR TITLE
[melodic][Windows] install binaries to portable locations

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -314,8 +314,13 @@ target_link_libraries(gazebo_ros_template ${catkin_LIBRARIES} ${Boost_LIBRARIES}
 
 install(TARGETS
   hokuyo_node
-  vision_reconfigure
   camera_synchronizer
+  pub_joint_trajectory_test
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  )
+
+install(TARGETS
+  vision_reconfigure
   gazebo_ros_utils
   gazebo_ros_camera_utils
   gazebo_ros_camera
@@ -346,24 +351,26 @@ install(TARGETS
   gazebo_ros_video
   gazebo_ros_planar_move
   gazebo_ros_vacuum_gripper
-  pub_joint_trajectory_test
   gazebo_ros_gpu_laser
   gazebo_ros_range
-  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
   )
 
 if (NOT GAZEBO_VERSION VERSION_LESS 6.0)
   install(TARGETS gazebo_ros_elevator
-    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
     LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
     )
 endif()
 
 if (NOT GAZEBO_VERSION VERSION_LESS 7.3)
   install(TARGETS gazebo_ros_harness
-    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
     LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
     )
 endif()
 


### PR DESCRIPTION
This pull request is to install the library to the correct location for Windows.

The change adheres with the catkin guide:
https://docs.ros.org/api/catkin/html/howto/format1/building_libraries.html#installing
https://docs.ros.org/api/catkin/html/howto/format1/building_executables.html#installing

And hope this can be cherry-picked to `noetic` branch too. Thanks!