### PR TITLE
Compute twist in BODY frame for p3d plugin

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -289,7 +289,7 @@ void GazeboRosP3D::UpdateChild()
         }
         else
         {
-          const math::Quaternion rot_inv = pose.rot.GetInverse();
+          const auto rot_inv = pose.Rot().Inverse();
           vpos = rot_inv.RotateVector(vpos);
           veul = rot_inv.RotateVector(veul);
         }

--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -287,6 +287,12 @@ void GazeboRosP3D::UpdateChild()
           vpos = frame_pose.Rot().RotateVector(vpos - frame_vpos);
           veul = frame_pose.Rot().RotateVector(veul - frame_veul);
         }
+        else
+        {
+          const math::Quaternion rot_inv = pose.rot.GetInverse();
+          vpos = rot_inv.RotateVector(vpos);
+          veul = rot_inv.RotateVector(veul);
+        }
 
         // Apply Constant Offsets
         // apply xyz offsets and get position and rotation components


### PR DESCRIPTION
Cherry-pick https://github.com/clearpathrobotics/gazebo_ros_pkgs/commit/aa787b06a1050e07673d3ec5b0e16e68b3a0a735

This makes the ground truth odometry twist be in the BODY frame, for the p3d plugin.

We've been using this for a couple of years in our fork. I'd like to know what do you think of getting this into `noetic-devel`.