### PR TITLE
gazebo_ros_wheel_slip: remove unused member data

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_wheel_slip.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_wheel_slip.h
@@ -68,9 +68,6 @@ class GazeboRosWheelSlip : public WheelSlipPlugin
     /// \brief pointer to ros node
     private: ros::NodeHandle *rosnode_;
 
-    /// \brief Subscriber to detach control messages.
-    private: ros::Subscriber detachSub_;
-
     /// \brief Dynamic reconfigure server.
     private: dynamic_reconfigure::Server<gazebo_plugins::WheelSlipConfig>
                     *dyn_srv_;


### PR DESCRIPTION
There was an unused subscriber `detachSub_` as a member variable in the `gazebo_ros_wheel_slip` class that sneaked past in #995. It hasn't been released yet, so it won't break ABI if we remove it now.