### PR TITLE
Replace deprecated parameters callback API

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera.cpp
@@ -499,17 +499,9 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
       "update_rate", MultiCameraPlugin::parent_sensor_->UpdateRate());
   }
 
-  auto existing_callback = impl_->ros_node_->set_on_parameters_set_callback(nullptr);
   auto param_change_callback =
-    [this, existing_callback](std::vector<rclcpp::Parameter> parameters) {
+    [this](std::vector<rclcpp::Parameter> parameters) {
       auto result = rcl_interfaces::msg::SetParametersResult();
-      if (nullptr != existing_callback) {
-        result = existing_callback(parameters);
-        if (!result.successful) {
-          return result;
-        }
-      }
-
       result.successful = true;
       for (const auto & parameter : parameters) {
         std::string param_name = parameter.get_name();
@@ -553,7 +545,7 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
       return result;
     };
 
-  impl_->ros_node_->set_on_parameters_set_callback(param_change_callback);
+  impl_->ros_node_->add_on_set_parameters_callback(param_change_callback);
 }
 
 void GazeboRosCamera::NewFrame(


### PR DESCRIPTION
rclcpp::Node now supports multiple parameter callbacks, so we do not need to worry about overwriting an existing callback.
This change fixes compile time deprecation warnings since ROS Foxy.