### PR TITLE
Include preprocessor conditions to avoid compile OnNewNormalsFrame and OnNewReflectanceFrame

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_depth_camera.h
@@ -90,6 +90,7 @@ namespace gazebo
                    unsigned int _width, unsigned int _height,
                    unsigned int _depth, const std::string &_format) override;
 
+#if GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION > 12
      /// \brief Update the reflectance frame
      protected: virtual void OnNewReflectanceFrame(const float * _reflectance,
                     unsigned int _width, unsigned int _height,
@@ -99,6 +100,7 @@ namespace gazebo
     protected: virtual void OnNewNormalsFrame(const float * _normals,
                    unsigned int _width, unsigned int _height,
                    unsigned int _depth, const std::string &_format) override;
+#endif
 
     /// \brief Put camera data to the ROS topic
     private: void FillPointdCloud(const float *_src);

--- a/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
@@ -56,7 +56,10 @@ GazeboRosDepthCamera::GazeboRosDepthCamera()
 // Destructor
 GazeboRosDepthCamera::~GazeboRosDepthCamera()
 {
-  delete [] pcd_;
+  if (pcd_ != nullptr)
+  {
+    delete [] pcd_;
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -156,6 +159,7 @@ void GazeboRosDepthCamera::Advertise()
         ros::VoidPtr(), &this->camera_queue_);
   this->depth_image_camera_info_pub_ = this->rosnode_->advertise(depth_image_camera_info_ao);
 
+#if GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION > 12
   ros::AdvertiseOptions reflectance_ao =
     ros::AdvertiseOptions::create<sensor_msgs::Image>(
       reflectance_topic_name_, 1,
@@ -171,6 +175,7 @@ void GazeboRosDepthCamera::Advertise()
       boost::bind( &GazeboRosDepthCamera::NormalsDisconnect,this),
       ros::VoidPtr(), &this->camera_queue_);
   this->normal_pub_ = this->rosnode_->advertise(normals_ao);
+#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -375,6 +380,7 @@ void GazeboRosDepthCamera::OnNewRGBPointCloud(const float *_pcd,
   }
 }
 
+#if GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION > 12
 ////////////////////////////////////////////////////////////////////////////////
 // Update the controller
 void GazeboRosDepthCamera::OnNewReflectanceFrame(const float *_image,
@@ -404,6 +410,7 @@ void GazeboRosDepthCamera::OnNewReflectanceFrame(const float *_image,
   }
 
 }
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // Update the controller
@@ -438,6 +445,7 @@ void GazeboRosDepthCamera::OnNewImageFrame(const unsigned char *_image,
   }
 }
 
+#if GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION > 12
 void GazeboRosDepthCamera::OnNewNormalsFrame(const float * _normals,
                unsigned int _width, unsigned int _height,
                unsigned int _depth, const std::string &_format)
@@ -517,6 +525,7 @@ void GazeboRosDepthCamera::OnNewNormalsFrame(const float * _normals,
     }
   }
 }
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // Put camera data to the interface


### PR DESCRIPTION
`OnNewReflectanceFrame` and `OnNewNormalsFrame` will be introduce exclusively in Gazebo 9 for minor version > 12.

These preprocessor conditions allow to compile for other Gazebo versions

Signed-off-by: ahcorde <ahcorde@gmail.com>