### PR TITLE
Add node required parameter to empty_world.launch file

### DIFF
--- a/gazebo_ros/launch/empty_world.launch
+++ b/gazebo_ros/launch/empty_world.launch
@@ -19,6 +19,8 @@
   <arg name="respawn_gazebo" default="false"/>
   <arg name="use_clock_frequency" default="false"/>
   <arg name="pub_clock_frequency" default="100"/>
+  <arg name="server_required" default="false"/>
+  <arg name="gui_required" default="false"/>
 
   <!-- set use_sim_time flag -->
   <param name="/use_sim_time" value="$(arg use_sim_time)"/>
@@ -38,11 +40,13 @@
     <param name="gazebo/pub_clock_frequency" value="$(arg pub_clock_frequency)" />
   </group>
   <node name="gazebo" pkg="gazebo_ros" type="$(arg script_type)" respawn="$(arg respawn_gazebo)" output="$(arg output)"
-  args="$(arg command_arg1) $(arg command_arg2) $(arg command_arg3) -e $(arg physics) $(arg extra_gazebo_args) $(arg world_name)" />
+  args="$(arg command_arg1) $(arg command_arg2) $(arg command_arg3) -e $(arg physics) $(arg extra_gazebo_args) $(arg world_name)"
+  required="$(arg server_required)" />
 
   <!-- start gazebo client -->
   <group if="$(arg gui)">
-    <node name="gazebo_gui" pkg="gazebo_ros" type="gzclient" respawn="false" output="$(arg output)" args="$(arg command_arg3)"/>
+    <node name="gazebo_gui" pkg="gazebo_ros" type="gzclient" respawn="false" output="$(arg output)" args="$(arg command_arg3)"
+    required="$(arg gui_required)"/>
   </group>
 
 </launch>


### PR DESCRIPTION
This exposes the `required` fields of the `<node>` tags for gzserver and gzclient in `empty_world.launch`, such that if either the server or client dies, the entire `roslaunch` will terminate too.

Actual names of parameters, currently `gui_required` and `server_required`, are up for suggestions.
Tested on Xenial.

Test with:
```
$ roslaunch gazebo_ros empty_world.launch gui_required:=true
```
Close the GUI window, and launch script should quit by itself:
```
================================================================================REQUIRED process [gazebo_gui-3] has died!
process has finished cleanly
log file: /home/developer/.ros/log/03fcfb24-793e-11ea-bd1e-0242ac110002/gazebo_gui-3*.log
Initiating shutdown!
================================================================================
[gazebo_gui-3] killing on exit
[gazebo-2] killing on exit
```

Test requirement on server with:
```
$ roslaunch gazebo_ros empty_world.launch server_required:=true
$ kill <gzserver_PID>
```
Launch script should quit, similar to above.

Signed-off-by: Mabel Zhang <mabel@openrobotics.org>