### PR TITLE
[ROS 2] Set to true automatically_declare_parameters_from_overrides when creating the node

### DIFF
--- a/gazebo_ros/src/node.cpp
+++ b/gazebo_ros/src/node.cpp
@@ -96,6 +96,7 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf)
 
   rclcpp::NodeOptions node_options;
   node_options.arguments(arguments);
+  node_options.automatically_declare_parameters_from_overrides(true);
   node_options.parameter_overrides(parameter_overrides);
 
   // Create node with parsed arguments


### PR DESCRIPTION
Set to true automatically_declare_parameters_from_overrides in gazebo_ros

Signed-off-by: ahcorde <ahcorde@gmail.com>