### PR TITLE
Use fallback instead of pkg-config for gazebo discovery

### DIFF
--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -23,11 +23,8 @@
 
   <build_depend>cmake_modules</build_depend>
   <build_depend>gazebo_dev</build_depend>
-  <!--
-    Need to use gazebo_dev since run script needs pkg-config
-    See: https://github.com/ros-simulation/gazebo_ros_pkgs/issues/323 for more info
-  -->
-  <exec_depend>gazebo_dev</exec_depend>
+
+  <exec_depend>gazebo</exec_depend>
   <depend>gazebo_msgs</depend>
   <depend>roslib</depend>
   <depend>roscpp</depend>

--- a/gazebo_ros/scripts/debug
+++ b/gazebo_ros/scripts/debug
@@ -18,5 +18,5 @@ then
     final="$final -s `catkin_find --first-only libgazebo_ros_api_plugin.$EXT`"
 fi
 
-setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
+find_gazebo
 . $setup_path/setup.sh && rosrun gazebo_ros gdbrun gzserver $final

--- a/gazebo_ros/scripts/gazebo
+++ b/gazebo_ros/scripts/gazebo
@@ -25,7 +25,7 @@ fi
 
 client_final="-g `catkin_find --first-only libgazebo_ros_paths_plugin.$EXT`"
 
-setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
+find_gazebo
 
 # source setup.sh, but keep local modifications to GAZEBO_MASTER_URI and GAZEBO_MODEL_DATABASE_URI
 desired_master_uri="$GAZEBO_MASTER_URI"

--- a/gazebo_ros/scripts/gzclient
+++ b/gazebo_ros/scripts/gzclient
@@ -23,7 +23,7 @@ then
     final="$final -g `catkin_find --first-only libgazebo_ros_api_plugin.$EXT`"
 fi
 
-setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
+find_gazebo
 
 # source setup.sh, but keep local modifications to GAZEBO_MASTER_URI and GAZEBO_MODEL_DATABASE_URI
 desired_master_uri="$GAZEBO_MASTER_URI"

--- a/gazebo_ros/scripts/gzserver
+++ b/gazebo_ros/scripts/gzserver
@@ -23,7 +23,7 @@ then
     final="$final -s `catkin_find --first-only libgazebo_ros_api_plugin.$EXT`"
 fi
 
-setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
+find_gazebo
 
 # source setup.sh, but keep local modifications to GAZEBO_MASTER_URI and GAZEBO_MODEL_DATABASE_URI
 desired_master_uri="$GAZEBO_MASTER_URI"

--- a/gazebo_ros/scripts/libcommon.sh
+++ b/gazebo_ros/scripts/libcommon.sh
@@ -17,3 +17,22 @@ relocate_remappings()
 
   echo "$gazebo_args$ros_remaps" | cut -c 1-
 }
+
+# In order to avoid a runtime dependency on gazebo_dev in Debian packages
+# a fallback to the default location of /usr/share/gazebo is used.
+# For more information see:
+# https://github.com/ros-simulation/gazebo_ros_pkgs/issues/323
+find_gazebo()
+{
+    if pkg-config --exists gazebo
+    then
+        setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo
+    elif [ -d "/usr/share/gazebo" ]
+    then
+        echo "using default path /usr/share/gazebo"
+        setup_path=/usr/share/gazebo
+    else
+        echo "gazebo not found, neither via pkg-config nor in /usr/share/gazebo"
+        exit -1
+    fi
+}

--- a/gazebo_ros/scripts/perf
+++ b/gazebo_ros/scripts/perf
@@ -17,5 +17,5 @@ then
     final="$final -s `catkin_find --first-only libgazebo_ros_api_plugin.$EXT`"
 fi
 
-setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
+find_gazebo
 . $setup_path/setup.sh && /usr/bin/valgrind --tool=callgrind gzserver $final


### PR DESCRIPTION
Currently `gazebo_ros` depends on `gazebo_dev` which depends on `libgazebo11-dev` in order to use the pkg-config file included there to locate the `setup.sh` (see #323 )

`libgazebo11-dev` however also depends on `libogre-1.9-dev` which conflicts with `libogre-1.12-dev` which `rviz` would like to use for focal (see https://github.com/ros/rosdistro/pull/24448 for discussion)

This PR adds a fallback to `/usr/share/gazebo` as this is the location used in the packages and therefore allows to drop the runtime dependency on `gazebo_dev`