### PR TITLE
[gazebo_plugins] fix bug for memory problem and subscripts wrong in gazebo_ros_moveit_planning_scene

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_moveit_planning_scene.cpp
+++ b/gazebo_plugins/src/gazebo_ros_moveit_planning_scene.cpp
@@ -401,16 +401,16 @@ void GazeboRosMoveItPlanningScene::UpdateCB()
                     //gzwarn<<"TRIANGLES"<<std::endl;
                     shape_msgs::Mesh mesh_msg;
                     mesh_msg.vertices.resize(n_vertices);
-                    mesh_msg.triangles.resize(n_vertices/3);
+                    mesh_msg.triangles.resize(n_vertices/3+1);
 
                     for(size_t v=0; v < n_vertices; v++) {
 
                       const int index = submesh->GetIndex(v);
                       const ignition::math::Vector3d vertex = submesh->Vertex(v);
 
-                      mesh_msg.vertices[index].x = vertex.X() * scale.X();
-                      mesh_msg.vertices[index].y = vertex.Y() * scale.Y();
-                      mesh_msg.vertices[index].z = vertex.Z() * scale.Z();
+                      mesh_msg.vertices[v].x = vertex.X() * scale.X();
+                      mesh_msg.vertices[v].y = vertex.Y() * scale.Y();
+                      mesh_msg.vertices[v].z = vertex.Z() * scale.Z();
 
                       mesh_msg.triangles[v/3].vertex_indices[v%3] = index;
                     }


