### PR TITLE
Backport Gazebo11/Bionic fix for boost variant (dashing)

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_ray_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ray_sensor.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <boost/make_shared.hpp>
+#include <boost/variant.hpp>
 #include <gazebo/transport/transport.hh>
 #include <gazebo_plugins/gazebo_ros_ray_sensor.hpp>
 #include <gazebo_ros/conversions/sensor_msgs.hpp>


### PR DESCRIPTION
In order to compile gazebo_ros_packages in Dashing using Gazebo11 we need the fix (currently in ros2 branch). Problem here: https://build.osrfoundation.org/view/debbuild-bloom/job/gazebo-plugins-bloom-debbuilder/117/consoleFull#-19212728866ea37b8d-a6d4-40ae-8431-d90c018842af