### PR TITLE
[ROS 2] Bridge to republish PerformanceMetrics in ROS 2

### DIFF
--- a/gazebo_msgs/CMakeLists.txt
+++ b/gazebo_msgs/CMakeLists.txt
@@ -29,6 +29,8 @@ set(msg_files
   "msg/ModelStates.msg"
   "msg/ODEJointProperties.msg"
   "msg/ODEPhysics.msg"
+  "msg/PerformanceMetrics.msg"
+  "msg/SensorPerformanceMetric.msg"
   "msg/WorldState.msg"
 )
 

--- a/gazebo_msgs/msg/PerformanceMetrics.msg
+++ b/gazebo_msgs/msg/PerformanceMetrics.msg
@@ -1,0 +1,4 @@
+std_msgs/Header header
+
+float64 real_time_factor
+gazebo_msgs/SensorPerformanceMetric[] sensors

--- a/gazebo_msgs/msg/SensorPerformanceMetric.msg
+++ b/gazebo_msgs/msg/SensorPerformanceMetric.msg
@@ -1,4 +1,4 @@
-string sensor_name
+string name
 float64 sim_update_rate
 float64 real_update_rate
 float64 fps

--- a/gazebo_msgs/msg/SensorPerformanceMetric.msg
+++ b/gazebo_msgs/msg/SensorPerformanceMetric.msg
@@ -1,0 +1,4 @@
+string sensor_name
+float64 sim_update_rate
+float64 real_update_rate
+float64 fps

--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -87,6 +87,7 @@ add_library(gazebo_ros_init SHARED
 ament_target_dependencies(gazebo_ros_init
   "builtin_interfaces"
   "gazebo_dev"
+  "gazebo_msgs"
   "rclcpp"
   "std_srvs"
 )

--- a/gazebo_ros/src/gazebo_ros_init.cpp
+++ b/gazebo_ros/src/gazebo_ros_init.cpp
@@ -78,9 +78,11 @@ public:
     std_srvs::srv::Empty::Request::SharedPtr req,
     std_srvs::srv::Empty::Response::SharedPtr res);
 
+#if (GAZEBO_MAJOR_VERSION == 11 && GAZEBO_MINOR_VERSION > 1) || (GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION > 14)
   /// \brief Subscriber callback for performance metrics. This will be send in the ROS network
   /// \param[in] msg Received PerformanceMetrics message
   void onPerformanceMetrics(ConstPerformanceMetricsPtr & msg);
+#endif
 
   /// \brief Keep a pointer to the world.
   gazebo::physics::WorldPtr world_;
@@ -154,9 +156,11 @@ void GazeboRosInit::Load(int argc, char ** argv)
     "/clock",
     rclcpp::QoS(rclcpp::KeepLast(10)).transient_local());
 
+#if (GAZEBO_MAJOR_VERSION == 11 && GAZEBO_MINOR_VERSION > 1) || (GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION > 14)
   impl_->performance_metrics_pub_ =
     impl_->ros_node_->create_publisher<gazebo_msgs::msg::PerformanceMetrics>(
     "performance_metrics", 10);
+#endif
 
   // Publish rate parameter
   auto rate_param = impl_->ros_node_->declare_parameter(
@@ -172,6 +176,7 @@ void GazeboRosInit::Load(int argc, char ** argv)
     std::bind(&GazeboRosInitPrivate::OnWorldCreated, impl_.get(), std::placeholders::_1));
 }
 
+#if (GAZEBO_MAJOR_VERSION == 11 && GAZEBO_MINOR_VERSION > 1) || (GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION > 14)
 void GazeboRosInitPrivate::onPerformanceMetrics(
   ConstPerformanceMetricsPtr & msg)
 {
@@ -195,6 +200,7 @@ void GazeboRosInitPrivate::onPerformanceMetrics(
 
   performance_metrics_pub_->publish(msg_ros);
 }
+#endif
 
 void GazeboRosInitPrivate::OnWorldCreated(const std::string & _world_name)
 {
@@ -229,12 +235,14 @@ void GazeboRosInitPrivate::OnWorldCreated(const std::string & _world_name)
       &GazeboRosInitPrivate::OnUnpause, this,
       std::placeholders::_1, std::placeholders::_2));
 
