### PR TITLE
Fix all Foxy tests

### DIFF
--- a/gazebo_plugins/test/test_gazebo_ros_gps_sensor.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_gps_sensor.cpp
@@ -60,7 +60,7 @@ TEST_F(GazeboRosGpsSensorTest, GpsMessageCorrect)
   EXPECT_NEAR(0.0, box->WorldPose().Pos().Y(), tol);
   EXPECT_NEAR(0.5, box->WorldPose().Pos().Z(), tol);
 
-  // Step until an gps message will have been published
+  // Step until a gps message will have been published
   int sleep{0};
   int max_sleep{1000};
   while (sleep < max_sleep && nullptr == msg) {
@@ -81,11 +81,18 @@ TEST_F(GazeboRosGpsSensorTest, GpsMessageCorrect)
   EXPECT_NEAR(0.5, pre_movement_msg->altitude, tol);
 
   // Change the position of the link and step a few times to wait the ros message to be received
+  msg = nullptr;
   ignition::math::Pose3d box_pose;
   box_pose.Pos() = {100.0, 200.0, 300.0};
   link->SetWorldPose(box_pose);
-  world->Step(50);
-  rclcpp::spin_some(node);
+
+  sleep = 0;
+  while (sleep < max_sleep && (nullptr == msg || msg->altitude < 150)) {
+    world->Step(50);
+    rclcpp::spin_some(node);
+    gazebo::common::Time::MSleep(100);
+    sleep++;
+  }
 
   // Check that GPS output reflects the position change
   auto post_movement_msg = std::make_shared<sensor_msgs::msg::NavSatFix>(*msg);

--- a/gazebo_plugins/test/test_gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_imu_sensor.cpp
@@ -72,11 +72,12 @@ TEST_F(GazeboRosImuSensorTest, ImuMessageCorrect)
   ASSERT_NE(nullptr, pre_movement_msg);
   auto pre_movement_yaw =
     gazebo_ros::Convert<ignition::math::Quaterniond>(pre_movement_msg->orientation).Euler().Z();
-  EXPECT_LT(pre_movement_yaw, 0.1);
+  EXPECT_LT(pre_movement_yaw, 0.05);
   EXPECT_LT(pre_movement_msg->linear_acceleration.x, 0.5);
   EXPECT_LT(pre_movement_msg->angular_velocity.z, 0.1);
 
   // Apply a force + torque and collect a new message
+  msg = nullptr;
   for (unsigned int i = 0; i < 5; i++) {
     // Small steps so the force is continually applied
     link->SetForce({500.0, 0.0, 0.0});
@@ -90,7 +91,7 @@ TEST_F(GazeboRosImuSensorTest, ImuMessageCorrect)
   ASSERT_NE(nullptr, post_movement_msg);
   auto post_movement_yaw =
     gazebo_ros::Convert<ignition::math::Quaterniond>(post_movement_msg->orientation).Euler().Z();
-  EXPECT_GT(post_movement_yaw, 0.1);
+  EXPECT_GT(post_movement_yaw, 0.05);
   // The linear acceleration reported by Gazebo flips signs, so we take the absolute value
   EXPECT_GT(std::abs(post_movement_msg->linear_acceleration.x), 1.0);
   EXPECT_GT(post_movement_msg->angular_velocity.z, 1.0);

--- a/gazebo_ros/src/node.cpp
+++ b/gazebo_ros/src/node.cpp
@@ -57,8 +57,9 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf)
   if (sdf->HasElement("namespace")) {
     ns = sdf->GetElement("namespace")->Get<std::string>();
     // prevent exception: namespace must be absolute, it must lead with a '/'
-    if (ns.empty() || ns[0] != '/')
+    if (ns.empty() || ns[0] != '/') {
       ns = '/' + ns;
+    }
   }
 
   // Get list of arguments from SDF

--- a/gazebo_ros/src/node.cpp
+++ b/gazebo_ros/src/node.cpp
@@ -56,6 +56,9 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf)
   // Set namespace if tag is present
   if (sdf->HasElement("namespace")) {
     ns = sdf->GetElement("namespace")->Get<std::string>();
+    // prevent exception: namespace must be absolute, it must lead with a '/'
+    if (ns.empty() || ns[0] != '/')
+      ns = '/' + ns;
   }
 
   // Get list of arguments from SDF


### PR DESCRIPTION
This fixes all tests for me when I run them locally. :crossed_fingers: for them to be also fixed on CI.

Many tests were crashing because an exception is now thrown when a namespace is not prefixed by "/". Since we've been supporting that until now, I just made sure that namespaces coming from SDF are always correct.

Related to https://github.com/ros-simulation/gazebo_ros_pkgs/pull/1091 and https://github.com/ros-simulation/gazebo_ros_pkgs/pull/1117

Once this is in, we're ready to bloom - #1080 