### PR TITLE
[forward port to noetic] Add node required parameter to empty world (#1074)

### DIFF
--- a/gazebo_ros/launch/empty_world.launch
+++ b/gazebo_ros/launch/empty_world.launch
@@ -20,6 +20,8 @@
   <arg name="use_clock_frequency" default="false"/>
   <arg name="pub_clock_frequency" default="100"/>
   <arg name="enable_ros_network" default="true" />
+  <arg name="server_required" default="false"/>
+  <arg name="gui_required" default="false"/>
 
   <!-- set use_sim_time flag -->
   <param name="/use_sim_time" value="$(arg use_sim_time)"/>
@@ -42,11 +44,13 @@
     <param name="gazebo/enable_ros_network" value="$(arg enable_ros_network)" />
   </group>
   <node name="gazebo" pkg="gazebo_ros" type="$(arg script_type)" respawn="$(arg respawn_gazebo)" output="$(arg output)"
-	args="$(arg command_arg1) $(arg command_arg2) $(arg command_arg3) -e $(arg physics) $(arg extra_gazebo_args) $(arg world_name)" />
+	args="$(arg command_arg1) $(arg command_arg2) $(arg command_arg3) -e $(arg physics) $(arg extra_gazebo_args) $(arg world_name)"
+  required="$(arg server_required)" />
 
   <!-- start gazebo client -->
   <group if="$(arg gui)">
-    <node name="gazebo_gui" pkg="gazebo_ros" type="gzclient" respawn="false" output="$(arg output)" args="$(arg command_arg3)"/>
+    <node name="gazebo_gui" pkg="gazebo_ros" type="gzclient" respawn="false" output="$(arg output)" args="$(arg command_arg3)"
+    required="$(arg gui_required)"/>
   </group>
 
 </launch>


### PR DESCRIPTION
Forward port from #1074 in kinetic-devel to noetic-devel.

Tested in Noetic + gazebo11 + Ubuntu 20.04.
Similar to Melodic (#1078), gzclient requires `kill` - closing GUI isn't enough.

Signed-off-by: Mabel Zhang <mabel@openrobotics.org>