+#if (GAZEBO_MAJOR_VERSION == 11 && GAZEBO_MINOR_VERSION > 1) || (GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION > 14)
   // Gazebo transport
   gz_node_ = gazebo::transport::NodePtr(new gazebo::transport::Node());
   gz_node_->Init(world_->Name());
   performance_metric_sub_ = gz_node_->Subscribe(
     "/gazebo/performance_metrics",
     &GazeboRosInitPrivate::onPerformanceMetrics, this);
+#endif
 }
 
 GazeboRosInitPrivate::GazeboRosInitPrivate()

--- a/gazebo_ros/src/gazebo_ros_init.cpp
+++ b/gazebo_ros/src/gazebo_ros_init.cpp
@@ -78,7 +78,8 @@ public:
     std_srvs::srv::Empty::Request::SharedPtr req,
     std_srvs::srv::Empty::Response::SharedPtr res);
 
-#if (GAZEBO_MAJOR_VERSION == 11 && GAZEBO_MINOR_VERSION > 1) || (GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION > 14)
+#if (GAZEBO_MAJOR_VERSION == 11 && GAZEBO_MINOR_VERSION > 1) || (GAZEBO_MAJOR_VERSION == 9 && \
+  GAZEBO_MINOR_VERSION > 14)
   /// \brief Subscriber callback for performance metrics. This will be send in the ROS network
   /// \param[in] msg Received PerformanceMetrics message
   void onPerformanceMetrics(ConstPerformanceMetricsPtr & msg);
@@ -156,7 +157,8 @@ void GazeboRosInit::Load(int argc, char ** argv)
     "/clock",
     rclcpp::QoS(rclcpp::KeepLast(10)).transient_local());
 
-#if (GAZEBO_MAJOR_VERSION == 11 && GAZEBO_MINOR_VERSION > 1) || (GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION > 14)
+#if (GAZEBO_MAJOR_VERSION == 11 && GAZEBO_MINOR_VERSION > 1) || (GAZEBO_MAJOR_VERSION == 9 && \
+  GAZEBO_MINOR_VERSION > 14)
   impl_->performance_metrics_pub_ =
     impl_->ros_node_->create_publisher<gazebo_msgs::msg::PerformanceMetrics>(
     "performance_metrics", 10);
@@ -176,7 +178,8 @@ void GazeboRosInit::Load(int argc, char ** argv)
     std::bind(&GazeboRosInitPrivate::OnWorldCreated, impl_.get(), std::placeholders::_1));
 }
 
-#if (GAZEBO_MAJOR_VERSION == 11 && GAZEBO_MINOR_VERSION > 1) || (GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION > 14)
+#if (GAZEBO_MAJOR_VERSION == 11 && GAZEBO_MINOR_VERSION > 1) || (GAZEBO_MAJOR_VERSION == 9 && \
+  GAZEBO_MINOR_VERSION > 14)
 void GazeboRosInitPrivate::onPerformanceMetrics(
   ConstPerformanceMetricsPtr & msg)
 {
@@ -235,7 +238,8 @@ void GazeboRosInitPrivate::OnWorldCreated(const std::string & _world_name)
       &GazeboRosInitPrivate::OnUnpause, this,
       std::placeholders::_1, std::placeholders::_2));
 
-#if (GAZEBO_MAJOR_VERSION == 11 && GAZEBO_MINOR_VERSION > 1) || (GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION > 14)
+#if (GAZEBO_MAJOR_VERSION == 11 && GAZEBO_MINOR_VERSION > 1) || (GAZEBO_MAJOR_VERSION == 9 && \
+  GAZEBO_MINOR_VERSION > 14)
   // Gazebo transport
   gz_node_ = gazebo::transport::NodePtr(new gazebo::transport::Node());
   gz_node_->Init(world_->Name());

