### PR TITLE
Make QoS for publishers and subscriptions configurable 

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_ackermann_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ackermann_drive.cpp
@@ -210,7 +210,7 @@ void GazeboRosAckermannDrive::Load(gazebo::physics::ModelPtr _model, sdf::Elemen
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
   // Get QoS profiles
-  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+  const gazebo_ros::QoS & qos = impl_->ros_node_->get_qos();
 
   impl_->joints_.resize(7);
 

--- a/gazebo_plugins/src/gazebo_ros_ackermann_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ackermann_drive.cpp
@@ -209,6 +209,9 @@ void GazeboRosAckermannDrive::Load(gazebo::physics::ModelPtr _model, sdf::Elemen
   // Initialize ROS node
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
+  // Get QoS profiles
+  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+
   impl_->joints_.resize(7);
 
   auto steering_wheel_joint =
@@ -355,7 +358,7 @@ void GazeboRosAckermannDrive::Load(gazebo::physics::ModelPtr _model, sdf::Elemen
   impl_->last_update_time_ = _model->GetWorld()->SimTime();
 
   impl_->cmd_vel_sub_ = impl_->ros_node_->create_subscription<geometry_msgs::msg::Twist>(
-    "cmd_vel", rclcpp::QoS(rclcpp::KeepLast(1)),
+    "cmd_vel", qos.get_subscription_qos("cmd_vel", rclcpp::QoS(1)),
     std::bind(&GazeboRosAckermannDrivePrivate::OnCmdVel, impl_.get(), std::placeholders::_1));
 
   RCLCPP_INFO(
@@ -369,7 +372,7 @@ void GazeboRosAckermannDrive::Load(gazebo::physics::ModelPtr _model, sdf::Elemen
   impl_->publish_odom_ = _sdf->Get<bool>("publish_odom", false).first;
   if (impl_->publish_odom_) {
     impl_->odometry_pub_ = impl_->ros_node_->create_publisher<nav_msgs::msg::Odometry>(
-      "odom", rclcpp::QoS(rclcpp::KeepLast(1)));
+      "odom", qos.get_publisher_qos("odom", rclcpp::QoS(1)));
 
     RCLCPP_INFO(
       impl_->ros_node_->get_logger(), "Advertise odometry on [%s]",
@@ -380,7 +383,7 @@ void GazeboRosAckermannDrive::Load(gazebo::physics::ModelPtr _model, sdf::Elemen
   impl_->publish_distance_ = _sdf->Get<bool>("publish_distance", false).first;
   if (impl_->publish_distance_) {
     impl_->distance_pub_ = impl_->ros_node_->create_publisher<std_msgs::msg::Float32>(
-      "distance", rclcpp::QoS(rclcpp::KeepLast(1)));
+      "distance", qos.get_publisher_qos("distance", rclcpp::QoS(1)));
 
     RCLCPP_INFO(
       impl_->ros_node_->get_logger(), "Advertise distance on [%s]",

--- a/gazebo_plugins/src/gazebo_ros_bumper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_bumper.cpp
@@ -81,7 +81,7 @@ void GazeboRosBumper::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
   }
 
   // Get QoS profiles
-  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+  const gazebo_ros::QoS & qos = impl_->ros_node_->get_qos();
 
   // Contact state publisher
   impl_->pub_ = impl_->ros_node_->create_publisher<gazebo_msgs::msg::ContactsState>(

--- a/gazebo_plugins/src/gazebo_ros_bumper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_bumper.cpp
@@ -80,9 +80,12 @@ void GazeboRosBumper::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
     return;
   }
 
+  // Get QoS profiles
+  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+
   // Contact state publisher
   impl_->pub_ = impl_->ros_node_->create_publisher<gazebo_msgs::msg::ContactsState>(
-    "bumper_states", rclcpp::SensorDataQoS());
+    "bumper_states", qos.get_publisher_qos("bumper_states", rclcpp::SensorDataQoS()));
 
   RCLCPP_INFO(
     impl_->ros_node_->get_logger(), "Publishing contact states to [%s]",

--- a/gazebo_plugins/src/gazebo_ros_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera.cpp
@@ -147,6 +147,9 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
   // Initialize ROS node
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
+  // Get QoS profiles
+  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+
   if (std::dynamic_pointer_cast<gazebo::sensors::MultiCameraSensor>(_sensor)) {
     impl_->sensor_type_ = GazeboRosCameraPrivate::MULTICAMERA;
     MultiCameraPlugin::Load(_sensor, _sdf);
@@ -174,9 +177,12 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
   if (impl_->sensor_type_ != GazeboRosCameraPrivate::MULTICAMERA) {
     // Image publisher
     // TODO(louise) Migrate image_connect logic once SubscriberStatusCallback is ported to ROS2
+    const std::string camera_topic = impl_->camera_name_ + "/image_raw";
     impl_->image_pub_.push_back(
       image_transport::create_publisher(
-        impl_->ros_node_.get(), impl_->camera_name_ + "/image_raw"));
+        impl_->ros_node_.get(),
+        camera_topic,
+        qos.get_publisher_qos(camera_topic).get_rmw_qos_profile()));
 
     // TODO(louise) Uncomment this once image_transport::Publisher has a function to return the
     // full topic.
@@ -185,10 +191,10 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
 
     // Camera info publisher
     // TODO(louise) Migrate ImageConnect logic once SubscriberStatusCallback is ported to ROS2
+    const std::string camera_info_topic = impl_->camera_name_ + "/camera_info";
     impl_->camera_info_pub_.push_back(
       impl_->ros_node_->create_publisher<sensor_msgs::msg::CameraInfo>(
-        impl_->camera_name_ + "/camera_info",
-        rclcpp::SensorDataQoS()));
+        camera_info_topic, qos.get_publisher_qos(camera_info_topic, rclcpp::SensorDataQoS())));
 
     RCLCPP_INFO(
       impl_->ros_node_->get_logger(), "Publishing camera info to [%s]",
@@ -196,22 +202,25 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
 
   } else {
     for (uint64_t i = 0; i < impl_->num_cameras_; ++i) {
+      const std::string camera_topic =
+        impl_->camera_name_ + "/" + MultiCameraPlugin::camera_[i]->Name() + "/image_raw";
       // Image publisher
       impl_->image_pub_.push_back(
         image_transport::create_publisher(
           impl_->ros_node_.get(),
-          impl_->camera_name_ + "/" + MultiCameraPlugin::camera_[i]->Name() + "/image_raw"));
+          camera_topic, qos.get_publisher_qos(camera_topic).get_rmw_qos_profile()));
 
       // RCLCPP_INFO(
       //   impl_->ros_node_->get_logger(), "Publishing %s camera images to [%s]",
       //   MultiCameraPlugin::camera_[i]->Name().c_str(),
       //   impl_->image_pub_.back().getTopic());
 
+      const std::string camera_info_topic =
+        impl_->camera_name_ + "/" + MultiCameraPlugin::camera_[i]->Name() + "/camera_info";
       // Camera info publisher
       impl_->camera_info_pub_.push_back(
         impl_->ros_node_->create_publisher<sensor_msgs::msg::CameraInfo>(
-          impl_->camera_name_ + "/" + MultiCameraPlugin::camera_[i]->Name() + "/camera_info",
-          rclcpp::SensorDataQoS()));
+          camera_info_topic, qos.get_publisher_qos(camera_info_topic, rclcpp::SensorDataQoS())));
 
       RCLCPP_INFO(
         impl_->ros_node_->get_logger(), "Publishing %s camera info to [%s]",
@@ -221,25 +230,30 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
   }
 
   if (impl_->sensor_type_ == GazeboRosCameraPrivate::DEPTH) {
+    const std::string depth_topic = impl_->camera_name_ + "/depth/image_raw";
     // Depth image publisher
     impl_->depth_image_pub_ = image_transport::create_publisher(
-      impl_->ros_node_.get(), impl_->camera_name_ + "/depth/image_raw");
+      impl_->ros_node_.get(),
+      depth_topic,
+      qos.get_publisher_qos(depth_topic).get_rmw_qos_profile());
 
     // RCLCPP_INFO(impl_->ros_node_->get_logger(), "Publishing depth images to [%s]",
     //   impl_->depth_image_pub_.getTopic().c_str());
 
+    const std::string depth_info_topic = impl_->camera_name_ + "/depth/camera_info";
     // Depth info publisher
     impl_->depth_camera_info_pub_ =
       impl_->ros_node_->create_publisher<sensor_msgs::msg::CameraInfo>(
-      impl_->camera_name_ + "/depth/camera_info", rclcpp::QoS(rclcpp::KeepLast(1)));
+      depth_info_topic, qos.get_publisher_qos(depth_info_topic, rclcpp::QoS(1)));
 
     RCLCPP_INFO(
       impl_->ros_node_->get_logger(), "Publishing depth camera info to [%s]",
       impl_->depth_camera_info_pub_->get_topic_name());
 
+    const std::string point_cloud_topic = impl_->camera_name_ + "/points";
     // Point cloud publisher
     impl_->point_cloud_pub_ = impl_->ros_node_->create_publisher<sensor_msgs::msg::PointCloud2>(
-      impl_->camera_name_ + "/points", rclcpp::QoS(rclcpp::KeepLast(1)));
+      point_cloud_topic, qos.get_publisher_qos(point_cloud_topic, rclcpp::QoS(1)));
 
     RCLCPP_INFO(
       impl_->ros_node_->get_logger(), "Publishing pointcloud to [%s]",
@@ -248,9 +262,9 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
 
   // Trigger
   if (_sdf->Get<bool>("triggered", false).first) {
+    const std::string trigger_topic = impl_->camera_name_ + "/image_trigger";
     impl_->trigger_sub_ = impl_->ros_node_->create_subscription<std_msgs::msg::Empty>(
-      impl_->camera_name_ + "/image_trigger",
-      rclcpp::QoS(rclcpp::KeepLast(1)),
+      trigger_topic, qos.get_subscription_qos(trigger_topic, rclcpp::QoS(1)),
       std::bind(&GazeboRosCamera::OnTrigger, this, std::placeholders::_1));
 
     RCLCPP_INFO(

--- a/gazebo_plugins/src/gazebo_ros_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera.cpp
@@ -148,7 +148,7 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
   // Get QoS profiles
-  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+  const gazebo_ros::QoS & qos = impl_->ros_node_->get_qos();
 
   if (std::dynamic_pointer_cast<gazebo::sensors::MultiCameraSensor>(_sensor)) {
     impl_->sensor_type_ = GazeboRosCameraPrivate::MULTICAMERA;

--- a/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
@@ -236,6 +236,9 @@ void GazeboRosDiffDrive::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr 
   // Initialize ROS node
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
+  // Get QoS profiles
+  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+
   // Get number of wheel pairs in the model
   impl_->num_wheel_pairs_ = static_cast<unsigned int>(_sdf->Get<int>("num_wheel_pairs", 1).first);
 
@@ -344,7 +347,7 @@ void GazeboRosDiffDrive::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr 
   impl_->last_update_time_ = _model->GetWorld()->SimTime();
 
   impl_->cmd_vel_sub_ = impl_->ros_node_->create_subscription<geometry_msgs::msg::Twist>(
-    "cmd_vel", rclcpp::QoS(rclcpp::KeepLast(1)),
+    "cmd_vel", qos.get_subscription_qos("cmd_vel", rclcpp::QoS(1)),
     std::bind(&GazeboRosDiffDrivePrivate::OnCmdVel, impl_.get(), std::placeholders::_1));
 
   RCLCPP_INFO(
@@ -361,7 +364,7 @@ void GazeboRosDiffDrive::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr 
   impl_->publish_odom_ = _sdf->Get<bool>("publish_odom", false).first;
   if (impl_->publish_odom_) {
     impl_->odometry_pub_ = impl_->ros_node_->create_publisher<nav_msgs::msg::Odometry>(
-      "odom", rclcpp::QoS(rclcpp::KeepLast(1)));
+      "odom", qos.get_publisher_qos("odom", rclcpp::QoS(1)));
 
     RCLCPP_INFO(
       impl_->ros_node_->get_logger(), "Advertise odometry on [%s]",

--- a/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
@@ -237,7 +237,7 @@ void GazeboRosDiffDrive::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr 
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
   // Get QoS profiles
-  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+  const gazebo_ros::QoS & qos = impl_->ros_node_->get_qos();
 
   // Get number of wheel pairs in the model
   impl_->num_wheel_pairs_ = static_cast<unsigned int>(_sdf->Get<int>("num_wheel_pairs", 1).first);

--- a/gazebo_plugins/src/gazebo_ros_elevator.cpp
+++ b/gazebo_plugins/src/gazebo_ros_elevator.cpp
@@ -54,7 +54,7 @@ void GazeboRosElevator::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr _
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
   // Get QoS profiles
-  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+  const gazebo_ros::QoS & qos = impl_->ros_node_->get_qos();
 
   impl_->sub_ = impl_->ros_node_->create_subscription<std_msgs::msg::String>(
     "elevator", qos.get_subscription_qos("elevator", rclcpp::QoS(1)),

--- a/gazebo_plugins/src/gazebo_ros_elevator.cpp
+++ b/gazebo_plugins/src/gazebo_ros_elevator.cpp
@@ -53,8 +53,11 @@ void GazeboRosElevator::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr _
   // Initialize ROS node
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
+  // Get QoS profiles
+  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+
   impl_->sub_ = impl_->ros_node_->create_subscription<std_msgs::msg::String>(
-    "elevator", rclcpp::QoS(rclcpp::KeepLast(1)),
+    "elevator", qos.get_subscription_qos("elevator", rclcpp::QoS(1)),
     std::bind(&GazeboRosElevator::OnElevator, this, std::placeholders::_1));
 
   RCLCPP_INFO(impl_->ros_node_->get_logger(), "Subscribed to [%s]", impl_->sub_->get_topic_name());

--- a/gazebo_plugins/src/gazebo_ros_force.cpp
+++ b/gazebo_plugins/src/gazebo_ros_force.cpp
@@ -97,7 +97,7 @@ void GazeboRosForce::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf)
   impl_->ros_node_ = gazebo_ros::Node::Get(sdf);
 
   // Get QoS profiles
-  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+  const gazebo_ros::QoS & qos = impl_->ros_node_->get_qos();
 
   impl_->wrench_sub_ = impl_->ros_node_->create_subscription<geometry_msgs::msg::Wrench>(
     "gazebo_ros_force", qos.get_subscription_qos("gazebo_ros_force", rclcpp::SystemDefaultsQoS()),

--- a/gazebo_plugins/src/gazebo_ros_force.cpp
+++ b/gazebo_plugins/src/gazebo_ros_force.cpp
@@ -96,8 +96,11 @@ void GazeboRosForce::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf)
   // Subscribe to wrench messages
   impl_->ros_node_ = gazebo_ros::Node::Get(sdf);
 
+  // Get QoS profiles
+  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+
   impl_->wrench_sub_ = impl_->ros_node_->create_subscription<geometry_msgs::msg::Wrench>(
-    "gazebo_ros_force", rclcpp::SystemDefaultsQoS(),
+    "gazebo_ros_force", qos.get_subscription_qos("gazebo_ros_force", rclcpp::SystemDefaultsQoS()),
     std::bind(&GazeboRosForce::OnRosWrenchMsg, this, std::placeholders::_1));
 
   // Callback on every iteration

--- a/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
@@ -92,7 +92,7 @@ void GazeboRosFTSensor::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr _
   impl_->rosnode_ = gazebo_ros::Node::Get(_sdf);
 
   // Get QoS profiles
-  const gazebo_ros::QoS qos = impl_->rosnode_->get_qos();
+  const gazebo_ros::QoS & qos = impl_->rosnode_->get_qos();
 
   if (!_sdf->HasElement("update_rate")) {
     RCLCPP_DEBUG(

--- a/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
@@ -91,6 +91,9 @@ void GazeboRosFTSensor::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr _
   // Initialize ROS node
   impl_->rosnode_ = gazebo_ros::Node::Get(_sdf);
 
+  // Get QoS profiles
+  const gazebo_ros::QoS qos = impl_->rosnode_->get_qos();
+
   if (!_sdf->HasElement("update_rate")) {
     RCLCPP_DEBUG(
       impl_->rosnode_->get_logger(),
@@ -151,8 +154,7 @@ void GazeboRosFTSensor::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr _
   impl_->gaussian_noise_ = _sdf->Get<double>("gaussian_noise", 0.0).first;
 
   impl_->pub_ = impl_->rosnode_->create_publisher<geometry_msgs::msg::WrenchStamped>(
-    "wrench",
-    rclcpp::QoS(rclcpp::KeepLast(1)));
+    "wrench", qos.get_publisher_qos("wrench", rclcpp::QoS(1)));
 
   RCLCPP_INFO(
     impl_->rosnode_->get_logger(),

--- a/gazebo_plugins/src/gazebo_ros_gps_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_gps_sensor.cpp
@@ -60,7 +60,7 @@ void GazeboRosGpsSensor::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPt
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
   // Get QoS profiles
-  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+  const gazebo_ros::QoS & qos = impl_->ros_node_->get_qos();
 
   impl_->sensor_ = std::dynamic_pointer_cast<gazebo::sensors::GpsSensor>(_sensor);
   if (!impl_->sensor_) {

--- a/gazebo_plugins/src/gazebo_ros_gps_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_gps_sensor.cpp
@@ -59,6 +59,9 @@ void GazeboRosGpsSensor::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPt
 {
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
+  // Get QoS profiles
+  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+
   impl_->sensor_ = std::dynamic_pointer_cast<gazebo::sensors::GpsSensor>(_sensor);
   if (!impl_->sensor_) {
     RCLCPP_ERROR(impl_->ros_node_->get_logger(), "Parent is not a GPS sensor. Exiting.");
@@ -66,7 +69,7 @@ void GazeboRosGpsSensor::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPt
   }
 
   impl_->pub_ = impl_->ros_node_->create_publisher<sensor_msgs::msg::NavSatFix>(
-    "~/out", rclcpp::SensorDataQoS());
+    "~/out", qos.get_publisher_qos("~/out", rclcpp::SensorDataQoS()));
 
   // Create message to be reused
   auto msg = std::make_shared<sensor_msgs::msg::NavSatFix>();

--- a/gazebo_plugins/src/gazebo_ros_harness.cpp
+++ b/gazebo_plugins/src/gazebo_ros_harness.cpp
@@ -60,7 +60,7 @@ void GazeboRosHarness::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr _s
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
   // Get QoS profiles
-  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+  const gazebo_ros::QoS & qos = impl_->ros_node_->get_qos();
 
   impl_->model_ = _model->GetName();
 

--- a/gazebo_plugins/src/gazebo_ros_harness.cpp
+++ b/gazebo_plugins/src/gazebo_ros_harness.cpp
@@ -59,10 +59,14 @@ void GazeboRosHarness::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr _s
   // Initialize ROS node
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
+  // Get QoS profiles
+  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+
   impl_->model_ = _model->GetName();
 
+  const std::string velocity_topic = impl_->model_ + "/harness/velocity";
   impl_->vel_sub_ = impl_->ros_node_->create_subscription<std_msgs::msg::Float32>(
-    impl_->model_ + "/harness/velocity", rclcpp::QoS(rclcpp::KeepLast(1)),
+    velocity_topic, qos.get_subscription_qos(velocity_topic, rclcpp::QoS(1)),
     [this](const std_msgs::msg::Float32::ConstSharedPtr msg) {
       SetWinchVelocity(msg->data);
     });
@@ -70,8 +74,9 @@ void GazeboRosHarness::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr _s
   RCLCPP_INFO(
     impl_->ros_node_->get_logger(), "Subscribed to [%s]", impl_->vel_sub_->get_topic_name());
 
+  const std::string detach_topic = impl_->model_ + "/harness/detach";
   impl_->detach_sub_ = impl_->ros_node_->create_subscription<std_msgs::msg::Empty>(
-    impl_->model_ + "/harness/detach", rclcpp::QoS(rclcpp::KeepLast(1)),
+    detach_topic, qos.get_subscription_qos(detach_topic, rclcpp::QoS(1)),
     std::bind(&GazeboRosHarness::OnDetach, this, std::placeholders::_1));
 
   RCLCPP_INFO(

--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -60,14 +60,17 @@ void GazeboRosImuSensor::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPt
 {
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
+  // Get QoS profiles
+  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+
   impl_->sensor_ = std::dynamic_pointer_cast<gazebo::sensors::ImuSensor>(_sensor);
   if (!impl_->sensor_) {
     RCLCPP_ERROR(impl_->ros_node_->get_logger(), "Parent is not an imu sensor. Exiting.");
     return;
   }
 
-  impl_->pub_ =
-    impl_->ros_node_->create_publisher<sensor_msgs::msg::Imu>("~/out", rclcpp::SensorDataQoS());
+  impl_->pub_ = impl_->ros_node_->create_publisher<sensor_msgs::msg::Imu>(
+    "~/out", qos.get_publisher_qos("~/out", rclcpp::SensorDataQoS()));
 
   // Create message to be reused
   auto msg = std::make_shared<sensor_msgs::msg::Imu>();

--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -61,7 +61,7 @@ void GazeboRosImuSensor::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPt
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
   // Get QoS profiles
-  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+  const gazebo_ros::QoS & qos = impl_->ros_node_->get_qos();
 
   impl_->sensor_ = std::dynamic_pointer_cast<gazebo::sensors::ImuSensor>(_sensor);
   if (!impl_->sensor_) {

--- a/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
@@ -109,6 +109,9 @@ void GazeboRosJointPoseTrajectory::Load(gazebo::physics::ModelPtr model, sdf::El
   // Initialize ROS node
   impl_->ros_node_ = gazebo_ros::Node::Get(sdf);
 
+  // Get QoS profiles
+  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+
   // Update rate
   auto update_rate = sdf->Get<double>("update_rate", 100.0).first;
   if (update_rate > 0.0) {
@@ -120,7 +123,7 @@ void GazeboRosJointPoseTrajectory::Load(gazebo::physics::ModelPtr model, sdf::El
 
   // Set Joint Trajectory Callback
   impl_->sub_ = impl_->ros_node_->create_subscription<trajectory_msgs::msg::JointTrajectory>(
-    "set_joint_trajectory", rclcpp::QoS(rclcpp::KeepLast(1)),
+    "set_joint_trajectory", qos.get_subscription_qos("set_joint_trajectory", rclcpp::QoS(1)),
     std::bind(
       &GazeboRosJointPoseTrajectoryPrivate::SetJointTrajectory,
       impl_.get(), std::placeholders::_1));

--- a/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
@@ -110,7 +110,7 @@ void GazeboRosJointPoseTrajectory::Load(gazebo::physics::ModelPtr model, sdf::El
   impl_->ros_node_ = gazebo_ros::Node::Get(sdf);
 
   // Get QoS profiles
-  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+  const gazebo_ros::QoS & qos = impl_->ros_node_->get_qos();
 
   // Update rate
   auto update_rate = sdf->Get<double>("update_rate", 100.0).first;

--- a/gazebo_plugins/src/gazebo_ros_joint_state_publisher.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_state_publisher.cpp
@@ -88,7 +88,7 @@ void GazeboRosJointStatePublisher::Load(gazebo::physics::ModelPtr model, sdf::El
   impl_->ros_node_ = gazebo_ros::Node::Get(sdf);
 
   // Get QoS profiles
-  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+  const gazebo_ros::QoS & qos = impl_->ros_node_->get_qos();
 
   // Joints
   if (!sdf->HasElement("joint_name")) {

--- a/gazebo_plugins/src/gazebo_ros_joint_state_publisher.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_state_publisher.cpp
@@ -87,6 +87,9 @@ void GazeboRosJointStatePublisher::Load(gazebo::physics::ModelPtr model, sdf::El
   // ROS node
   impl_->ros_node_ = gazebo_ros::Node::Get(sdf);
 
+  // Get QoS profiles
+  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+
   // Joints
   if (!sdf->HasElement("joint_name")) {
     RCLCPP_ERROR(impl_->ros_node_->get_logger(), "Plugin missing <joint_name>s");
@@ -136,7 +139,7 @@ void GazeboRosJointStatePublisher::Load(gazebo::physics::ModelPtr model, sdf::El
 
   // Joint state publisher
   impl_->joint_state_pub_ = impl_->ros_node_->create_publisher<sensor_msgs::msg::JointState>(
-    "joint_states", 1000);
+    "joint_states", qos.get_publisher_qos("joint_states", rclcpp::QoS(1000)));
 
   // Callback on every iteration
   impl_->update_connection_ = gazebo::event::Events::ConnectWorldUpdateBegin(

--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -93,7 +93,7 @@ void GazeboRosP3D::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf)
   impl_->ros_node_ = gazebo_ros::Node::Get(sdf);
 
   // Get QoS profiles
-  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+  const gazebo_ros::QoS & qos = impl_->ros_node_->get_qos();
 
   if (!sdf->HasElement("update_rate")) {
     RCLCPP_DEBUG(

--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -92,6 +92,9 @@ void GazeboRosP3D::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf)
   // Configure the plugin from the SDF file
   impl_->ros_node_ = gazebo_ros::Node::Get(sdf);
 
+  // Get QoS profiles
+  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+
   if (!sdf->HasElement("update_rate")) {
     RCLCPP_DEBUG(
       impl_->ros_node_->get_logger(), "p3d plugin missing <update_rate>, defaults to 0.0"
@@ -117,7 +120,7 @@ void GazeboRosP3D::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf)
   }
 
   impl_->pub_ = impl_->ros_node_->create_publisher<nav_msgs::msg::Odometry>(
-    impl_->topic_name_, rclcpp::SensorDataQoS());
+    impl_->topic_name_, qos.get_publisher_qos(impl_->topic_name_, rclcpp::SensorDataQoS()));
   impl_->topic_name_ = impl_->pub_->get_topic_name();
   RCLCPP_DEBUG(
     impl_->ros_node_->get_logger(), "Publishing on topic [%s]", impl_->topic_name_.c_str());

--- a/gazebo_plugins/src/gazebo_ros_planar_move.cpp
+++ b/gazebo_plugins/src/gazebo_ros_planar_move.cpp
@@ -132,7 +132,7 @@ void GazeboRosPlanarMove::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
   // Get QoS profiles
-  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+  const gazebo_ros::QoS & qos = impl_->ros_node_->get_qos();
 
   // Odometry
   impl_->odometry_frame_ = _sdf->Get<std::string>("odometry_frame", "odom").first;

--- a/gazebo_plugins/src/gazebo_ros_planar_move.cpp
+++ b/gazebo_plugins/src/gazebo_ros_planar_move.cpp
@@ -131,6 +131,9 @@ void GazeboRosPlanarMove::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr
   // Initialize ROS node
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
+  // Get QoS profiles
+  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+
   // Odometry
   impl_->odometry_frame_ = _sdf->Get<std::string>("odometry_frame", "odom").first;
   impl_->robot_base_frame_ = _sdf->Get<std::string>("robot_base_frame", "base_footprint").first;
@@ -154,7 +157,7 @@ void GazeboRosPlanarMove::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr
   impl_->last_publish_time_ = impl_->world_->SimTime();
 
   impl_->cmd_vel_sub_ = impl_->ros_node_->create_subscription<geometry_msgs::msg::Twist>(
-    "cmd_vel", rclcpp::QoS(rclcpp::KeepLast(1)),
+    "cmd_vel", qos.get_subscription_qos("cmd_vel", rclcpp::QoS(1)),
     std::bind(&GazeboRosPlanarMovePrivate::OnCmdVel, impl_.get(), std::placeholders::_1));
 
   RCLCPP_INFO(
@@ -165,7 +168,7 @@ void GazeboRosPlanarMove::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr
   impl_->publish_odom_ = _sdf->Get<bool>("publish_odom", true).first;
   if (impl_->publish_odom_) {
     impl_->odometry_pub_ = impl_->ros_node_->create_publisher<nav_msgs::msg::Odometry>(
-      "odom", rclcpp::QoS(rclcpp::KeepLast(1)));
+      "odom", qos.get_publisher_qos("odom", rclcpp::QoS(1)));
 
     RCLCPP_INFO(
       impl_->ros_node_->get_logger(), "Advertise odometry on [%s]",

--- a/gazebo_plugins/src/gazebo_ros_projector.cpp
+++ b/gazebo_plugins/src/gazebo_ros_projector.cpp
@@ -68,7 +68,7 @@ void GazeboRosProjector::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr 
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
   // Get QoS profiles
-  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+  const gazebo_ros::QoS & qos = impl_->ros_node_->get_qos();
 
   // Create gazebo transport node
   impl_->gazebo_node_ = boost::make_shared<gazebo::transport::Node>();

--- a/gazebo_plugins/src/gazebo_ros_projector.cpp
+++ b/gazebo_plugins/src/gazebo_ros_projector.cpp
@@ -67,6 +67,9 @@ void GazeboRosProjector::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr 
   // Initialize ROS node
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
+  // Get QoS profiles
+  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+
   // Create gazebo transport node
   impl_->gazebo_node_ = boost::make_shared<gazebo::transport::Node>();
   impl_->gazebo_node_->Init(_model->GetWorld()->Name());
@@ -85,7 +88,7 @@ void GazeboRosProjector::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr 
     "Controlling projector at [%s]", impl_->projector_pub_->GetTopic().c_str());
 
   impl_->toggle_sub_ = impl_->ros_node_->create_subscription<std_msgs::msg::Bool>(
-    "switch", rclcpp::QoS(rclcpp::KeepLast(1)),
+    "switch", qos.get_subscription_qos("switch", rclcpp::QoS(1)),
     std::bind(&GazeboRosProjectorPrivate::ToggleProjector, impl_.get(), std::placeholders::_1));
 
   RCLCPP_INFO(

--- a/gazebo_plugins/src/gazebo_ros_ray_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ray_sensor.cpp
@@ -104,7 +104,7 @@ void GazeboRosRaySensor::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPt
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
   // Get QoS profiles
-  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+  const gazebo_ros::QoS & qos = impl_->ros_node_->get_qos();
 
   // Get QoS profile for the publisher
   rclcpp::QoS pub_qos = qos.get_publisher_qos("~/out", rclcpp::SensorDataQoS());

--- a/gazebo_plugins/src/gazebo_ros_ray_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ray_sensor.cpp
@@ -103,6 +103,12 @@ void GazeboRosRaySensor::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPt
   // Create ros_node configured from sdf
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
+  // Get QoS profiles
+  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+
+  // Get QoS profile for the publisher
+  rclcpp::QoS pub_qos = qos.get_publisher_qos("~/out", rclcpp::SensorDataQoS());
+
   // Get tf frame for output
   impl_->frame_name_ = gazebo_ros::SensorFrameID(*_sensor, *_sdf);
 
@@ -111,21 +117,21 @@ void GazeboRosRaySensor::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPt
     RCLCPP_WARN(
       impl_->ros_node_->get_logger(), "missing <output_type>, defaults to sensor_msgs/PointCloud2");
     impl_->pub_ = impl_->ros_node_->create_publisher<sensor_msgs::msg::PointCloud2>(
-      "~/out", rclcpp::SensorDataQoS());
+      "~/out", pub_qos);
   } else {
     std::string output_type_string = _sdf->Get<std::string>("output_type");
     if (output_type_string == "sensor_msgs/LaserScan") {
       impl_->pub_ = impl_->ros_node_->create_publisher<sensor_msgs::msg::LaserScan>(
-        "~/out", rclcpp::SensorDataQoS());
+        "~/out", pub_qos);
     } else if (output_type_string == "sensor_msgs/PointCloud") {
       impl_->pub_ = impl_->ros_node_->create_publisher<sensor_msgs::msg::PointCloud>(
-        "~/out", rclcpp::SensorDataQoS());
+        "~/out", pub_qos);
     } else if (output_type_string == "sensor_msgs/PointCloud2") {
       impl_->pub_ = impl_->ros_node_->create_publisher<sensor_msgs::msg::PointCloud2>(
-        "~/out", rclcpp::SensorDataQoS());
+        "~/out", pub_qos);
     } else if (output_type_string == "sensor_msgs/Range") {
       impl_->pub_ = impl_->ros_node_->create_publisher<sensor_msgs::msg::Range>(
-        "~/out", rclcpp::SensorDataQoS());
+        "~/out", pub_qos);
     } else {
       RCLCPP_ERROR(
         impl_->ros_node_->get_logger(), "Invalid <output_type> [%s]", output_type_string.c_str());

--- a/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
@@ -239,7 +239,7 @@ void GazeboRosTricycleDrive::Load(gazebo::physics::ModelPtr _model, sdf::Element
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
   // Get QoS profiles
-  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+  const gazebo_ros::QoS & qos = impl_->ros_node_->get_qos();
 
   // Odometry
   impl_->odometry_frame_ = _sdf->Get<std::string>("odometry_frame", "odom").first;

--- a/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
@@ -238,6 +238,9 @@ void GazeboRosTricycleDrive::Load(gazebo::physics::ModelPtr _model, sdf::Element
   // Initialize ROS node
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
+  // Get QoS profiles
+  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+
   // Odometry
   impl_->odometry_frame_ = _sdf->Get<std::string>("odometry_frame", "odom").first;
   impl_->robot_base_frame_ = _sdf->Get<std::string>("robot_base_frame", "base_link").first;
@@ -326,7 +329,7 @@ void GazeboRosTricycleDrive::Load(gazebo::physics::ModelPtr _model, sdf::Element
   impl_->last_actuator_update_ = _model->GetWorld()->SimTime();
 
   impl_->cmd_vel_sub_ = impl_->ros_node_->create_subscription<geometry_msgs::msg::Twist>(
-    "cmd_vel", rclcpp::QoS(rclcpp::KeepLast(1)),
+    "cmd_vel", qos.get_subscription_qos("cmd_vel", rclcpp::QoS(1)),
     std::bind(&GazeboRosTricycleDrivePrivate::OnCmdVel, impl_.get(), std::placeholders::_1));
 
   RCLCPP_INFO(
@@ -337,7 +340,8 @@ void GazeboRosTricycleDrive::Load(gazebo::physics::ModelPtr _model, sdf::Element
   impl_->publish_wheel_joint_state_ = _sdf->Get<bool>("publish_wheel_joint_state", false).first;
   if (impl_->publish_wheel_joint_state_) {
     impl_->joint_state_publisher_ =
-      impl_->ros_node_->create_publisher<sensor_msgs::msg::JointState>("joint_states", 1000);
+      impl_->ros_node_->create_publisher<sensor_msgs::msg::JointState>(
+      "joint_states", qos.get_publisher_qos("joint_states", rclcpp::QoS(1000)));
     RCLCPP_INFO(
       impl_->ros_node_->get_logger(), "Advertise joint_states on [%s]",
       impl_->joint_state_publisher_->get_topic_name());
@@ -347,7 +351,7 @@ void GazeboRosTricycleDrive::Load(gazebo::physics::ModelPtr _model, sdf::Element
   impl_->publish_odom_ = _sdf->Get<bool>("publish_odom", false).first;
   if (impl_->publish_odom_) {
     impl_->odometry_pub_ = impl_->ros_node_->create_publisher<nav_msgs::msg::Odometry>(
-      "odom", rclcpp::QoS(rclcpp::KeepLast(1)));
+      "odom", qos.get_publisher_qos("odom", rclcpp::QoS(1)));
 
     RCLCPP_INFO(
       impl_->ros_node_->get_logger(), "Advertise odometry on [%s]",

--- a/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
@@ -97,7 +97,7 @@ void GazeboRosVacuumGripper::Load(gazebo::physics::ModelPtr _model, sdf::Element
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
   // Get QoS profiles
-  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+  const gazebo_ros::QoS & qos = impl_->ros_node_->get_qos();
 
   if (_sdf->HasElement("link_name")) {
     auto link = _sdf->Get<std::string>("link_name");

--- a/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
@@ -96,6 +96,9 @@ void GazeboRosVacuumGripper::Load(gazebo::physics::ModelPtr _model, sdf::Element
   // Initialize ROS node
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
 
+  // Get QoS profiles
+  const gazebo_ros::QoS qos = impl_->ros_node_->get_qos();
+
   if (_sdf->HasElement("link_name")) {
     auto link = _sdf->Get<std::string>("link_name");
     impl_->link_ = _model->GetLink(link);
@@ -126,7 +129,7 @@ void GazeboRosVacuumGripper::Load(gazebo::physics::ModelPtr _model, sdf::Element
 
   // Initialize publisher
   impl_->pub_ = impl_->ros_node_->create_publisher<std_msgs::msg::Bool>(
-    "grasping", rclcpp::QoS(rclcpp::KeepLast(1)));
+    "grasping", qos.get_publisher_qos("grasping", rclcpp::QoS(1)));
 
   RCLCPP_INFO(
     impl_->ros_node_->get_logger(),

--- a/gazebo_plugins/src/gazebo_ros_video.cpp
+++ b/gazebo_plugins/src/gazebo_ros_video.cpp
@@ -197,7 +197,7 @@ void GazeboRosVideo::Load(
   impl_->rosnode_ = gazebo_ros::Node::Get(_sdf);
 
   // Get QoS profiles
-  const gazebo_ros::QoS qos = impl_->rosnode_->get_qos();
+  const gazebo_ros::QoS & qos = impl_->rosnode_->get_qos();
 
   int height = _sdf->Get<int>("height", 240).first;
 

--- a/gazebo_plugins/src/gazebo_ros_video.cpp
+++ b/gazebo_plugins/src/gazebo_ros_video.cpp
@@ -196,6 +196,9 @@ void GazeboRosVideo::Load(
 {
   impl_->rosnode_ = gazebo_ros::Node::Get(_sdf);
 
+  // Get QoS profiles
+  const gazebo_ros::QoS qos = impl_->rosnode_->get_qos();
+
   int height = _sdf->Get<int>("height", 240).first;
 
   int width = _sdf->Get<int>("width", 320).first;
@@ -207,7 +210,7 @@ void GazeboRosVideo::Load(
   // Subscribe to the image topic
   impl_->camera_subscriber_ =
     impl_->rosnode_->create_subscription<sensor_msgs::msg::Image>(
-    "~/image_raw", rclcpp::QoS(rclcpp::KeepLast(1)),
+    "~/image_raw", qos.get_subscription_qos("~/image_raw", rclcpp::QoS(1)),
     std::bind(&GazeboRosVideoPrivate::processImage, impl_.get(), std::placeholders::_1));
 
   impl_->new_image_available_ = false;


### PR DESCRIPTION
Closes https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1079

This PR builds on top of https://github.com/ros-simulation/gazebo_ros_pkgs/pull/1091

Whenever a plugin creates a ROS publisher or subscription, use the QoS profile provided by the node for the given topic.
This enables users to override the QoS settings in SDF.