### PR TITLE
[ROS2] Option for P3D plugin to broadcast tf frame

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_p3d.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_p3d.hpp
@@ -44,6 +44,9 @@ class GazeboRosP3DPrivate;
       <!-- Name of the link within this model whose pose will be published -->
       <body_name>box_link</body_name>
 
+      <!-- If set, broadcasts tf frame of body frame under name specified here. -->
+      <body_tf_name>box_link</body_tf_name>
+
       <!-- Name of another link within this model to use as a reference frame.
            Remove the tag to use the world as a reference. -->
       <frame_name>sphere_link</frame_name>

--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -288,23 +288,27 @@ void GazeboRosP3DPrivate::OnUpdate(const gazebo::common::UpdateInfo & info)
   pose_msg.twist.covariance[28] = gn2;
   pose_msg.twist.covariance[35] = gn2;
 
-
-  // Create TF Transform
-  geometry_msgs::msg::TransformStamped transform_msg;
-
-  transform_msg.header.frame_id = frame_name_;
-  transform_msg.header.stamp = gazebo_ros::Convert<builtin_interfaces::msg::Time>(current_time);
-  transform_msg.child_frame_id = body_tf_name_;
-  transform_msg.transform.translation = gazebo_ros::Convert<geometry_msgs::msg::Vector3>(pose.Pos());
-  transform_msg.transform.rotation = gazebo_ros::Convert<geometry_msgs::msg::Quaternion>(pose.Rot());
-
-  tf2_msgs::msg::TFMessage tf_msg;
-
-  tf_msg.transforms.push_back(transform_msg);
-
   // Publish to ROS
   pub_->publish(pose_msg);
-  tf_pub_->publish(tf_msg);
+
+  // Broadcast tf transform
+  if (!body_tf_name_.empty()) {
+    // Create TF Transform
+    geometry_msgs::msg::TransformStamped transform_msg;
+
+    transform_msg.header.frame_id = frame_name_;
+    transform_msg.header.stamp = gazebo_ros::Convert<builtin_interfaces::msg::Time>(current_time);
+    transform_msg.child_frame_id = body_tf_name_;
+    transform_msg.transform.translation = gazebo_ros::Convert<geometry_msgs::msg::Vector3>(pose.Pos());
+    transform_msg.transform.rotation = gazebo_ros::Convert<geometry_msgs::msg::Quaternion>(pose.Rot());
+
+    tf2_msgs::msg::TFMessage tf_msg;
+
+    tf_msg.transforms.push_back(transform_msg);
+
+    // Publish to ROS
+    tf_pub_->publish(tf_msg);
+  }
 
   // Save last time stamp
   last_time_ = current_time;

--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -67,6 +67,9 @@ public:
   /// Frame transform name, should match name of reference link, or be world.
   std::string frame_name_{"world"};
 
+  /// TF Frame name of child in case it should be different from child link name.
+  std::string child_frame_name_{"odom"};
+
   /// Constant xyz and rpy offsets
   ignition::math::Pose3d offset_;
 
@@ -282,7 +285,7 @@ void GazeboRosP3DPrivate::OnUpdate(const gazebo::common::UpdateInfo & info)
 
   transform_msg.header.frame_id = frame_name_;
   transform_msg.header.stamp = gazebo_ros::Convert<builtin_interfaces::msg::Time>(current_time);
-  transform_msg.child_frame_id = link_->GetName();
+  transform_msg.child_frame_id = child_frame_name_;
   transform_msg.transform.translation = gazebo_ros::Convert<geometry_msgs::msg::Vector3>(pose.Pos());
   transform_msg.transform.rotation = gazebo_ros::Convert<geometry_msgs::msg::Quaternion>(pose.Rot());
 

--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -31,6 +31,7 @@
 #include "tf2_msgs/msg/tf_message.hpp"
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>
+#include "tf2_ros/qos.hpp"
 
 #include <string>
 #include <memory>
@@ -123,8 +124,9 @@ void GazeboRosP3D::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf)
 
   impl_->pub_ = impl_->ros_node_->create_publisher<nav_msgs::msg::Odometry>(
     impl_->topic_name_, rclcpp::SensorDataQoS());
-  // TODO: add actual QoS
-  impl_->tf_pub_ = impl_->ros_node_->create_publisher<tf2_msgs::msg::TFMessage>("/tf", 100);
+
+  impl_->tf_pub_ = impl_->ros_node_->create_publisher<tf2_msgs::msg::TFMessage>("/tf",
+    tf2_ros::DynamicBroadcasterQoS());
 
   impl_->topic_name_ = impl_->pub_->get_topic_name();
   RCLCPP_DEBUG(

--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -201,7 +201,8 @@ void GazeboRosP3DPrivate::OnUpdate(const gazebo::common::UpdateInfo & info)
   }
 
   // If we don't have any subscribers, don't bother composing and sending the message
-  if (ros_node_->count_subscribers(topic_name_) == 0) {
+  if (ros_node_->count_subscribers(topic_name_) == 0
+      && ros_node_->count_subscribers("/tf") == 0) {
     return;
   }
 


### PR DESCRIPTION
This PR refers to the questions described in #1101 

It adds the ability of broadcasting the tf transform from the specified body to the specified frame in addition to the odom topic.

We use this to visualize the pose of our rover in rviz. Furthermore the name of the tf frame broadcasted can be customized. If no tf_name is specified, then no tf frame will be broadcast.

If there is a better way of doing the described functionality, let me know. I implemented the features mainly for our specific usecase but if they can be used here, I'm happy to also add testing functionality.

**Environment:**

 - OS: Ubuntu 18.04
 - Gazebo version: Gazebo 9
 - ROS version: Eloquent
  - gazebo_ros_pkgs: debian install
 - glx server in use: server glx vendor string: SGI