### PR TITLE
[ROS 2] Use "" as default in spawn_entity.py instead of self.get_namespace().

### DIFF
--- a/gazebo_ros/scripts/spawn_entity.py
+++ b/gazebo_ros/scripts/spawn_entity.py
@@ -70,7 +70,7 @@ class SpawnEntityNode(Node):
         parser.add_argument('-gazebo_namespace', type=str, default='',
                             help='ROS namespace of gazebo offered ROS interfaces. \
                             Default is without any namespace')
-        parser.add_argument('-robot_namespace', type=str, default=self.get_namespace(),
+        parser.add_argument('-robot_namespace', type=str, default='',
                             help='change ROS namespace of gazebo-plugins')
         parser.add_argument('-timeout', type=float, default=30.0,
                             help='Number of seconds to wait for the spawn and delete services to \

--- a/gazebo_ros/src/gazebo_ros_factory.cpp
+++ b/gazebo_ros/src/gazebo_ros_factory.cpp
@@ -230,7 +230,7 @@ void GazeboRosFactoryPrivate::SpawnEntity(
 
   // Walk recursively through the entire file, and add <ros><namespace> tags to all plugins
   auto robot_namespace = req->robot_namespace;
-  if (!robot_namespace.empty()) {
+  if (robot_namespace.compare("/") != 0) {
     AddNamespace(entity_elem, robot_namespace);
   }
 
@@ -349,9 +349,10 @@ void GazeboRosFactoryPrivate::AddNamespace(
 
         // Then we can add the element
         ns_elem = ros_elem->AddElement("namespace");
-        // Set namespace
-        ns_elem->Set<std::string>(_robot_namespace);
       }
+
+      // Set namespace
+      ns_elem->Set<std::string>(_robot_namespace);
     }
     AddNamespace(child_elem, _robot_namespace);
   }

--- a/gazebo_ros/src/gazebo_ros_factory.cpp
+++ b/gazebo_ros/src/gazebo_ros_factory.cpp
@@ -230,7 +230,7 @@ void GazeboRosFactoryPrivate::SpawnEntity(
 
   // Walk recursively through the entire file, and add <ros><namespace> tags to all plugins
   auto robot_namespace = req->robot_namespace;
-  if (robot_namespace.compare("/") != 0) {
+  if (!robot_namespace.empty()) {
     AddNamespace(entity_elem, robot_namespace);
   }
 

--- a/gazebo_ros/src/gazebo_ros_factory.cpp
+++ b/gazebo_ros/src/gazebo_ros_factory.cpp
@@ -349,10 +349,9 @@ void GazeboRosFactoryPrivate::AddNamespace(
 
         // Then we can add the element
         ns_elem = ros_elem->AddElement("namespace");
+        // Set namespace
+        ns_elem->Set<std::string>(_robot_namespace);
       }
-
-      // Set namespace
-      ns_elem->Set<std::string>(_robot_namespace);
     }
     AddNamespace(child_elem, _robot_namespace);
   }


### PR DESCRIPTION
Targeting this issue https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1116

if the <namespace> tag is defined then we should not override the value

Signed-off-by: ahcorde <ahcorde@gmail.com>