### PR TITLE
Noetic patch for Opencv libraries

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -3,7 +3,7 @@ project(gazebo_plugins)
 
 option(ENABLE_DISPLAY_TESTS "Enable the building of tests that requires a display" OFF)
 
-find_package(catkin REQUIRED COMPONENTS 
+find_package(catkin REQUIRED COMPONENTS
   gazebo_dev
   message_generation
   gazebo_msgs
@@ -63,6 +63,11 @@ else()
 endif()
 
 find_package(Boost REQUIRED COMPONENTS thread)
+if (CATKIN_ENABLE_TESTING)
+  find_package(OpenCV COMPONENTS core imgproc calib3d highgui REQUIRED)
+else()
+  find_package(OpenCV COMPONENTS core highgui REQUIRED)
+endif()
 
 execute_process(COMMAND
   pkg-config --variable=plugindir OGRE
@@ -86,6 +91,7 @@ include_directories(include
   ${OGRE_INCLUDE_DIRS}
   ${OGRE-Terrain_INCLUDE_DIRS}
   ${OGRE-Paging_INCLUDE_DIRS}
+  ${OpenCV_INCLUDE_DIRS})
 )
 
 link_directories(
@@ -105,23 +111,23 @@ endif()
 
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES 
-  vision_reconfigure 
-  gazebo_ros_utils 
-  gazebo_ros_camera_utils 
-  gazebo_ros_camera 
+  LIBRARIES
+  vision_reconfigure
+  gazebo_ros_utils
+  gazebo_ros_camera_utils
+  gazebo_ros_camera
   gazebo_ros_triggered_camera
-  gazebo_ros_multicamera 
+  gazebo_ros_multicamera
   gazebo_ros_triggered_multicamera
-  gazebo_ros_depth_camera 
-  gazebo_ros_openni_kinect 
-  gazebo_ros_gpu_laser 
-  gazebo_ros_laser 
-  gazebo_ros_block_laser 
-  gazebo_ros_p3d 
-  gazebo_ros_imu 
+  gazebo_ros_depth_camera
+  gazebo_ros_openni_kinect
+  gazebo_ros_gpu_laser
+  gazebo_ros_laser
+  gazebo_ros_block_laser
+  gazebo_ros_p3d
+  gazebo_ros_imu
   gazebo_ros_imu_sensor
-  gazebo_ros_f3d 
+  gazebo_ros_f3d
   gazebo_ros_ft_sensor
   gazebo_ros_bumper
   gazebo_ros_template
@@ -270,7 +276,7 @@ target_link_libraries(gazebo_ros_projector ${Boost_LIBRARIES} ${catkin_LIBRARIES
 
 add_library(gazebo_ros_prosilica src/gazebo_ros_prosilica.cpp)
 add_dependencies(gazebo_ros_prosilica ${PROJECT_NAME}_gencfg)
-target_link_libraries(gazebo_ros_prosilica gazebo_ros_camera_utils CameraPlugin ${catkin_LIBRARIES})
+target_link_libraries(gazebo_ros_prosilica gazebo_ros_camera_utils CameraPlugin ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 
 add_library(gazebo_ros_force src/gazebo_ros_force.cpp)
 target_link_libraries(gazebo_ros_force ${catkin_LIBRARIES} ${Boost_LIBRARIES})
@@ -295,7 +301,7 @@ add_library(gazebo_ros_skid_steer_drive src/gazebo_ros_skid_steer_drive.cpp)
 target_link_libraries(gazebo_ros_skid_steer_drive ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(gazebo_ros_video src/gazebo_ros_video.cpp)
-target_link_libraries(gazebo_ros_video ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OGRE_LIBRARIES})
+target_link_libraries(gazebo_ros_video ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OGRE_LIBRARIES} ${opencv_LIBRARIES})
 
 add_library(gazebo_ros_planar_move src/gazebo_ros_planar_move.cpp)
 target_link_libraries(gazebo_ros_planar_move ${catkin_LIBRARIES} ${Boost_LIBRARIES})
@@ -440,11 +446,11 @@ if (CATKIN_ENABLE_TESTING)
     add_rostest_gtest(distortion_barrel_test
                       test/camera/distortion_barrel.test
                       test/camera/distortion_barrel.cpp)
-    target_link_libraries(distortion_barrel_test ${catkin_LIBRARIES})
+    target_link_libraries(distortion_barrel_test ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
     add_rostest_gtest(distortion_pincushion_test
                       test/camera/distortion_pincushion.test
                       test/camera/distortion_pincushion.cpp)
-    target_link_libraries(distortion_pincushion_test ${catkin_LIBRARIES})
+    target_link_libraries(distortion_pincushion_test ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
     add_rostest_gtest(triggered-camera-test
                       test/camera/triggered_camera.test
                       test/camera/triggered_camera.cpp)

--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -91,7 +91,7 @@ include_directories(include
   ${OGRE_INCLUDE_DIRS}
   ${OGRE-Terrain_INCLUDE_DIRS}
   ${OGRE-Paging_INCLUDE_DIRS}
-  ${OpenCV_INCLUDE_DIRS})
+  ${OpenCV_INCLUDE_DIRS}
 )
 
 link_directories(

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_video.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_video.h
@@ -27,7 +27,7 @@
 #include <boost/thread/mutex.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <image_transport/image_transport.h>
-#include <opencv2/opencv.hpp>
+#include <opencv2/core.hpp>
 #include <ros/advertise_options.h>
 #include <ros/callback_queue.h>
 #include <ros/ros.h>

--- a/gazebo_plugins/test/camera/distortion.h
+++ b/gazebo_plugins/test/camera/distortion.h
@@ -4,6 +4,8 @@
 // OpenCV includes
 #include <opencv2/core/core.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
+// undistort function has been moved to calib3d in opencv4
+#include <opencv2/calib3d.hpp>
 
 // Test includes
 #include <gtest/gtest.h>


### PR DESCRIPTION
Different part of `gazebo_plugins` use OpenCV also the CMake code does not seems to look for them. The thing compiles probably because of opencv libraries brought to compilation as a result of Gazebo + cv_bridge dependencies.

The Noetic build was failing in Jenkins with problems related to Opencv [undistort](https://build.osrfoundation.org/job/ros_gazebo_pkgs-ci-default_noetic-focal-amd64/5/consoleFull#5312693186ea37b8d-a6d4-40ae-8431-d90c018842af) method. This PR adds some bits to look for OpenCV libraries and link against the libraries that use it.