### PR TITLE
gazebo_ros_wheel_slip: support parameters specified in launch file (backport to melodic)

### DIFF
--- a/gazebo_plugins/cfg/WheelSlip.cfg
+++ b/gazebo_plugins/cfg/WheelSlip.cfg
@@ -9,7 +9,7 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 gen = ParameterGenerator()
 
 #       Name                                      Type      Reconf level   Description                                                                  Default    Min   Max
-gen.add("slip_compliance_unitless_lateral",       double_t, 0,             "Unitless slip compliance (slip / friction) in the lateral direction.",      0.0,       0.0,  20.0)
-gen.add("slip_compliance_unitless_longitudinal",  double_t, 0,             "Unitless slip compliance (slip / friction) in the longitudinal direction.", 0.0,       0.0,  20.0)
+gen.add("slip_compliance_unitless_lateral",       double_t, 0,             "Unitless slip compliance (slip / friction) in the lateral direction.",      -1.0,      -1.0,  20.0)
+gen.add("slip_compliance_unitless_longitudinal",  double_t, 0,             "Unitless slip compliance (slip / friction) in the longitudinal direction.", -1.0,      -1.0,  20.0)
 
 exit(gen.generate(PACKAGE, "wheel_slip",     "WheelSlip"))

--- a/gazebo_plugins/src/gazebo_ros_wheel_slip.cpp
+++ b/gazebo_plugins/src/gazebo_ros_wheel_slip.cpp
@@ -46,20 +46,22 @@ GazeboRosWheelSlip::~GazeboRosWheelSlip()
 
 /////////////////////////////////////////////////
 void GazeboRosWheelSlip::configCallback(
-  gazebo_plugins::WheelSlipConfig &config, uint32_t level)
+  gazebo_plugins::WheelSlipConfig &config, uint32_t /*level*/)
 {
-  if (level == ~0)
+  if (config.slip_compliance_unitless_lateral >= 0)
   {
-    // don't overwrite initial parameters
-    return;
+    ROS_INFO_NAMED("wheel_slip", "Reconfigure request for the gazebo ros wheel_slip: %s. New lateral slip compliance: %.3e",
+             this->GetParentModel()->GetScopedName().c_str(),
+             config.slip_compliance_unitless_lateral);
+    this->SetSlipComplianceLateral(config.slip_compliance_unitless_lateral);
   }
-
-  ROS_INFO_NAMED("wheel_slip", "Reconfigure request for the gazebo ros wheel_slip: %s. New slip compliances, lateral: %.3e, longitudinal: %.3e",
-           this->GetParentModel()->GetScopedName().c_str(),
-           config.slip_compliance_unitless_lateral,
-           config.slip_compliance_unitless_longitudinal);
-  this->SetSlipComplianceLateral(config.slip_compliance_unitless_lateral);
-  this->SetSlipComplianceLongitudinal(config.slip_compliance_unitless_longitudinal);
+  if (config.slip_compliance_unitless_longitudinal >= 0)
+  {
+    ROS_INFO_NAMED("wheel_slip", "Reconfigure request for the gazebo ros wheel_slip: %s. New longitudinal slip compliance: %.3e",
+             this->GetParentModel()->GetScopedName().c_str(),
+             config.slip_compliance_unitless_longitudinal);
+    this->SetSlipComplianceLongitudinal(config.slip_compliance_unitless_longitudinal);
+  }
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
The `gazebo_ros_wheel_slip` plugin currently ignores slip compliance values specified in a  launch file due to the check of the `level` parameter added in 3cf9f5e1bdf424d5b1866e74f3bde2e904c74298, which ensures that parameter values specified in the urdf / sdf xml parameters are not over-ridden by the default values specified in the `.cfg` file. In order to respect the values set in launch files but ignore the defaults in the `.cfg` file, change the `.cfg` default values to `-1` and adjust the callback to ignore negative values. This is fine because gazebo's WheelSlipPlugin already has default values for the slip compliance parameters, so the `.cfg` defaults are extraneous.

This also reverts 3cf9f5e1bdf424d5b1866e74f3bde2e904c74298 so that the `level` parameter is ignored again.

cc @maxx84