### PR TITLE
gazebo_ros_control: catch all pluginlib exceptions

### DIFF
--- a/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
+++ b/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
@@ -199,7 +199,7 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
       (boost::bind(&GazeboRosControlPlugin::Update, this));
 
   }
-  catch(pluginlib::LibraryLoadException &ex)
+  catch(pluginlib::PluginlibException &ex)
   {
     ROS_FATAL_STREAM_NAMED("gazebo_ros_control","Failed to create robot simulation interface loader: "<<ex.what());
   }


### PR DESCRIPTION
Before we only displayed an error message on LibraryLoadExceptions, but there is also ClassLoaderException, CreateClassException, InvalidXMLException, and some more. So catch pluginlib::PluginlibException, which is base class of all of these.

Uncaught exceptions don't show up at all (probably a bug in gazebo itself), which leads to situations which are quite hard to debug.

This should apply to noetic as well.