### PR DESCRIPTION
When I use the gazebo_ros_moveit_planning_scene to get MoveIt PlanningScene messages, the code report error about memory for thousands of lines as follows:
<code>
*** Error in `gzserver': free(): invalid next size (fast): 0x00007fd8c769ff70 ***
======= Backtrace: =========
/lib/x86_64-linux-gnu/libc.so.6(+0x777f5)[0x7fd9d81f77f5]
/lib/x86_64-linux-gnu/libc.so.6(+0x8038a)[0x7fd9d820038a]
/lib/x86_64-linux-gnu/libc.so.6(cfree+0x4c)[0x7fd9d820458c]
/home/yin/catkin_ws/devel/lib/libgazebo_ros_moveit_planning_scene.so(_ZN9__gnu_cxx13new_allocatorIN10shape_msgs13MeshTriangle_ISaIvEEEE10deallocateEPS4_m+0x20)[0x7fd8b19685dc]
/home/yin/catkin_ws/devel/lib/libgazebo_ros_moveit_planning_scene.so(_ZNSt16allocator_traitsISaIN10shape_msgs13MeshTriangle_ISaIvEEEEE10deallocateERS4_PS3_m+0x2b)[0x7fd8b19644a4]
/home/yin/catkin_ws/devel/lib/libgazebo_ros_moveit_planning_scene.so(_ZNSt12_Vector_baseIN10shape_msgs13MeshTriangle_ISaIvEEESaIS3_EE13_M_deallocateEPS3_m+0x32)[0x7fd8b195faa4]
/home/yin/catkin_ws/devel/lib/libgazebo_ros_moveit_planning_scene.so(_ZNSt12_Vector_baseIN10shape_msgs13MeshTriangle_ISaIvEEESaIS3_EED1Ev+0x52)[0x7fd8b19598ee]
/home/yin/catkin_ws/devel/lib/libgazebo_ros_moveit_planning_scene.so(_ZNSt6vectorIN10shape_msgs13MeshTriangle_ISaIvEEESaIS3_EED1Ev+0x41)[0x7fd8b195236d]
/home/yin/catkin_ws/devel/lib/libgazebo_ros_moveit_planning_scene.so(_ZN10shape_msgs5Mesh_ISaIvEED2Ev+0x28)[0x7fd8b194c7f8]
/home/yin/catkin_ws/devel/lib/libgazebo_ros_moveit_planning_scene.so(_ZN6gazebo28GazeboRosMoveItPlanningScene8UpdateCBEv+0x19f9)[0x7fd8b1946df5]
/home/yin/catkin_ws/devel/lib/libgazebo_ros_moveit_planning_scene.so(_ZNK5boost4_mfi3mf0IvN6gazebo28GazeboRosMoveItPlanningSceneEEclEPS3_+0x65)[0x7fd8b196d4f5]
/home/yin/catkin_ws/devel/lib/libgazebo_ros_moveit_planning_scene.so(_ZN5boost3_bi5list1INS0_5valueIPN6gazebo28GazeboRosMoveItPlanningSceneEEEEclINS_4_mfi3mf0IvS4_EENS1_IRKNS3_6common10UpdateInfoEEEEEvNS0_4typeIvEERT_RT0_i+0x4a)[0x7fd8b196dc42]
/home/yin/catkin_ws/devel/lib/libgazebo_ros_moveit_planning_scene.so(_ZN5boost3_bi6bind_tIvNS_4_mfi3mf0IvN6gazebo28GazeboRosMoveItPlanningSceneEEENS0_5list1INS0_5valueIPS5_EEEEEclIRKNS4_6common10UpdateInfoEEEvOT_+0x55)[0x7fd8b196ae59]
/home/yin/catkin_ws/devel/lib/libgazebo_ros_moveit_planning_scene.so(_ZN5boost6detail8function26void_function_obj_invoker1INS_3_bi6bind_tIvNS_4_mfi3mf0IvN6gazebo28GazeboRosMoveItPlanningSceneEEENS3_5list1INS3_5valueIPS8_EEEEEEvRKNS7_6common10UpdateInfoEE6invokeERNS1_15function_bufferESJ_+0x36)[0x7fd8b1967634]
/usr/lib/x86_64-linux-gnu/libgazebo_physics.so.7(_ZN6gazebo7physics5World6UpdateEv+0x2b7)[0x7fd9d7962367]
/usr/lib/x86_64-linux-gnu/libgazebo_physics.so.7(_ZN6gazebo7physics5World4StepEv+0x37f)[0x7fd9d79709af]
/usr/lib/x86_64-linux-gnu/libgazebo_physics.so.7(_ZN6gazebo7physics5World7RunLoopEv+0x1b5)[0x7fd9d7970e25]
/usr/lib/x86_64-linux-gnu/libboost_thread.so.1.58.0(+0x115d5)[0x7fd9d57705d5]
/lib/x86_64-linux-gnu/libpthread.so.0(+0x76ba)[0x7fd9d7c856ba]
/lib/x86_64-linux-gnu/libc.so.6(clone+0x6d)[0x7fd9d82874dd]
======= Memory map: ========
00400000-00409000 r-xp 00000000 08:02 15748442                           /usr/bin/gzserver-7.0.0
00608000-00609000 r--p 00008000 08:02 15748442                           /usr/bin/gzserver-7.0.0
00609000-0060a000 rw-p 00009000 08:02 15748442                           /usr/bin/gzserver-7.0.0
00bf3000-0f772000 rw-p 00000000 00:00 0                                  [heap]
7fd874000000-7fd874021000 rw-p 00000000 00:00 0 
7fd874021000-7fd878000000 ---p 00000000 00:00 0 
7fd8791ff000-7fd879fff000 rw-s 00000000 00:19 2267                       /i915 (deleted)
7fd87aafb000-7fd87aafc000 rw-p 00000000 00:00 0 
7fd87aafc000-7fd87ab0c000 rw-s 00000000 00:19 5157                       /i915 (deleted)
7fd87ab0c000-7fd87ab10000 rw-s 00000000 00:19 5156                       /i915 (deleted)
7fd87ab10000-7fd87ab15000 rw-s 00000000 00:19 5155                       /i915 (deleted)
7fd87ab15000-7fd87ab25000 rw-s 00000000 00:19 5154                       /i915 (deleted)
7fd87ab25000-7fd87ab29000 rw-s 00000000 00:19 5151                       /i915 (deleted)
7fd87ab29000-7fd87ab2e000 rw-s 00000000 00:19 5150                       /i915 (deleted)
7fd87ab2e000-7fd87ab3e000 rw-s 00000000 00:19 5149                       /i915 (deleted)
7fd87ab3e000-7fd87ab42000 rw-s 00000000 00:19 5148                       /i915 (deleted)
7fd87ab42000-7fd87ab47000 rw-s 00000000 00:19 5147                       /i915 (deleted)
7fd87ab47000-7fd87ab57000 rw-s 00000000 00:19 5146                       /i915 (deleted)
7fd87ab57000-7fd87ab5b000 rw-s 00000000 00:19 5145                       /i915 (deleted)
7fd87ab5b000-7fd87ab60000 rw-s 00000000 00:19 5144                       /i915 (deleted)
</code>

The wrong is in the line 404 of [gazebo_plugins/src/gazebo_ros_moveit_planning_scene.cpp](). The size `n_vertices/3` is not true, which should be `n_vertices/3+1`.

Otherwise, the subscripts `index` in line 411-413 result in the wrong model in MoveIt, like this picture.
![Screenshot from 2020-08-05 09-53-09](https://user-images.githubusercontent.com/24321881/89363232-470a8680-d702-11ea-929b-461acebda0f1.png)
The subscripts should be `v`. Then the model in MoveIt will be true.
![Screenshot from 2020-08-05 09-58-20](https://user-images.githubusercontent.com/24321881/89363258-51c51b80-d702-11ea-977a-4560409a4888.png)
BTW, the subscripts `index` in line 433-435 may be wrong, too. However, My model has no submesh of type `SubMesh::TRISTRIPS` and I cannot test it, so I didn't modify those codes.