--- a/gazebo_ros/src/gazebo_ros_init.cpp
+++ b/gazebo_ros/src/gazebo_ros_init.cpp
@@ -15,8 +15,13 @@
 #include "gazebo_ros/gazebo_ros_init.hpp"
 
 #include <gazebo/common/Plugin.hh>
+#include <gazebo/msgs/MessageTypes.hh>
 #include <gazebo/physics/PhysicsIface.hh>
 #include <gazebo/physics/World.hh>
+#include <gazebo/transport/Node.hh>
+
+#include <gazebo_msgs/msg/performance_metrics.hpp>
+#include <gazebo_msgs/msg/sensor_performance_metric.hpp>
 
 #include <gazebo_ros/conversions/builtin_interfaces.hpp>
 #include <gazebo_ros/node.hpp>
@@ -73,6 +78,10 @@ public:
     std_srvs::srv::Empty::Request::SharedPtr req,
     std_srvs::srv::Empty::Response::SharedPtr res);
 
+  /// \brief Subscriber callback for performance metrics. This will be send in the ROS network
+  /// \param[in] msg Received PerformanceMetrics message
+  void onPerformanceMetrics(ConstPerformanceMetricsPtr & msg);
+
   /// \brief Keep a pointer to the world.
   gazebo::physics::WorldPtr world_;
 
@@ -94,6 +103,9 @@ public:
   /// ROS service to handle requests to unpause physics.
   rclcpp::Service<std_srvs::srv::Empty>::SharedPtr unpause_service_;
 
+  /// \brief ROS publisher to publish performance metrics.
+  rclcpp::Publisher<gazebo_msgs::msg::PerformanceMetrics>::SharedPtr performance_metrics_pub_;
+
   /// Connection to world update event, called at every iteration
   gazebo::event::ConnectionPtr world_update_event_;
 
@@ -102,6 +114,12 @@ public:
 
   /// Throttler for clock publisher.
   gazebo_ros::Throttler throttler_;
+
+  /// Gazebo subscriber to receive the performance metrics message.
+  gazebo::transport::SubscriberPtr performance_metric_sub_;
+
+  /// Gazebo node for communication.
+  gazebo::transport::NodePtr gz_node_;
 
   /// Default frequency for clock publisher.
   static constexpr double DEFAULT_PUBLISH_FREQUENCY = 10.;
@@ -136,6 +154,10 @@ void GazeboRosInit::Load(int argc, char ** argv)
     "/clock",
     rclcpp::QoS(rclcpp::KeepLast(10)).transient_local());
 
+  impl_->performance_metrics_pub_ =
+    impl_->ros_node_->create_publisher<gazebo_msgs::msg::PerformanceMetrics>(
+    "performance_metrics", 10);
+
   // Publish rate parameter
   auto rate_param = impl_->ros_node_->declare_parameter(
     "publish_rate",
@@ -148,6 +170,30 @@ void GazeboRosInit::Load(int argc, char ** argv)
   // Get a callback when a world is created
   impl_->world_created_event_ = gazebo::event::Events::ConnectWorldCreated(
     std::bind(&GazeboRosInitPrivate::OnWorldCreated, impl_.get(), std::placeholders::_1));
+}
+
+void GazeboRosInitPrivate::onPerformanceMetrics(
+  ConstPerformanceMetricsPtr & msg)
+{
+  gazebo_msgs::msg::PerformanceMetrics msg_ros;
+  msg_ros.header.stamp = Convert<builtin_interfaces::msg::Time>(world_->SimTime());
+  msg_ros.real_time_factor = msg->real_time_factor();
+  for (auto sensor : msg->sensor()) {
+    gazebo_msgs::msg::SensorPerformanceMetric sensor_msgs;
+    sensor_msgs.sim_update_rate = sensor.sim_sensor_update_rate();
+    sensor_msgs.real_update_rate = sensor.real_sensor_update_rate();
+    sensor_msgs.sensor_name = sensor.sensor_name();
+
+    if (sensor.has_fps()) {
+      sensor_msgs.fps = sensor.fps();
+    } else {
+      sensor_msgs.fps = -1;
+    }
+
+    msg_ros.sensors.push_back(sensor_msgs);
+  }
+
+  performance_metrics_pub_->publish(msg_ros);
 }
 
 void GazeboRosInitPrivate::OnWorldCreated(const std::string & _world_name)
