### PR TITLE
[eloquent] Fix Windows build.

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -11,6 +11,16 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
 endif()
 
+if(WIN32)
+  add_compile_definitions(
+    # For math constants
+    _USE_MATH_DEFINES
+    # Minimize Windows namespace collision
+    NOMINMAX
+    WIN32_LEAN_AND_MEAN
+  )
+endif()
+
 find_package(ament_cmake REQUIRED)
 find_package(camera_info_manager REQUIRED)
 find_package(gazebo_dev REQUIRED)
@@ -220,6 +230,9 @@ ament_export_libraries(gazebo_ros_ft_sensor)
 # gazebo_ros_bumper
 add_library(gazebo_ros_bumper SHARED
   src/gazebo_ros_bumper.cpp
+)
+target_link_libraries(gazebo_ros_bumper
+  ContactPlugin
 )
 ament_target_dependencies(gazebo_ros_bumper
   "gazebo_ros"

--- a/gazebo_plugins/src/gazebo_ros_ray_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ray_sensor.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <boost/variant.hpp>
 #include <boost/make_shared.hpp>
 #include <gazebo/transport/transport.hh>
 #include <gazebo_plugins/gazebo_ros_ray_sensor.hpp>

--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -11,6 +11,16 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
 endif()
 
+if(WIN32)
+  add_compile_definitions(
+    # For math constants
+    _USE_MATH_DEFINES
+    # Minimize Windows namespace collision
+    NOMINMAX
+    WIN32_LEAN_AND_MEAN
+  )
+endif()
+
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(gazebo_dev REQUIRED)
@@ -38,6 +48,7 @@ target_include_directories(gazebo_ros_node
     $<INSTALL_INTERFACE:include>
     ${gazebo_dev_INCLUDE_DIRS}
 )
+target_compile_definitions(gazebo_ros_node PRIVATE "GAZEBO_ROS_NODE_BUILDING_DLL")
 
 ament_target_dependencies(gazebo_ros_node
   "gazebo_dev"
@@ -55,6 +66,7 @@ target_include_directories(gazebo_ros_utils
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
+target_compile_definitions(gazebo_ros_utils PRIVATE "GAZEBO_ROS_UTILS_BUILDING_DLL")
 ament_target_dependencies(gazebo_ros_utils
   "gazebo_dev"
   "rclcpp"

--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -48,7 +48,9 @@ target_include_directories(gazebo_ros_node
     $<INSTALL_INTERFACE:include>
     ${gazebo_dev_INCLUDE_DIRS}
 )
-target_compile_definitions(gazebo_ros_node PRIVATE "GAZEBO_ROS_NODE_BUILDING_DLL")
+if(WIN32)
+  target_compile_definitions(gazebo_ros_node PRIVATE "GAZEBO_ROS_NODE_BUILDING_DLL")
+endif()
 
 ament_target_dependencies(gazebo_ros_node
   "gazebo_dev"
@@ -66,7 +68,9 @@ target_include_directories(gazebo_ros_utils
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
-target_compile_definitions(gazebo_ros_utils PRIVATE "GAZEBO_ROS_UTILS_BUILDING_DLL")
+if(WIN32)
+  target_compile_definitions(gazebo_ros_utils PRIVATE "GAZEBO_ROS_UTILS_BUILDING_DLL")
+endif()
 ament_target_dependencies(gazebo_ros_utils
   "gazebo_dev"
   "rclcpp"

--- a/gazebo_ros/include/gazebo_ros/node.hpp
+++ b/gazebo_ros/include/gazebo_ros/node.hpp
@@ -18,6 +18,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <gazebo_ros/executor.hpp>
+#include <gazebo_ros/node_visibility_control.h>
 
 #include <atomic>
 #include <memory>
@@ -33,7 +34,7 @@ namespace gazebo_ros
  * Wrapper around an rclcpp::Node which ensures all instances share an executor.
  * \include gazebo_ros/node.hpp
  */
-class Node : public rclcpp::Node
+class GAZEBO_ROS_NODE_PUBLIC Node : public rclcpp::Node
 {
 public:
   /// Shared pointer to a #gazebo_ros::Node

--- a/gazebo_ros/include/gazebo_ros/node_visibility_control.h
+++ b/gazebo_ros/include/gazebo_ros/node_visibility_control.h
@@ -1,0 +1,56 @@
+// Copyright 2020 Microsoft Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* This header must be included by all rclcpp headers which declare symbols
+ * which are defined in the rclcpp library. When not building the rclcpp
+ * library, i.e. when using the headers in other package's code, the contents
+ * of this header change the visibility of certain symbols which the rclcpp
+ * library cannot have, but the consuming code must have inorder to link.
+ */
+
+#ifndef GAZEBO_ROS_NODE__VISIBILITY_CONTROL_H_
+#define GAZEBO_ROS_NODE__VISIBILITY_CONTROL_H_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define GAZEBO_ROS_NODE_EXPORT __attribute__ ((dllexport))
+    #define GAZEBO_ROS_NODE_IMPORT __attribute__ ((dllimport))
+  #else
+    #define GAZEBO_ROS_NODE_EXPORT __declspec(dllexport)
+    #define GAZEBO_ROS_NODE_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef GAZEBO_ROS_NODE_BUILDING_DLL
+    #define GAZEBO_ROS_NODE_PUBLIC GAZEBO_ROS_NODE_EXPORT
+  #else
+    #define GAZEBO_ROS_NODE_PUBLIC GAZEBO_ROS_NODE_IMPORT
+  #endif
+  #define GAZEBO_ROS_NODE_PUBLIC_TYPE GAZEBO_ROS_NODE_PUBLIC
+  #define GAZEBO_ROS_NODE_LOCAL
+#else
+  #define GAZEBO_ROS_NODE_EXPORT __attribute__ ((visibility("default")))
+  #define GAZEBO_ROS_NODE_IMPORT
+  #if __GNUC__ >= 4
+    #define GAZEBO_ROS_NODE_PUBLIC __attribute__ ((visibility("default")))
+    #define GAZEBO_ROS_NODE_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define GAZEBO_ROS_NODE_PUBLIC
+    #define GAZEBO_ROS_NODE_LOCAL
+  #endif
+  #define GAZEBO_ROS_NODE_PUBLIC_TYPE
+#endif
+
+#endif  // GAZEBO_ROS_NODE__VISIBILITY_CONTROL_H_

--- a/gazebo_ros/include/gazebo_ros/node_visibility_control.h
+++ b/gazebo_ros/include/gazebo_ros/node_visibility_control.h
@@ -19,8 +19,8 @@
  * library cannot have, but the consuming code must have inorder to link.
  */
 
-#ifndef GAZEBO_ROS_NODE__VISIBILITY_CONTROL_H_
-#define GAZEBO_ROS_NODE__VISIBILITY_CONTROL_H_
+#ifndef GAZEBO_ROS__NODE_VISIBILITY_CONTROL_H_
+#define GAZEBO_ROS__NODE_VISIBILITY_CONTROL_H_
 
 // This logic was borrowed (then namespaced) from the examples on the gcc wiki:
 //     https://gcc.gnu.org/wiki/Visibility
@@ -53,4 +53,4 @@
   #define GAZEBO_ROS_NODE_PUBLIC_TYPE
 #endif
 
-#endif  // GAZEBO_ROS_NODE__VISIBILITY_CONTROL_H_
+#endif  // GAZEBO_ROS__NODE_VISIBILITY_CONTROL_H_

--- a/gazebo_ros/include/gazebo_ros/utils.hpp
+++ b/gazebo_ros/include/gazebo_ros/utils.hpp
@@ -18,6 +18,7 @@
 #include <gazebo/common/Time.hh>
 #include <gazebo/sensors/Noise.hh>
 #include <gazebo/sensors/Sensor.hh>
+#include <gazebo_ros/utils_visibility_control.h>
 
 #include <string>
 
@@ -37,12 +38,14 @@ namespace gazebo_ros
 /// \return If the model is Gaussian, return the square of the standard deviation.
 /// \return If the model is no noise, return 0.
 /// \return If the model is custom, return -1
+GAZEBO_ROS_UTILS_PUBLIC
 double NoiseVariance(const gazebo::sensors::Noise & _noise);
 
 /// Get the variance of a gazebo sensor noise model
 /// \param[in] _noise_ptr Shared pointer to the gazebo noise model
 /// \return If the pointer is nullptr, return 0.
 /// \return Otherwise, returns the same as @ref NoiseVariance(const gazebo::sensors::Noise &).
+GAZEBO_ROS_UTILS_PUBLIC
 double NoiseVariance(const gazebo::sensors::NoisePtr & _noise_ptr);
 
 /// Gets the base name of a gazebo scoped name
@@ -51,6 +54,7 @@ double NoiseVariance(const gazebo::sensors::NoisePtr & _noise_ptr);
 /// \return Input string with all base scopes removed, see example
 /// \todo Deprecate once with is implemented in gazebo/ignition/sdf.
 ///       See: https://bitbucket.org/osrf/gazebo/issues/1735/add-helper-functions-to-handle-scoped
+GAZEBO_ROS_UTILS_PUBLIC
 std::string ScopedNameBase(const std::string & str);
 
 /// Selects an appropriate tf frame id for a gazebo sensor
@@ -62,10 +66,11 @@ std::string ScopedNameBase(const std::string & str);
 /// \param[in] _sensor The gazebo sensor which the frame should be in
 /// \param[in] _sdf SDF pointer which may contain a tag to override the frame id
 /// \return The string representing the tf frame of the sensor
+GAZEBO_ROS_UTILS_PUBLIC
 std::string SensorFrameID(const gazebo::sensors::Sensor & _sensor, const sdf::Element & _sdf);
 
 /// Helper class used to throttle something to a given rate
-class Throttler
+class GAZEBO_ROS_UTILS_PUBLIC Throttler
 {
 public:
   /// Create a throttler with a frequency

--- a/gazebo_ros/include/gazebo_ros/utils_visibility_control.h
+++ b/gazebo_ros/include/gazebo_ros/utils_visibility_control.h
@@ -19,8 +19,8 @@
  * library cannot have, but the consuming code must have inorder to link.
  */
 
-#ifndef GAZEBO_ROS_UTILS__VISIBILITY_CONTROL_H_
-#define GAZEBO_ROS_UTILS__VISIBILITY_CONTROL_H_
+#ifndef GAZEBO_ROS__UTILS_VISIBILITY_CONTROL_H_
+#define GAZEBO_ROS__UTILS_VISIBILITY_CONTROL_H_
 
 // This logic was borrowed (then namespaced) from the examples on the gcc wiki:
 //     https://gcc.gnu.org/wiki/Visibility
@@ -53,4 +53,4 @@
   #define GAZEBO_ROS_UTILS_PUBLIC_TYPE
 #endif
 
-#endif  // GAZEBO_ROS_UTILS__VISIBILITY_CONTROL_H_
+#endif  // GAZEBO_ROS__UTILS_VISIBILITY_CONTROL_H_

--- a/gazebo_ros/include/gazebo_ros/utils_visibility_control.h
+++ b/gazebo_ros/include/gazebo_ros/utils_visibility_control.h
@@ -1,0 +1,56 @@
+// Copyright 2020 Microsoft Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* This header must be included by all rclcpp headers which declare symbols
+ * which are defined in the rclcpp library. When not building the rclcpp
+ * library, i.e. when using the headers in other package's code, the contents
+ * of this header change the visibility of certain symbols which the rclcpp
+ * library cannot have, but the consuming code must have inorder to link.
+ */
+
+#ifndef GAZEBO_ROS_UTILS__VISIBILITY_CONTROL_H_
+#define GAZEBO_ROS_UTILS__VISIBILITY_CONTROL_H_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define GAZEBO_ROS_UTILS_EXPORT __attribute__ ((dllexport))
+    #define GAZEBO_ROS_UTILS_IMPORT __attribute__ ((dllimport))
+  #else
+    #define GAZEBO_ROS_UTILS_EXPORT __declspec(dllexport)
+    #define GAZEBO_ROS_UTILS_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef GAZEBO_ROS_UTILS_BUILDING_DLL
+    #define GAZEBO_ROS_UTILS_PUBLIC GAZEBO_ROS_UTILS_EXPORT
+  #else
+    #define GAZEBO_ROS_UTILS_PUBLIC GAZEBO_ROS_UTILS_IMPORT
+  #endif
+  #define GAZEBO_ROS_UTILS_PUBLIC_TYPE GAZEBO_ROS_UTILS_PUBLIC
+  #define GAZEBO_ROS_UTILS_LOCAL
+#else
+  #define GAZEBO_ROS_UTILS_EXPORT __attribute__ ((visibility("default")))
+  #define GAZEBO_ROS_UTILS_IMPORT
+  #if __GNUC__ >= 4
+    #define GAZEBO_ROS_UTILS_PUBLIC __attribute__ ((visibility("default")))
+    #define GAZEBO_ROS_UTILS_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define GAZEBO_ROS_UTILS_PUBLIC
+    #define GAZEBO_ROS_UTILS_LOCAL
+  #endif
+  #define GAZEBO_ROS_UTILS_PUBLIC_TYPE
+#endif
+
+#endif  // GAZEBO_ROS_UTILS__VISIBILITY_CONTROL_H_


### PR DESCRIPTION
This is a minimum fix to unblock Windows build breaks.

* Adding visibility control headers.
* Minimizing Windows header namespace exposure.
* Explicitly defining `_USE_MATH_DEFINES` to use math constants, like `M_PI`.
* Adding missing linkage dependency for `gazebo_ros_bumper`.
* Adding missing header inclusion for `gazebo_ros_ray_sensor.cpp`.