### PR TITLE
Measure IMU orientation with respect to world (ros2)

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -69,14 +69,22 @@ void GazeboRosImuSensor::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPt
     return;
   }
 
-  if (_sdf->HasElement("initial_orientation_as_reference")) {
-    bool initial_orientation_as_reference = _sdf->Get<bool>("initial_orientation_as_reference");
+  bool initial_orientation_as_reference = false;
+  if (!_sdf->HasElement("initial_orientation_as_reference")) {
     RCLCPP_INFO_STREAM(impl_->ros_node_->get_logger(),
-      "<initial_orientation_as_reference> set to: " << initial_orientation_as_reference);
-    if (!initial_orientation_as_reference) {
-      // This complies with REP 145
-      impl_->sensor_->SetWorldToReferenceOrientation(ignition::math::Quaterniond::Identity);
-    }
+        "<initial_orientation_as_reference> is unset, using default value of false "
+        "to comply with REP 145 (world as orientation reference)");
+  } else {
+    initial_orientation_as_reference = _sdf->Get<bool>("initial_orientation_as_reference");
+  }
+
+  if (initial_orientation_as_reference) {
+    RCLCPP_WARN_STREAM(impl_->ros_node_->get_logger(),
+        "<initial_orientation_as_reference> set to true, this behavior is deprecated "
+        "as it does not comply with REP 145.");
+  } else {
+    // This complies with REP 145
+    impl_->sensor_->SetWorldToReferenceOrientation(ignition::math::Quaterniond::Identity);
   }
 
   impl_->pub_ = impl_->ros_node_->create_publisher<sensor_msgs::msg::Imu>(

--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -71,17 +71,19 @@ void GazeboRosImuSensor::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPt
 
   bool initial_orientation_as_reference = false;
   if (!_sdf->HasElement("initial_orientation_as_reference")) {
-    RCLCPP_INFO_STREAM(impl_->ros_node_->get_logger(),
-        "<initial_orientation_as_reference> is unset, using default value of false "
-        "to comply with REP 145 (world as orientation reference)");
+    RCLCPP_INFO_STREAM(
+      impl_->ros_node_->get_logger(),
+      "<initial_orientation_as_reference> is unset, using default value of false "
+      "to comply with REP 145 (world as orientation reference)");
   } else {
     initial_orientation_as_reference = _sdf->Get<bool>("initial_orientation_as_reference");
   }
 
   if (initial_orientation_as_reference) {
-    RCLCPP_WARN_STREAM(impl_->ros_node_->get_logger(),
-        "<initial_orientation_as_reference> set to true, this behavior is deprecated "
-        "as it does not comply with REP 145.");
+    RCLCPP_WARN_STREAM(
+      impl_->ros_node_->get_logger(),
+      "<initial_orientation_as_reference> set to true, this behavior is deprecated "
+      "as it does not comply with REP 145.");
   } else {
     // This complies with REP 145
     impl_->sensor_->SetWorldToReferenceOrientation(ignition::math::Quaterniond::Identity);

--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -69,6 +69,16 @@ void GazeboRosImuSensor::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPt
     return;
   }
 
+  if (_sdf->HasElement("initial_orientation_as_reference")) {
+    bool initial_orientation_as_reference = _sdf->Get<bool>("initial_orientation_as_reference");
+    RCLCPP_INFO_STREAM(impl_->ros_node_->get_logger(),
+      "<initial_orientation_as_reference> set to: " << initial_orientation_as_reference);
+    if (!initial_orientation_as_reference) {
+      // This complies with REP 145
+      impl_->sensor_->SetWorldToReferenceOrientation(ignition::math::Quaterniond::Identity);
+    }
+  }
+
   impl_->pub_ = impl_->ros_node_->create_publisher<sensor_msgs::msg::Imu>(
     "~/out", qos.get_publisher_qos("~/out", rclcpp::SensorDataQoS()));
 


### PR DESCRIPTION
Report the IMU orientation from the sensor plugin with respect to the world frame.
This complies with convention documented in REP 145: https://www.ros.org/reps/rep-0145.html

This ports #1058 from eloquent forward to ros2 (foxy) and changes the default from retaining the legacy behavior (`initial_orientation_as_reference ` == true) to complying with REP 145 by default (`initial_orientation_as_reference ` == false). It also prints a deprecation warning if the user explicitly sets `initial_orientation_as_reference` to true. This PR is similar to #1057 which ported from melodic -> noetic.