### PR TITLE
[Noetic] Added Ignition common profiler to gazebo_plugins

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -64,6 +64,18 @@ endif()
 
 find_package(Boost REQUIRED COMPONENTS thread)
 
+option(ENABLE_PROFILER "Enable Ignition Profiler" FALSE)
+if (ENABLE_PROFILER)
+  find_package(ignition-common3 QUIET)
+  if (ignition-common3_FOUND)
+    add_definitions("-DIGN_PROFILER_ENABLE=1" "-DIGN_PROFILER_REMOTERY=1")
+    message("Profiler is active")
+  else()
+    message("Can't find Ignition common3. Profiler will not be actived")
+    add_definitions("-DIGN_PROFILER_ENABLE=0" "-DIGN_PROFILER_REMOTERY=0")
+  endif()
+endif()
+
 execute_process(COMMAND
   pkg-config --variable=plugindir OGRE
   OUTPUT_VARIABLE OGRE_PLUGIN_PATH
@@ -105,23 +117,23 @@ endif()
 
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES 
-  vision_reconfigure 
-  gazebo_ros_utils 
-  gazebo_ros_camera_utils 
-  gazebo_ros_camera 
+  LIBRARIES
+  vision_reconfigure
+  gazebo_ros_utils
+  gazebo_ros_camera_utils
+  gazebo_ros_camera
   gazebo_ros_triggered_camera
-  gazebo_ros_multicamera 
+  gazebo_ros_multicamera
   gazebo_ros_triggered_multicamera
-  gazebo_ros_depth_camera 
-  gazebo_ros_openni_kinect 
-  gazebo_ros_gpu_laser 
-  gazebo_ros_laser 
-  gazebo_ros_block_laser 
-  gazebo_ros_p3d 
-  gazebo_ros_imu 
+  gazebo_ros_depth_camera
+  gazebo_ros_openni_kinect
+  gazebo_ros_gpu_laser
+  gazebo_ros_laser
+  gazebo_ros_block_laser
+  gazebo_ros_p3d
+  gazebo_ros_imu
   gazebo_ros_imu_sensor
-  gazebo_ros_f3d 
+  gazebo_ros_f3d
   gazebo_ros_ft_sensor
   gazebo_ros_bumper
   gazebo_ros_template

--- a/gazebo_plugins/src/gazebo_ros_block_laser.cpp
+++ b/gazebo_plugins/src/gazebo_ros_block_laser.cpp
@@ -37,6 +37,8 @@
 #include <gazebo/sensors/SensorTypes.hh>
 #include <gazebo/transport/Node.hh>
 
+#include <ignition/common/Profiler.hh>
+
 #include <geometry_msgs/Point32.h>
 #include <sensor_msgs/ChannelFloat32.h>
 
@@ -209,6 +211,8 @@ void GazeboRosBlockLaser::LaserDisconnect()
 // Update the controller
 void GazeboRosBlockLaser::OnNewLaserScans()
 {
+  IGN_PROFILE("GazeboRosBlockLaser::OnNewLaserScans");
+
   if (this->topic_name_ != "")
   {
     common::Time sensor_update_time = this->parent_sensor_->LastUpdateTime();
@@ -220,7 +224,9 @@ void GazeboRosBlockLaser::OnNewLaserScans()
 
     if (last_update_time_ < sensor_update_time)
     {
+      IGN_PROFILE_BEGIN("PutLaserData");
       this->PutLaserData(sensor_update_time);
+      IGN_PROFILE_END();
       last_update_time_ = sensor_update_time;
     }
   }

--- a/gazebo_plugins/src/gazebo_ros_bumper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_bumper.cpp
@@ -36,6 +36,8 @@
 #include <ignition/math/Quaternion.hh>
 #include <ignition/math/Vector3.hh>
 
+#include <ignition/common/Profiler.hh>
+
 #include <tf/tf.h>
 
 #include <gazebo_plugins/gazebo_ros_bumper.h>
@@ -132,9 +134,12 @@ void GazeboRosBumper::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
 // Update the controller
 void GazeboRosBumper::OnContact()
 {
+  IGN_PROFILE("GazeboRosBumper::OnContact");
+
   if (this->contact_pub_.getNumSubscribers() <= 0)
     return;
 
+  IGN_PROFILE_BEGIN("fill message");
   msgs::Contacts contacts;
   contacts = this->parentSensor->Contacts();
   /// \TODO: need a time for each Contact in i-loop, they may differ
@@ -311,8 +316,11 @@ void GazeboRosBumper::OnContact()
     state.total_wrench = total_wrench;
     this->contact_state_msg_.states.push_back(state);
   }
+  IGN_PROFILE_END();
 
+  IGN_PROFILE_BEGIN("publish");
   this->contact_pub_.publish(this->contact_state_msg_);
+  IGN_PROFILE_END();
 }
 
 

--- a/gazebo_plugins/src/gazebo_ros_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera.cpp
@@ -30,6 +30,8 @@
 #include <gazebo/sensors/CameraSensor.hh>
 #include <gazebo/sensors/SensorTypes.hh>
 
+#include <ignition/common/Profiler.hh>
+
 namespace gazebo
 {
 // Register this plugin with the simulator
@@ -76,6 +78,10 @@ void GazeboRosCamera::OnNewFrame(const unsigned char *_image,
     unsigned int _width, unsigned int _height, unsigned int _depth,
     const std::string &_format)
 {
+  IGN_PROFILE("GazeboRosCamera::OnNewFrame");
+  IGN_PROFILE_BEGIN("fill ROS message");
+  IGN_PROFILE_END();
+
 # if GAZEBO_MAJOR_VERSION >= 7
   common::Time sensor_update_time = this->parentSensor_->LastMeasurementTime();
 # else
@@ -107,8 +113,14 @@ void GazeboRosCamera::OnNewFrame(const unsigned char *_image,
       // zero and the conditional always will be true.
       if (sensor_update_time - this->last_update_time_ >= this->update_period_)
       {
+        IGN_PROFILE_BEGIN("PutCameraData");
         this->PutCameraData(_image, sensor_update_time);
+        IGN_PROFILE_END();
+
+        IGN_PROFILE_BEGIN("PublishCameraInfo");
         this->PublishCameraInfo(sensor_update_time);
+        IGN_PROFILE_END();
+
         this->last_update_time_ = sensor_update_time;
       }
     }

--- a/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
@@ -31,6 +31,8 @@
 #include <sdf/sdf.hh>
 #include <gazebo/sensors/SensorTypes.hh>
 
+#include <ignition/common/Profiler.hh>
+
 #include <sensor_msgs/point_cloud2_iterator.h>
 
 #include <tf/tf.h>
@@ -275,8 +277,11 @@ void GazeboRosDepthCamera::OnNewDepthFrame(const float *_image,
     unsigned int _width, unsigned int _height, unsigned int _depth,
     const std::string &_format)
 {
+  IGN_PROFILE("GazeboRosDepthCamera::OnNewDepthFrame");
+
   if (!this->initialized_ || this->height_ <=0 || this->width_ <=0)
     return;
+  IGN_PROFILE_BEGIN("fill ROS message");
 
 # if GAZEBO_MAJOR_VERSION >= 7
   this->depth_sensor_update_time_ = this->parentSensor->LastMeasurementTime();
@@ -312,6 +317,7 @@ void GazeboRosDepthCamera::OnNewDepthFrame(const float *_image,
       // do this first so there's chance for sensor to run 1 frame after activate
       this->parentSensor->SetActive(true);
   }
+  IGN_PROFILE_END();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -320,9 +326,11 @@ void GazeboRosDepthCamera::OnNewRGBPointCloud(const float *_pcd,
     unsigned int _width, unsigned int _height, unsigned int _depth,
     const std::string &_format)
 {
+  IGN_PROFILE("GazeboRosDepthCamera::OnNewRGBPointCloud");
   if (!this->initialized_ || this->height_ <=0 || this->width_ <=0)
     return;
 
+  IGN_PROFILE_BEGIN("fill ROS message");
 # if GAZEBO_MAJOR_VERSION >= 7
   this->depth_sensor_update_time_ = this->parentSensor->LastMeasurementTime();
 # else
@@ -380,6 +388,7 @@ void GazeboRosDepthCamera::OnNewRGBPointCloud(const float *_pcd,
       this->lock_.unlock();
     }
   }
+  IGN_PROFILE_END();
 }
 
 #if GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION > 12
@@ -389,9 +398,12 @@ void GazeboRosDepthCamera::OnNewReflectanceFrame(const float *_image,
     unsigned int _width, unsigned int _height, unsigned int _depth,
     const std::string &_format)
 {
+  IGN_PROFILE("GazeboRosDepthCamera::OnNewReflectanceFrame");
 
   if (!this->initialized_ || this->height_ <=0 || this->width_ <=0)
     return;
+
+    IGN_PROFILE_BEGIN("fill ROS message");
 
   /// don't bother if there are no subscribers
   if (this->reflectance_connect_count_ > 0)
@@ -410,7 +422,7 @@ void GazeboRosDepthCamera::OnNewReflectanceFrame(const float *_image,
     // publish to ros
     this->reflectance_pub_.publish(this->reflectance_msg_);
   }
-
+  IGN_PROFILE_END();
 }
 #endif
 
@@ -420,9 +432,11 @@ void GazeboRosDepthCamera::OnNewImageFrame(const unsigned char *_image,
     unsigned int _width, unsigned int _height, unsigned int _depth,
     const std::string &_format)
 {
+  IGN_PROFILE("GazeboRosDepthCamera::OnNewImageFrame");
+
   if (!this->initialized_ || this->height_ <=0 || this->width_ <=0)
     return;
-
+  IGN_PROFILE_BEGIN("fill ROS message");
   //ROS_ERROR_NAMED("depth_camera", "camera_ new frame %s %s",this->parentSensor_->GetName().c_str(),this->frame_name_.c_str());
 # if GAZEBO_MAJOR_VERSION >= 7
   this->sensor_update_time_ = this->parentSensor->LastMeasurementTime();
@@ -445,6 +459,7 @@ void GazeboRosDepthCamera::OnNewImageFrame(const unsigned char *_image,
       // this->PublishCameraInfo(sensor_update_time);
     }
   }
+  IGN_PROFILE_END();
 }
 
 #if GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION > 12
@@ -452,8 +467,11 @@ void GazeboRosDepthCamera::OnNewNormalsFrame(const float * _normals,
                unsigned int _width, unsigned int _height,
                unsigned int _depth, const std::string &_format)
 {
+  IGN_PROFILE("GazeboRosDepthCamera::OnNewNormalsFrame");
+
   if (!this->initialized_ || this->height_ <=0 || this->width_ <=0)
     return;
+  IGN_PROFILE_BEGIN("fill ROS message");
 
   visualization_msgs::MarkerArray m_array;
 
@@ -529,6 +547,7 @@ void GazeboRosDepthCamera::OnNewNormalsFrame(const float * _normals,
       this->normal_pub_.publish(m_array);
     }
   }
+  IGN_PROFILE_END();
 }
 #endif
 

--- a/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
@@ -52,6 +52,8 @@
 
 #include <gazebo_plugins/gazebo_ros_diff_drive.h>
 
+#include <ignition/common/Profiler.hh>
+
 #include <ignition/math/Angle.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/math/Quaternion.hh>
@@ -239,7 +241,8 @@ void GazeboRosDiffDrive::publishWheelTF()
 // Update the controller
 void GazeboRosDiffDrive::UpdateChild()
 {
-
+  IGN_PROFILE("GazeboRosDiffDrive::UpdateChild");
+  IGN_PROFILE_BEGIN("update");
     /* force reset SetParam("fmax") since Joint::Reset reset MaxForce to zero at
        https://bitbucket.org/osrf/gazebo/src/8091da8b3c529a362f39b042095e12c94656a5d1/gazebo/physics/Joint.cc?at=gazebo2_2.2.5#cl-331
        (this has been solved in https://bitbucket.org/osrf/gazebo/diff/gazebo/physics/Joint.cc?diff2=b64ff1b7b6ff&at=issue_964 )
@@ -299,6 +302,7 @@ void GazeboRosDiffDrive::UpdateChild()
         }
         last_update_time_+= common::Time ( update_period_ );
     }
+    IGN_PROFILE_END();
 }
 
 // Finalize the controller

--- a/gazebo_plugins/src/gazebo_ros_f3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_f3d.cpp
@@ -22,6 +22,7 @@
  */
 
 #include <gazebo_plugins/gazebo_ros_f3d.h>
+#include <ignition/common/Profiler.hh>
 #include <tf/tf.h>
 
 namespace gazebo
@@ -146,8 +147,12 @@ void GazeboRosF3D::F3DDisconnect()
 // Update the controller
 void GazeboRosF3D::UpdateChild()
 {
+  IGN_PROFILE("GazeboRosF3D::UpdateChild");
+
   if (this->f3d_connect_count_ == 0)
     return;
+
+  IGN_PROFILE_BEGIN("fill ROS message");
 
   ignition::math::Vector3d torque;
   ignition::math::Vector3d force;
@@ -178,8 +183,10 @@ void GazeboRosF3D::UpdateChild()
   this->wrench_msg_.wrench.torque.x   = torque.X();
   this->wrench_msg_.wrench.torque.y   = torque.Y();
   this->wrench_msg_.wrench.torque.z   = torque.Z();
-
+  IGN_PROFILE_END();
+  IGN_PROFILE_BEGIN("publish");
   this->pub_.publish(this->wrench_msg_);
+  IGN_PROFILE_END();
   this->lock_.unlock();
 
 }

--- a/gazebo_plugins/src/gazebo_ros_force.cpp
+++ b/gazebo_plugins/src/gazebo_ros_force.cpp
@@ -25,6 +25,7 @@
 #include <assert.h>
 
 #include <gazebo_plugins/gazebo_ros_force.h>
+#include <ignition/common/Profiler.hh>
 
 namespace gazebo
 {
@@ -136,12 +137,15 @@ void GazeboRosForce::UpdateObjectForce(const geometry_msgs::Wrench::ConstPtr& _m
 // Update the controller
 void GazeboRosForce::UpdateChild()
 {
+  IGN_PROFILE("GazeboRosForce::OnNewFrame");
+  IGN_PROFILE_BEGIN("fill ROS message");
   this->lock_.lock();
   ignition::math::Vector3d force(this->wrench_msg_.force.x,this->wrench_msg_.force.y,this->wrench_msg_.force.z);
   ignition::math::Vector3d torque(this->wrench_msg_.torque.x,this->wrench_msg_.torque.y,this->wrench_msg_.torque.z);
   this->link_->AddForce(force);
   this->link_->AddTorque(torque);
   this->lock_.unlock();
+  IGN_PROFILE_END();
 }
 
 // Custom Callback Queue

--- a/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ft_sensor.cpp
@@ -22,6 +22,7 @@
 
 #include <gazebo_plugins/gazebo_ros_ft_sensor.h>
 #include <tf/tf.h>
+#include <ignition/common/Profiler.hh>
 #include <ignition/math/Rand.hh>
 
 namespace gazebo
@@ -157,6 +158,9 @@ void GazeboRosFT::FTDisconnect()
 // Update the controller
 void GazeboRosFT::UpdateChild()
 {
+  IGN_PROFILE("GazeboRosFT::UpdateChild");
+  IGN_PROFILE_BEGIN("fill ROS message");
+
 #if GAZEBO_MAJOR_VERSION >= 8
   common::Time cur_time = this->world_->SimTime();
 #else
@@ -207,8 +211,10 @@ void GazeboRosFT::UpdateChild()
   this->wrench_msg_.wrench.torque.x = torque.X() + this->GaussianKernel(0, this->gaussian_noise_);
   this->wrench_msg_.wrench.torque.y = torque.Y() + this->GaussianKernel(0, this->gaussian_noise_);
   this->wrench_msg_.wrench.torque.z = torque.Z() + this->GaussianKernel(0, this->gaussian_noise_);
-
+  IGN_PROFILE_END();
+  IGN_PROFILE_BEGIN("publish");
   this->pub_.publish(this->wrench_msg_);
+  IGN_PROFILE_END();
   this->lock_.unlock();
 
   // save last time stamp

--- a/gazebo_plugins/src/gazebo_ros_gpu_laser.cpp
+++ b/gazebo_plugins/src/gazebo_ros_gpu_laser.cpp
@@ -35,6 +35,8 @@
 #include <gazebo/sensors/SensorTypes.hh>
 #include <gazebo/transport/transport.hh>
 
+#include <ignition/common/Profiler.hh>
+
 #include <tf/tf.h>
 #include <tf/transform_listener.h>
 
@@ -184,6 +186,9 @@ void GazeboRosLaser::LaserDisconnect()
 // Convert new Gazebo message to ROS message and publish it
 void GazeboRosLaser::OnScan(ConstLaserScanStampedPtr &_msg)
 {
+  IGN_PROFILE("GazeboRosLaser::OnScan");
+  IGN_PROFILE_BEGIN("fill ROS message");
+
   // We got a new message from the Gazebo sensor.  Stuff a
   // corresponding ROS message and publish it.
   sensor_msgs::LaserScan laser_msg;
@@ -205,5 +210,6 @@ void GazeboRosLaser::OnScan(ConstLaserScanStampedPtr &_msg)
             _msg->scan().intensities().end(),
             laser_msg.intensities.begin());
   this->pub_queue_->push(laser_msg, this->pub_);
+  IGN_PROFILE_END();
 }
 }

--- a/gazebo_plugins/src/gazebo_ros_harness.cpp
+++ b/gazebo_plugins/src/gazebo_ros_harness.cpp
@@ -16,6 +16,7 @@
 */
 #include <gazebo/physics/World.hh>
 #include <gazebo/physics/Model.hh>
+#include <ignition/common/Profiler.hh>
 #include <sdf/sdf.hh>
 
 #include "gazebo_plugins/gazebo_ros_harness.h"
@@ -84,8 +85,11 @@ void GazeboRosHarness::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf)
 /////////////////////////////////////////////////
 void GazeboRosHarness::OnVelocity(const std_msgs::Float32::ConstPtr &msg)
 {
+  IGN_PROFILE("GazeboRosHarness::OnVelocity");
   // Set the target winch velocity
+  IGN_PROFILE_BEGIN("process ROS message");
   this->SetWinchVelocity(msg->data);
+  IGN_PROFILE_END();
 }
 
 /////////////////////////////////////////////////

--- a/gazebo_plugins/src/gazebo_ros_imu.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu.cpp
@@ -22,6 +22,7 @@
 
 #include <gazebo_plugins/gazebo_ros_imu.h>
 #include <ignition/math/Rand.hh>
+#include <ignition/common/Profiler.hh>
 
 namespace gazebo
 {
@@ -216,6 +217,8 @@ bool GazeboRosIMU::ServiceCallback(std_srvs::Empty::Request &req,
 // Update the controller
 void GazeboRosIMU::UpdateChild()
 {
+  IGN_PROFILE("GazeboRosIMU::UpdateChild");
+
 #if GAZEBO_MAJOR_VERSION >= 8
   common::Time cur_time = this->world_->SimTime();
 #else
@@ -229,6 +232,7 @@ void GazeboRosIMU::UpdateChild()
 
   if ((this->pub_.getNumSubscribers() > 0 && this->topic_name_ != ""))
   {
+    IGN_PROFILE_BEGIN("fill ROS message");
     ignition::math::Pose3d pose;
     ignition::math::Quaterniond rot;
     ignition::math::Vector3d pos;
@@ -331,6 +335,7 @@ void GazeboRosIMU::UpdateChild()
 
     // save last time stamp
     this->last_time_ = cur_time;
+    IGN_PROFILE_END();
   }
 }
 

--- a/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_pose_trajectory.cpp
@@ -27,6 +27,8 @@
 
 #include <gazebo_plugins/gazebo_ros_joint_pose_trajectory.h>
 
+#include <ignition/common/Profiler.hh>
+
 namespace gazebo
 {
 GZ_REGISTER_MODEL_PLUGIN(GazeboRosJointPoseTrajectory);
@@ -337,6 +339,10 @@ bool GazeboRosJointPoseTrajectory::SetTrajectory(
 // Play the trajectory, update states
 void GazeboRosJointPoseTrajectory::UpdateStates()
 {
+  IGN_PROFILE("GazeboRosJointPoseTrajectory::UpdateStates");
+
+  IGN_PROFILE_BEGIN("update");
+
   boost::mutex::scoped_lock lock(this->update_mutex);
   if (this->has_trajectory_)
   {
@@ -437,6 +443,7 @@ void GazeboRosJointPoseTrajectory::UpdateStates()
       }
     }
   }
+  IGN_PROFILE_END();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gazebo_plugins/src/gazebo_ros_joint_state_publisher.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_state_publisher.cpp
@@ -27,6 +27,7 @@
  **/
 #include <boost/algorithm/string.hpp>
 #include <gazebo_plugins/gazebo_ros_joint_state_publisher.h>
+#include <ignition/common/Profiler.hh>
 #include <tf/transform_broadcaster.h>
 #include <tf/transform_listener.h>
 
@@ -109,7 +110,9 @@ void GazeboRosJointStatePublisher::Load ( physics::ModelPtr _parent, sdf::Elemen
                                  boost::bind ( &GazeboRosJointStatePublisher::OnUpdate, this, _1 ) );
 }
 
-void GazeboRosJointStatePublisher::OnUpdate ( const common::UpdateInfo & _info ) {
+void GazeboRosJointStatePublisher::OnUpdate ( const common::UpdateInfo & _info )
+{
+  IGN_PROFILE("GazeboRosCamera::OnNewFrame");
     // Apply a small linear velocity to the model.
 #if GAZEBO_MAJOR_VERSION >= 8
     common::Time current_time = this->world_->SimTime();
@@ -126,7 +129,9 @@ void GazeboRosJointStatePublisher::OnUpdate ( const common::UpdateInfo & _info )
 
     if ( seconds_since_last_update > update_period_ ) {
 
+        IGN_PROFILE_BEGIN("publishJointStates");
         publishJointStates();
+        IGN_PROFILE_END();
 
         last_update_time_+= common::Time ( update_period_ );
 

--- a/gazebo_plugins/src/gazebo_ros_laser.cpp
+++ b/gazebo_plugins/src/gazebo_ros_laser.cpp
@@ -35,6 +35,8 @@
 #include <gazebo/sensors/SensorTypes.hh>
 #include <gazebo/transport/transport.hh>
 
+#include <ignition/common/Profiler.hh>
+
 #include <tf/tf.h>
 #include <tf/transform_listener.h>
 
@@ -179,6 +181,9 @@ void GazeboRosLaser::LaserDisconnect()
 // Convert new Gazebo message to ROS message and publish it
 void GazeboRosLaser::OnScan(ConstLaserScanStampedPtr &_msg)
 {
+  IGN_PROFILE("GazeboRosLaser::OnScan");
+  IGN_PROFILE_BEGIN("fill ROS message");
+
   // We got a new message from the Gazebo sensor.  Stuff a
   // corresponding ROS message and publish it.
   sensor_msgs::LaserScan laser_msg;
@@ -200,5 +205,6 @@ void GazeboRosLaser::OnScan(ConstLaserScanStampedPtr &_msg)
             _msg->scan().intensities().end(),
             laser_msg.intensities.begin());
   this->pub_queue_->push(laser_msg, this->pub_);
+  IGN_PROFILE_END();
 }
 }

--- a/gazebo_plugins/src/gazebo_ros_multicamera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_multicamera.cpp
@@ -28,6 +28,8 @@
 
 #include "gazebo_plugins/gazebo_ros_multicamera.h"
 
+#include <ignition/common/Profiler.hh>
+
 namespace gazebo
 {
 // Register this plugin with the simulator
@@ -98,6 +100,8 @@ void GazeboRosMultiCamera::Load(sensors::SensorPtr _parent,
 void GazeboRosMultiCamera::OnNewFrame(const unsigned char *_image,
     GazeboRosCameraUtils* util)
 {
+  IGN_PROFILE("GazeboRosMultiCamera::OnNewFrame");
+
 # if GAZEBO_MAJOR_VERSION >= 7
   common::Time sensor_update_time = util->parentSensor_->LastMeasurementTime();
 # else
@@ -108,8 +112,12 @@ void GazeboRosMultiCamera::OnNewFrame(const unsigned char *_image,
   {
     if (sensor_update_time - util->last_update_time_ >= util->update_period_)
     {
+      IGN_PROFILE_BEGIN("PutCameraData");
       util->PutCameraData(_image, sensor_update_time);
+      IGN_PROFILE_END();
+      IGN_PROFILE_BEGIN("PublishCameraInfo");
       util->PublishCameraInfo(sensor_update_time);
+      IGN_PROFILE_END();
       util->last_update_time_ = sensor_update_time;
     }
   }

--- a/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
+++ b/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp
@@ -32,6 +32,8 @@
 #include <sdf/sdf.hh>
 #include <gazebo/sensors/SensorTypes.hh>
 
+#include <ignition/common/Profiler.hh>
+
 #include <sensor_msgs/point_cloud2_iterator.h>
 
 #include <tf/tf.h>
@@ -191,8 +193,12 @@ void GazeboRosOpenniKinect::OnNewDepthFrame(const float *_image,
     unsigned int _width, unsigned int _height, unsigned int _depth,
     const std::string &_format)
 {
+  IGN_PROFILE("GazeboRosOpenniKinect::OnNewDepthFrame");
+
   if (!this->initialized_ || this->height_ <=0 || this->width_ <=0)
     return;
+
+  IGN_PROFILE_BEGIN("fill ROS message");
 
   this->depth_sensor_update_time_ = this->parentSensor->LastMeasurementTime();
   if (this->parentSensor->IsActive())
@@ -219,7 +225,10 @@ void GazeboRosOpenniKinect::OnNewDepthFrame(const float *_image,
       // do this first so there's chance for sensor to run 1 frame after activate
       this->parentSensor->SetActive(true);
   }
+  IGN_PROFILE_END();
+  IGN_PROFILE_BEGIN("PublishCameraInfo");
   PublishCameraInfo();
+  IGN_PROFILE_END();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 
 #include "gazebo_plugins/gazebo_ros_p3d.h"
+#include <ignition/common/Profiler.hh>
 #include <ignition/math/Rand.hh>
 
 namespace gazebo
@@ -212,6 +213,8 @@ void GazeboRosP3D::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf)
 // Update the controller
 void GazeboRosP3D::UpdateChild()
 {
+  IGN_PROFILE("GazeboRosP3D::UpdateChild");
+
   if (!this->link_)
     return;
 
@@ -220,6 +223,8 @@ void GazeboRosP3D::UpdateChild()
 #else
   common::Time cur_time = this->world_->GetSimTime();
 #endif
+
+  IGN_PROFILE_BEGIN("fill ROS message");
 
   if (cur_time < this->last_time_)
   {
@@ -357,6 +362,7 @@ void GazeboRosP3D::UpdateChild()
       this->last_time_ = cur_time;
     }
   }
+  IGN_PROFILE_END();
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/gazebo_plugins/src/gazebo_ros_planar_move.cpp
+++ b/gazebo_plugins/src/gazebo_ros_planar_move.cpp
@@ -23,6 +23,7 @@
  */
 
 #include <gazebo_plugins/gazebo_ros_planar_move.h>
+#include <ignition/common/Profiler.hh>
 
 namespace gazebo
 {
@@ -167,6 +168,8 @@ namespace gazebo
   // Update the controller
   void GazeboRosPlanarMove::UpdateChild()
   {
+    IGN_PROFILE("GazeboRosPlanarMove::UpdateChild");
+    IGN_PROFILE_BEGIN("fill ROS message");
     boost::mutex::scoped_lock scoped_lock(lock);
 #if GAZEBO_MAJOR_VERSION >= 8
     ignition::math::Pose3d pose = parent_->WorldPose();
@@ -179,6 +182,8 @@ namespace gazebo
           y_ * cosf(yaw) + x_ * sinf(yaw),
           0));
     parent_->SetAngularVel(ignition::math::Vector3d(0, 0, rot_));
+    IGN_PROFILE_END();
+
     if (odometry_rate_ > 0.0) {
 #if GAZEBO_MAJOR_VERSION >= 8
       common::Time current_time = parent_->GetWorld()->SimTime();
@@ -188,7 +193,9 @@ namespace gazebo
       double seconds_since_last_update =
         (current_time - last_odom_publish_time_).Double();
       if (seconds_since_last_update > (1.0 / odometry_rate_)) {
+        IGN_PROFILE_BEGIN("publishOdometry");
         publishOdometry(seconds_since_last_update);
+        IGN_PROFILE_END();
         last_odom_publish_time_ = current_time;
       }
     }

--- a/gazebo_plugins/src/gazebo_ros_projector.cpp
+++ b/gazebo_plugins/src/gazebo_ros_projector.cpp
@@ -32,6 +32,8 @@
 #include <gazebo/rendering/RTShaderSystem.hh>
 #include <gazebo_plugins/gazebo_ros_projector.h>
 
+#include <ignition/common/Profiler.hh>
+
 #include <std_msgs/String.h>
 #include <std_msgs/Int32.h>
 
@@ -75,9 +77,6 @@ GazeboRosProjector::~GazeboRosProjector()
 void GazeboRosProjector::Load( physics::ModelPtr _parent, sdf::ElementPtr _sdf )
 {
   this->world_ = _parent->GetWorld();
-
-
-
 
   // Create a new transport node for talking to the projector
   this->node_.reset(new transport::Node());
@@ -144,20 +143,26 @@ void GazeboRosProjector::Load( physics::ModelPtr _parent, sdf::ElementPtr _sdf )
 // Load a texture into the projector
 void GazeboRosProjector::LoadImage(const std_msgs::String::ConstPtr& imageMsg)
 {
+  IGN_PROFILE("GazeboRosProjector::LoadImage");
+  IGN_PROFILE_BEGIN("publish");
   msgs::Projector msg;
   msg.set_name("texture_projector");
   msg.set_texture(imageMsg->data);
   this->projector_pub_->Publish(msg);
+  IGN_PROFILE_END();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 // Toggle the activation of the projector
 void GazeboRosProjector::ToggleProjector(const std_msgs::Int32::ConstPtr& projectorMsg)
 {
+  IGN_PROFILE("GazeboRosProjector::ToggleProjector");
+  IGN_PROFILE_BEGIN("publish");
   msgs::Projector msg;
   msg.set_name("texture_projector");
   msg.set_enabled(projectorMsg->data);
   this->projector_pub_->Publish(msg);
+  IGN_PROFILE_END();
 }
 
 

--- a/gazebo_plugins/src/gazebo_ros_prosilica.cpp
+++ b/gazebo_plugins/src/gazebo_ros_prosilica.cpp
@@ -157,7 +157,7 @@ void GazeboRosProsilica::OnNewImageFrame(const unsigned char *_image,
           IGN_PROFILE_BEGIN("PutCameraData");
           this->PutCameraData(_image, sensor_update_time);
           IGN_PROFILE_END();
-          IGN_PROFILE_BEGIN("PutCameraData");
+          IGN_PROFILE_BEGIN("PublishCameraInfo");
           this->PublishCameraInfo(sensor_update_time);
           IGN_PROFILE_END();
           this->last_update_time_ = sensor_update_time;

--- a/gazebo_plugins/src/gazebo_ros_prosilica.cpp
+++ b/gazebo_plugins/src/gazebo_ros_prosilica.cpp
@@ -35,6 +35,8 @@
 #include <gazebo/sensors/SensorTypes.hh>
 #include <gazebo/rendering/Camera.hh>
 
+#include <ignition/common/Profiler.hh>
+
 #include <sdf/sdf.hh>
 #include <sdf/Param.hh>
 
@@ -125,6 +127,8 @@ void GazeboRosProsilica::OnNewImageFrame(const unsigned char *_image,
     unsigned int _width, unsigned int _height, unsigned int _depth,
     const std::string &_format)
 {
+  IGN_PROFILE("GazeboRosProsilica::OnNewImageFrame");
+
   if (!this->rosnode_->getParam(this->mode_param_name,this->mode_))
       this->mode_ = "streaming";
 
@@ -150,8 +154,12 @@ void GazeboRosProsilica::OnNewImageFrame(const unsigned char *_image,
       {
         if (sensor_update_time - this->last_update_time_ >= this->update_period_)
         {
+          IGN_PROFILE_BEGIN("PutCameraData");
           this->PutCameraData(_image, sensor_update_time);
+          IGN_PROFILE_END();
+          IGN_PROFILE_BEGIN("PutCameraData");
           this->PublishCameraInfo(sensor_update_time);
+          IGN_PROFILE_END();
           this->last_update_time_ = sensor_update_time;
         }
       }

--- a/gazebo_plugins/src/gazebo_ros_range.cpp
+++ b/gazebo_plugins/src/gazebo_ros_range.cpp
@@ -48,6 +48,8 @@
 #include <gazebo/sensors/RaySensor.hh>
 #include <gazebo/sensors/SensorTypes.hh>
 
+#include <ignition/common/Profiler.hh>
+
 #include <sdf/sdf.hh>
 #include <sdf/Param.hh>
 
@@ -241,6 +243,8 @@ void GazeboRosRange::RangeDisconnect()
 // Update the plugin
 void GazeboRosRange::OnNewLaserScans()
 {
+  IGN_PROFILE("GazeboRosRange::OnNewLaserScans");
+
   if (this->topic_name_ != "")
   {
 #if GAZEBO_MAJOR_VERSION >= 8
@@ -258,7 +262,9 @@ void GazeboRosRange::OnNewLaserScans()
     {
       common::Time sensor_update_time =
         this->parent_sensor_->LastUpdateTime();
+      IGN_PROFILE_BEGIN("PutRangeData");
       this->PutRangeData(sensor_update_time);
+      IGN_PROFILE_END();
       this->last_update_time_ = cur_time;
     }
   }

--- a/gazebo_plugins/src/gazebo_ros_triggered_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_triggered_camera.cpp
@@ -24,6 +24,8 @@
 #include <gazebo/sensors/CameraSensor.hh>
 #include <gazebo/sensors/SensorTypes.hh>
 
+#include <ignition/common/Profiler.hh>
+
 namespace gazebo
 {
 
@@ -89,14 +91,22 @@ void GazeboRosTriggeredCamera::OnNewFrame(const unsigned char *_image,
     unsigned int _width, unsigned int _height, unsigned int _depth,
     const std::string &_format)
 {
+  IGN_PROFILE("GazeboRosTriggeredCamera::OnNewFrame");
+
   this->sensor_update_time_ = this->parentSensor_->LastMeasurementTime();
 
   if ((*this->image_connect_count_) > 0)
   {
+    IGN_PROFILE_BEGIN("PutCameraData");
     this->PutCameraData(_image);
+    IGN_PROFILE_END();
+    IGN_PROFILE_BEGIN("PublishCameraInfo");
     this->PublishCameraInfo();
+    IGN_PROFILE_END();
   }
+  IGN_PROFILE_BEGIN("SetCameraEnabled");
   this->SetCameraEnabled(false);
+  IGN_PROFILE_END();
 
   std::lock_guard<std::mutex> lock(this->mutex);
   this->triggered = std::max(this->triggered-1, 0);

--- a/gazebo_plugins/src/gazebo_ros_triggered_multicamera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_triggered_multicamera.cpp
@@ -23,6 +23,8 @@
 
 #include "gazebo_plugins/gazebo_ros_triggered_multicamera.h"
 
+#include <ignition/common/Profiler.hh>
+
 namespace gazebo
 {
 // Register this plugin with the simulator
@@ -94,8 +96,11 @@ void GazeboRosTriggeredMultiCamera::OnNewFrameLeft(const unsigned char *_image,
     unsigned int _width, unsigned int _height, unsigned int _depth,
     const std::string &_format)
 {
+  IGN_PROFILE("GazeboRosTriggeredMultiCamera::OnNewFrameLeft");
   GazeboRosTriggeredCamera * cam = this->triggered_cameras[0];
+  IGN_PROFILE_BEGIN("OnNewFrame");
   cam->OnNewFrame(_image, _width, _height, _depth, _format);
+  IGN_PROFILE_END();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -104,7 +109,10 @@ void GazeboRosTriggeredMultiCamera::OnNewFrameRight(const unsigned char *_image,
     unsigned int _width, unsigned int _height, unsigned int _depth,
     const std::string &_format)
 {
+  IGN_PROFILE("GazeboRosTriggeredMultiCamera::OnNewFrameRight");
   GazeboRosTriggeredCamera * cam = this->triggered_cameras[1];
+  IGN_PROFILE_BEGIN("OnNewFrame");
   cam->OnNewFrame(_image, _width, _height, _depth, _format);
+  IGN_PROFILE_END();
 }
 }

--- a/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_vacuum_gripper.cpp
@@ -26,7 +26,7 @@
 
 #include <std_msgs/Bool.h>
 #include <gazebo_plugins/gazebo_ros_vacuum_gripper.h>
-
+#include <ignition/common/Profiler.hh>
 
 namespace gazebo
 {
@@ -171,14 +171,19 @@ bool GazeboRosVacuumGripper::OffServiceCallback(std_srvs::Empty::Request &req,
 // Update the controller
 void GazeboRosVacuumGripper::UpdateChild()
 {
+  IGN_PROFILE("GazeboRosVacuumGripper::UpdateChild");
+
   std_msgs::Bool grasping_msg;
   grasping_msg.data = false;
   if (!status_) {
+    IGN_PROFILE_BEGIN("publish status");
     pub_.publish(grasping_msg);
+    IGN_PROFILE_END();
     return;
   }
   // apply force
   lock_.lock();
+  IGN_PROFILE_BEGIN("apply force");
 #if GAZEBO_MAJOR_VERSION >= 8
   ignition::math::Pose3d parent_pose = link_->WorldPose();
   physics::Model_V models = world_->Models();
@@ -225,7 +230,10 @@ void GazeboRosVacuumGripper::UpdateChild()
       }
     }
   }
+  IGN_PROFILE_END();
+  IGN_PROFILE_BEGIN("publish grasping_msg");
   pub_.publish(grasping_msg);
+  IGN_PROFILE_END();
   lock_.unlock();
 }
 

--- a/gazebo_plugins/src/gazebo_ros_video.cpp
+++ b/gazebo_plugins/src/gazebo_ros_video.cpp
@@ -21,8 +21,9 @@
  * Date: 26 July 2013
  */
 
-#include <gazebo_plugins/gazebo_ros_video.h>
 #include <boost/lexical_cast.hpp>
+#include <gazebo_plugins/gazebo_ros_video.h>
+#include <ignition/common/Profiler.hh>
 
 namespace gazebo
 {
@@ -224,10 +225,14 @@ namespace gazebo
   // Update the controller
   void GazeboRosVideo::UpdateChild()
   {
+    IGN_PROFILE("GazeboRosVideo::UpdateChild");
+
     boost::mutex::scoped_lock scoped_lock(m_image_);
     if (new_image_available_)
     {
+      IGN_PROFILE_BEGIN("render");
       video_visual_->render(image_->image);
+      IGN_PROFILE_END();
     }
     new_image_available_ = false;
   }


### PR DESCRIPTION
This PR is related to this other in Gazebo https://github.com/osrf/gazebo/pull/2776

It will allow to profile the methods in `gazebo_plugins` which are called periodically

To compile with the profile enable you need add this option `-DENABLE_PROFILER=1`. For example:

```
catkin_make_isolated --pkg gazebo_plugins --cmake-args -DENABLE_PROFILER=1
```

Signed-off-by: ahcorde <ahcorde@gmail.com>