### PR TITLE
Leave empty tf_prefix values unset

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
@@ -295,10 +295,6 @@ void GazeboRosCameraUtils::LoadThread()
 
   // resolve tf prefix
   this->tf_prefix_ = tf::getPrefixParam(*this->rosnode_);
-  if(this->tf_prefix_.empty()) {
-      this->tf_prefix_ = this->robot_namespace_;
-      boost::trim_right_if(this->tf_prefix_,boost::is_any_of("/"));
-  }
   this->frame_name_ = tf::resolve(this->tf_prefix_, this->frame_name_);
 
   ROS_INFO_NAMED("camera_utils", "Camera Plugin (ns = %s)  <tf_prefix_>, set to \"%s\"",

--- a/gazebo_plugins/src/gazebo_ros_gpu_laser.cpp
+++ b/gazebo_plugins/src/gazebo_ros_gpu_laser.cpp
@@ -134,10 +134,6 @@ void GazeboRosLaser::LoadThread()
   this->rosnode_ = new ros::NodeHandle(this->robot_namespace_);
 
   this->tf_prefix_ = tf::getPrefixParam(*this->rosnode_);
-  if(this->tf_prefix_.empty()) {
-      this->tf_prefix_ = this->robot_namespace_;
-      boost::trim_right_if(this->tf_prefix_,boost::is_any_of("/"));
-  }
   ROS_INFO_NAMED("gpu_laser", "GPU Laser Plugin (ns = %s) <tf_prefix_>, set to \"%s\"",
              this->robot_namespace_.c_str(), this->tf_prefix_.c_str());
 

--- a/gazebo_plugins/src/gazebo_ros_laser.cpp
+++ b/gazebo_plugins/src/gazebo_ros_laser.cpp
@@ -131,10 +131,6 @@ void GazeboRosLaser::LoadThread()
   this->rosnode_ = new ros::NodeHandle(this->robot_namespace_);
 
   this->tf_prefix_ = tf::getPrefixParam(*this->rosnode_);
-  if(this->tf_prefix_.empty()) {
-      this->tf_prefix_ = this->robot_namespace_;
-      boost::trim_right_if(this->tf_prefix_,boost::is_any_of("/"));
-  }
   ROS_INFO_NAMED("laser", "Laser Plugin (ns = %s)  <tf_prefix_>, set to \"%s\"",
              this->robot_namespace_.c_str(), this->tf_prefix_.c_str());
 


### PR DESCRIPTION
As reported in #554, tf_prefix has been long deprecated, so if it is unset, leave it empty instead of giving a default value.

Fixes #554.