@@ -182,6 +228,13 @@ void GazeboRosInitPrivate::OnWorldCreated(const std::string & _world_name)
     std::bind(
       &GazeboRosInitPrivate::OnUnpause, this,
       std::placeholders::_1, std::placeholders::_2));
+
+  // Gazebo transport
+  gz_node_ = gazebo::transport::NodePtr(new gazebo::transport::Node());
+  gz_node_->Init(world_->Name());
+  performance_metric_sub_ = gz_node_->Subscribe(
+    "/gazebo/gazebo/performance_metrics",
+    &GazeboRosInitPrivate::onPerformanceMetrics, this);
 }
 
 GazeboRosInitPrivate::GazeboRosInitPrivate()

--- a/gazebo_ros/src/gazebo_ros_init.cpp
+++ b/gazebo_ros/src/gazebo_ros_init.cpp
@@ -233,7 +233,7 @@ void GazeboRosInitPrivate::OnWorldCreated(const std::string & _world_name)
   gz_node_ = gazebo::transport::NodePtr(new gazebo::transport::Node());
   gz_node_->Init(world_->Name());
   performance_metric_sub_ = gz_node_->Subscribe(
-    "/gazebo/gazebo/performance_metrics",
+    "/gazebo/performance_metrics",
     &GazeboRosInitPrivate::onPerformanceMetrics, this);
 }
 

--- a/gazebo_ros/src/gazebo_ros_init.cpp
+++ b/gazebo_ros/src/gazebo_ros_init.cpp
@@ -190,7 +190,7 @@ void GazeboRosInitPrivate::onPerformanceMetrics(
     gazebo_msgs::msg::SensorPerformanceMetric sensor_msgs;
     sensor_msgs.sim_update_rate = sensor.sim_update_rate();
     sensor_msgs.real_update_rate = sensor.real_update_rate();
-    sensor_msgs.sensor_name = sensor.sensor_name();
+    sensor_msgs.name = sensor.name();
 
     if (sensor.has_fps()) {
       sensor_msgs.fps = sensor.fps();

--- a/gazebo_ros/src/gazebo_ros_init.cpp
+++ b/gazebo_ros/src/gazebo_ros_init.cpp
@@ -188,8 +188,8 @@ void GazeboRosInitPrivate::onPerformanceMetrics(
   msg_ros.real_time_factor = msg->real_time_factor();
   for (auto sensor : msg->sensor()) {
     gazebo_msgs::msg::SensorPerformanceMetric sensor_msgs;
-    sensor_msgs.sim_update_rate = sensor.sim_sensor_update_rate();
-    sensor_msgs.real_update_rate = sensor.real_sensor_update_rate();
+    sensor_msgs.sim_update_rate = sensor.sim_update_rate();
+    sensor_msgs.real_update_rate = sensor.real_update_rate();
     sensor_msgs.sensor_name = sensor.sensor_name();
 
     if (sensor.has_fps()) {


### PR DESCRIPTION
This PR is related to this other PR https://github.com/osrf/gazebo/pull/2819 which adds a performanceMetrics message. Then this msg will be republish from the Gazebo transport layer to the ROS 2 network.

Signed-off-by: ahcorde <ahcorde@gmail.com>