### PR TITLE
[Noetic] Bridge to republish PerformanceMetrics in ROS

### DIFF
--- a/gazebo_msgs/CMakeLists.txt
+++ b/gazebo_msgs/CMakeLists.txt
@@ -21,6 +21,8 @@ add_message_files(
   ModelStates.msg
   ODEJointProperties.msg
   ODEPhysics.msg
+  PerformanceMetrics.msg
+  SensorPerformanceMetric.msg
   WorldState.msg
   )
 

--- a/gazebo_msgs/msg/PerformanceMetrics.msg
+++ b/gazebo_msgs/msg/PerformanceMetrics.msg
@@ -1,0 +1,4 @@
+Header header
+
+float64 real_time_factor
+gazebo_msgs/SensorPerformanceMetric[] sensors

--- a/gazebo_msgs/msg/SensorPerformanceMetric.msg
+++ b/gazebo_msgs/msg/SensorPerformanceMetric.msg
@@ -1,4 +1,4 @@
-string sensor_name
+string name
 float64 sim_update_rate
 float64 real_update_rate
 float64 fps

--- a/gazebo_msgs/msg/SensorPerformanceMetric.msg
+++ b/gazebo_msgs/msg/SensorPerformanceMetric.msg
@@ -1,0 +1,4 @@
+string sensor_name
+float64 sim_update_rate
+float64 real_update_rate
+float64 fps

--- a/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
+++ b/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
@@ -292,9 +292,10 @@ private:
   /// \brief Unused
   void onResponse(ConstResponsePtr &response);
 
+#if (GAZEBO_MAJOR_VERSION == 11 && GAZEBO_MINOR_VERSION > 1) || (GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION > 14)
   /// \brief Subscriber callback for performance metrics. This will be send in the ROS network
   void onPerformanceMetrics(const boost::shared_ptr<gazebo::msgs::PerformanceMetrics const> &msg);
-
+#endif
   /// \brief utility for checking if string is in URDF format
   bool isURDF(std::string model_xml);
 

--- a/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
+++ b/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
@@ -81,6 +81,7 @@
 #include "gazebo_msgs/LinkState.h"
 #include "gazebo_msgs/ModelStates.h"
 #include "gazebo_msgs/LinkStates.h"
+#include "gazebo_msgs/PerformanceMetrics.h"
 
 #include "geometry_msgs/Vector3.h"
 #include "geometry_msgs/Wrench.h"
@@ -291,6 +292,9 @@ private:
   /// \brief Unused
   void onResponse(ConstResponsePtr &response);
 
+  /// \brief Subscriber callback for performance metrics. This will be send in the ROS network
+  void onPerformanceMetrics(const boost::shared_ptr<gazebo::msgs::PerformanceMetrics const> &msg);
+
   /// \brief utility for checking if string is in URDF format
   bool isURDF(std::string model_xml);
 
@@ -320,6 +324,7 @@ private:
   gazebo::transport::PublisherPtr factory_pub_;
   gazebo::transport::PublisherPtr factory_light_pub_;
   gazebo::transport::PublisherPtr light_modify_pub_;
+  gazebo::transport::SubscriberPtr performance_metric_sub_;
   gazebo::transport::PublisherPtr request_pub_;
   gazebo::transport::SubscriberPtr response_sub_;
 
@@ -366,6 +371,7 @@ private:
   ros::Subscriber    set_model_state_topic_;
   ros::Publisher     pub_link_states_;
   ros::Publisher     pub_model_states_;
