### PR TITLE
Use <depend> for gazebo_dev in gazebo_ros

### DIFF
--- a/gazebo_plugins/package.xml
+++ b/gazebo_plugins/package.xml
@@ -18,12 +18,11 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>gazebo_dev</build_depend>
   <!--
-    Need to use gazebo_dev since run script needs pkg-config
+    Need to exec_depend on gazebo_dev since run script needs pkg-config
     See: https://github.com/ros-simulation/gazebo_ros_pkgs/issues/323 for more info
   -->
-  <exec_depend>gazebo_dev</exec_depend>
+  <depend>gazebo_dev</depend>
 
   <depend>gazebo_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -36,6 +36,7 @@ catkin_package(
     gazebo_ros_paths_plugin
 
   CATKIN_DEPENDS
+    gazebo_dev
     roslib
     roscpp
     geometry_msgs

--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -36,7 +36,6 @@ catkin_package(
     gazebo_ros_paths_plugin
 
   CATKIN_DEPENDS
-    gazebo_dev
     roslib
     roscpp
     geometry_msgs

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -22,12 +22,11 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>cmake_modules</build_depend>
-  <build_depend>gazebo_dev</build_depend>
   <!--
-    Need to use gazebo_dev since run script needs pkg-config
+    Need to exec_depend on gazebo_dev since run script needs pkg-config
     See: https://github.com/ros-simulation/gazebo_ros_pkgs/issues/323 for more info
   -->
-  <exec_depend>gazebo_dev</exec_depend>
+  <depend>gazebo_dev</depend>
   <depend>gazebo_msgs</depend>
   <depend>roslib</depend>
   <depend>roscpp</depend>


### PR DESCRIPTION
Attempt to fix build farm CMake errors about not finding `gazebo_dev`: https://build.osrfoundation.org/job/ros_gazebo_pkgs-ci-pr_regression_any_kinetic-xenial-amd64/121/consoleFull#-274357824aa60f765-a60a-427d-900c-dc128ab22287

The hypothesis is that `<build_depend>` is not enough. Now using `<depend>`. Removed `<exec_depend>` because otherwise compiler complains about redundancy.

Will see result in the automatic checks below.