### PR TITLE
gazebo_ros_api_plugin cleanup

### DIFF
--- a/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
+++ b/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
@@ -241,8 +241,9 @@ private:
   /// \brief
   void forceJointSchedulerSlot();
 
-  /// \brief
-  void publishSimTime(const boost::shared_ptr<gazebo::msgs::WorldStatistics const> &msg);
+  /// \brief Callback to WorldUpdateBegin that publishes /clock.
+  /// If pub_clock_frequency_ <= 0 (default behavior), it publishes every time step.
+  /// Otherwise, it attempts to publish at that frequency in Hz.
   void publishSimTime();
 
   /// \brief

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -205,6 +205,11 @@ void GazeboRosApiPlugin::loadGazeboRosApiPlugin(std::string world_name)
 
   // Manage clock for simulated ros time
   pub_clock_ = nh_->advertise<rosgraph_msgs::Clock>("/clock",10);
+
+  /// \brief advertise all services
+  if (enable_ros_network_)
+    advertiseServices();
+
   // set param for use_sim_time if not set by user already
   if(!(nh_->hasParam("/use_sim_time")))
     nh_->setParam("/use_sim_time", true);
@@ -215,10 +220,6 @@ void GazeboRosApiPlugin::loadGazeboRosApiPlugin(std::string world_name)
 #else
   last_pub_clock_time_ = world_->GetSimTime();
 #endif
-
-  /// \brief advertise all services
-  if (enable_ros_network_)
-    advertiseServices();
 
   // hooks for applying forces, publishing simtime on /clock
   wrench_update_event_ = gazebo::event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboRosApiPlugin::wrenchBodySchedulerSlot,this));

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -204,7 +204,7 @@ void GazeboRosApiPlugin::loadGazeboRosApiPlugin(std::string world_name)
   pub_model_states_connection_count_ = 0;
 
   // Manage clock for simulated ros time
-  pub_clock_ = nh_->advertise<rosgraph_msgs::Clock>("/clock",10);
+  pub_clock_ = nh_->advertise<rosgraph_msgs::Clock>("/clock", 10);
 
   /// \brief advertise all services
   if (enable_ros_network_)

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -193,7 +193,6 @@ void GazeboRosApiPlugin::loadGazeboRosApiPlugin(std::string world_name)
 
   gazebonode_ = gazebo::transport::NodePtr(new gazebo::transport::Node());
   gazebonode_->Init(world_name);
-  //stat_sub_ = gazebonode_->Subscribe("~/world_stats", &GazeboRosApiPlugin::publishSimTime, this); // TODO: does not work in server plugin?
   factory_pub_ = gazebonode_->Advertise<gazebo::msgs::Factory>("~/factory");
   factory_light_pub_ = gazebonode_->Advertise<gazebo::msgs::Light>("~/factory/light");
   light_modify_pub_ = gazebonode_->Advertise<gazebo::msgs::Light>("~/light/modify");
@@ -2105,24 +2104,6 @@ void GazeboRosApiPlugin::forceJointSchedulerSlot()
   lock_.unlock();
 }
 
-void GazeboRosApiPlugin::publishSimTime(const boost::shared_ptr<gazebo::msgs::WorldStatistics const> &msg)
-{
-  ROS_ERROR_NAMED("api_plugin", "CLOCK2");
-#if GAZEBO_MAJOR_VERSION >= 8
-  gazebo::common::Time sim_time = world_->SimTime();
-#else
-  gazebo::common::Time sim_time = world_->GetSimTime();
-#endif
-  if (pub_clock_frequency_ > 0 && (sim_time - last_pub_clock_time_).Double() < 1.0/pub_clock_frequency_)
-    return;
-
-  gazebo::common::Time currentTime = gazebo::msgs::Convert( msg->sim_time() );
-  rosgraph_msgs::Clock ros_time_;
-  ros_time_.clock.fromSec(currentTime.Double());
-  //  publish time to ros
-  last_pub_clock_time_ = sim_time;
-  pub_clock_.publish(ros_time_);
-}
 void GazeboRosApiPlugin::publishSimTime()
 {
 #if GAZEBO_MAJOR_VERSION >= 8


### PR DESCRIPTION
I noticed with @clalancette that `gazebo_ros_api_plugin` advertises the `/clock` topic and sets some variables in multiple places ([loadGazeboRosApiPlugin()](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/f7a19b82f449044c5d39fc1f02f2fbb4471a7457/gazebo_ros/src/gazebo_ros_api_plugin.cpp#L212) and [advertiseServices()](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/f7a19b82f449044c5d39fc1f02f2fbb4471a7457/gazebo_ros/src/gazebo_ros_api_plugin.cpp#L253)). This removes that duplicate code from `advertiseServices()` and makes sure is called before `advertiseServices()`.

There's also an unused private function that is an overload of `publishSimTime()`, so I've removed it here and added doxygen for the remaining `publishSimTime()`.