+  ros::Publisher     pub_performance_metrics_;
   int                pub_link_states_connection_count_;
   int                pub_model_states_connection_count_;
 

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -239,7 +239,7 @@ void GazeboRosApiPlugin::onPerformanceMetrics(const boost::shared_ptr<gazebo::ms
     gazebo_msgs::SensorPerformanceMetric sensor_msgs;
     sensor_msgs.sim_update_rate = sensor.sim_update_rate();
     sensor_msgs.real_update_rate = sensor.real_update_rate();
-    sensor_msgs.sensor_name = sensor.sensor_name();
+    sensor_msgs.name = sensor.name();
 
     if (sensor.has_fps())
     {

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -193,7 +193,7 @@ void GazeboRosApiPlugin::loadGazeboRosApiPlugin(std::string world_name)
   light_modify_pub_ = gazebonode_->Advertise<gazebo::msgs::Light>("~/light/modify");
   request_pub_ = gazebonode_->Advertise<gazebo::msgs::Request>("~/request");
   response_sub_ = gazebonode_->Subscribe("~/response",&GazeboRosApiPlugin::onResponse, this);
-  response_sub_ = gazebonode_->Subscribe("/gazebo/gazebo/performance_metrics",
+  performance_metric_sub_ = gazebonode_->Subscribe("/gazebo/gazebo/performance_metrics",
     &GazeboRosApiPlugin::onPerformanceMetrics, this);
 
   // reset topic connection counts
@@ -632,7 +632,7 @@ bool GazeboRosApiPlugin::spawnURDFModel(gazebo_msgs::SpawnModel::Request &req,
     if (pos1 != std::string::npos && pos2 != std::string::npos)
       model_xml.replace(pos1,pos2-pos1+2,std::string(""));
   }
-  
+
   // Remove comments from URDF
   {
     std::string open_comment("<!--");

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -193,9 +193,10 @@ void GazeboRosApiPlugin::loadGazeboRosApiPlugin(std::string world_name)
   light_modify_pub_ = gazebonode_->Advertise<gazebo::msgs::Light>("~/light/modify");
   request_pub_ = gazebonode_->Advertise<gazebo::msgs::Request>("~/request");
   response_sub_ = gazebonode_->Subscribe("~/response",&GazeboRosApiPlugin::onResponse, this);
+#if (GAZEBO_MAJOR_VERSION == 11 && GAZEBO_MINOR_VERSION > 1) || (GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION > 14)
   performance_metric_sub_ = gazebonode_->Subscribe("/gazebo/performance_metrics",
     &GazeboRosApiPlugin::onPerformanceMetrics, this);
-
+#endif
   // reset topic connection counts
   pub_link_states_connection_count_ = 0;
   pub_model_states_connection_count_ = 0;
@@ -227,7 +228,7 @@ void GazeboRosApiPlugin::onResponse(ConstResponsePtr &response)
 {
 
 }
-
+#if (GAZEBO_MAJOR_VERSION == 11 && GAZEBO_MINOR_VERSION > 1) || (GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION > 14)
 void GazeboRosApiPlugin::onPerformanceMetrics(const boost::shared_ptr<gazebo::msgs::PerformanceMetrics const> &msg)
 {
   gazebo_msgs::PerformanceMetrics msg_ros;
@@ -253,6 +254,7 @@ void GazeboRosApiPlugin::onPerformanceMetrics(const boost::shared_ptr<gazebo::ms
 
   pub_performance_metrics_.publish(msg_ros);
 }
+#endif
 
 void GazeboRosApiPlugin::gazeboQueueThread()
 {
@@ -409,8 +411,10 @@ void GazeboRosApiPlugin::advertiseServices()
                                                             ros::VoidPtr(), &gazebo_queue_);
   pub_model_states_ = nh_->advertise(pub_model_states_ao);
 
+#if (GAZEBO_MAJOR_VERSION == 11 && GAZEBO_MINOR_VERSION > 1) || (GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION > 14)
   // publish performance metrics
   pub_performance_metrics_ = nh_->advertise<gazebo_msgs::PerformanceMetrics>("performance_metrics", 10);
+#endif
 
   // Advertise more services on the custom queue
   std::string set_link_properties_service_name("set_link_properties");

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -231,6 +231,7 @@ void GazeboRosApiPlugin::onResponse(ConstResponsePtr &response)
 void GazeboRosApiPlugin::onPerformanceMetrics(const boost::shared_ptr<gazebo::msgs::PerformanceMetrics const> &msg)
 {
   gazebo_msgs::PerformanceMetrics msg_ros;
+  msg_ros.header.stamp = ros::Time::now();
   msg_ros.real_time_factor = msg->real_time_factor();
   for (auto sensor: msg->sensor())
   {

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -193,7 +193,7 @@ void GazeboRosApiPlugin::loadGazeboRosApiPlugin(std::string world_name)
   light_modify_pub_ = gazebonode_->Advertise<gazebo::msgs::Light>("~/light/modify");
   request_pub_ = gazebonode_->Advertise<gazebo::msgs::Request>("~/request");
   response_sub_ = gazebonode_->Subscribe("~/response",&GazeboRosApiPlugin::onResponse, this);
-  performance_metric_sub_ = gazebonode_->Subscribe("/gazebo/gazebo/performance_metrics",
+  performance_metric_sub_ = gazebonode_->Subscribe("/gazebo/performance_metrics",
     &GazeboRosApiPlugin::onPerformanceMetrics, this);
 
   // reset topic connection counts

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -237,8 +237,8 @@ void GazeboRosApiPlugin::onPerformanceMetrics(const boost::shared_ptr<gazebo::ms
   for (auto sensor: msg->sensor())
   {
     gazebo_msgs::SensorPerformanceMetric sensor_msgs;
-    sensor_msgs.sim_update_rate = sensor.sim_sensor_update_rate();
-    sensor_msgs.real_update_rate = sensor.real_sensor_update_rate();
+    sensor_msgs.sim_update_rate = sensor.sim_update_rate();
+    sensor_msgs.real_update_rate = sensor.real_update_rate();
     sensor_msgs.sensor_name = sensor.sensor_name();
 
     if (sensor.has_fps())


### PR DESCRIPTION
This PR is related to this other PR https://github.com/osrf/gazebo/pull/2819 which adds a performanceMetrics message. Then this msg will be republish from the Gazebo transport layer to the ROS network.

Signed-off-by: ahcorde <ahcorde@gmail.com>