### PR TITLE
Fix cppcheck errors

### DIFF
--- a/gazebo_plugins/test/test_gazebo_ros_camera.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_camera.cpp
@@ -85,7 +85,7 @@ INSTANTIATE_TEST_CASE_P(
   GazeboRosCamera, GazeboRosCameraTest, ::testing::Values(
     TestParams({"worlds/gazebo_ros_camera.world", "test_cam/camera/image_test"}),
     TestParams({"worlds/gazebo_ros_camera_16bit.world", "test_cam_16bit/image_test_16bit"})
-  ), );
+));
 
 int main(int argc, char ** argv)
 {

--- a/gazebo_plugins/test/test_gazebo_ros_camera_distortion.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_camera_distortion.cpp
@@ -220,7 +220,7 @@ INSTANTIATE_TEST_CASE_P(
         "undistorted_image",
         "distorted_image",
         "distorted_info"})
-  ), );
+));
 
 int main(int argc, char ** argv)
 {

--- a/gazebo_plugins/test/test_gazebo_ros_depth_camera.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_depth_camera.cpp
@@ -143,7 +143,7 @@ INSTANTIATE_TEST_CASE_P(
         "test_cam/camera/raw_image_test",
         "test_cam/camera/depth_image_test",
         "test_cam/camera/points_test"})
-  ), );
+));
 
 int main(int argc, char ** argv)
 {

--- a/gazebo_plugins/test/test_gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_diff_drive.cpp
@@ -126,7 +126,7 @@ INSTANTIATE_TEST_CASE_P(
   GazeboRosDiffDrive, GazeboRosDiffDriveTest, ::testing::Values(
     TestParams({"worlds/gazebo_ros_diff_drive.world"}),
     TestParams({"worlds/gazebo_ros_skid_steer_drive.world"})
-  ), );
+));
 
 int main(int argc, char ** argv)
 {

--- a/gazebo_plugins/test/test_gazebo_ros_multicamera.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_multicamera.cpp
@@ -112,7 +112,7 @@ INSTANTIATE_TEST_CASE_P(
       {"worlds/gazebo_ros_multicamera.world",
         "test_cam/camera/left/image_test",
         "test_cam/camera/right/image_test"})
-  ), );
+));
 
 int main(int argc, char ** argv)
 {


### PR DESCRIPTION
cppcheck 1.90 complains about syntax errors even though it is valid C++ code.
This refactoring fixes the reported errors.