### PR TITLE
make compile wo/ warnings on osx

### DIFF
--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # we dont use add_compile_options with pedantic in message packages
   # because the Python C extensions dont comply with it
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wno-inconsistent-missing-override")
 endif()
 
 if(WIN32)

--- a/gazebo_ros/src/qos.cpp
+++ b/gazebo_ros/src/qos.cpp
@@ -151,7 +151,7 @@ QoSOverrides QoSPrivate::get_qos_overrides_from_sdf(sdf::ElementPtr _sdf)
           oss << "'" << find_result->first << "' used without providing a depth";
           throw InvalidQoSException(oss.str());
         }
-        qos_overrides.depth = history_element->Get<size_t>("depth");
+        qos_overrides.depth = history_element->Get<uint64_t>("depth");
       }
     } else {
       std::ostringstream oss;
@@ -162,13 +162,13 @@ QoSOverrides QoSPrivate::get_qos_overrides_from_sdf(sdf::ElementPtr _sdf)
 
   // Parse 'deadline' QoS
   if (_sdf->HasElement("deadline")) {
-    auto deadline = _sdf->GetElement("deadline")->Get<size_t>();
+    auto deadline = _sdf->GetElement("deadline")->Get<uint64_t>();
     qos_overrides.deadline = std::chrono::milliseconds(deadline);
   }
 
   // Parse 'lifespan' QoS
   if (_sdf->HasElement("lifespan")) {
-    auto lifespan = _sdf->GetElement("lifespan")->Get<size_t>();
+    auto lifespan = _sdf->GetElement("lifespan")->Get<uint64_t>();
     qos_overrides.lifespan = std::chrono::milliseconds(lifespan);
   }
 
@@ -187,7 +187,7 @@ QoSOverrides QoSPrivate::get_qos_overrides_from_sdf(sdf::ElementPtr _sdf)
 
   // Parse 'liveliness_lease_duration' QoS
   if (_sdf->HasElement("liveliness_lease_duration")) {
-    auto lease = _sdf->GetElement("liveliness_lease_duration")->Get<size_t>();
+    auto lease = _sdf->GetElement("liveliness_lease_duration")->Get<uint64_t>();
     qos_overrides.liveliness_lease = std::chrono::milliseconds(lease);
   }
 

--- a/gazebo_ros/test/test_gazebo_ros_factory.cpp
+++ b/gazebo_ros/test/test_gazebo_ros_factory.cpp
@@ -78,7 +78,7 @@ TEST_F(GazeboRosFactoryTest, SpawnDeleteList)
 
     auto response_future1 = spawn_client->async_send_request(request1);
     EXPECT_EQ(
-      rclcpp::executor::FutureReturnCode::SUCCESS,
+      rclcpp::FutureReturnCode::SUCCESS,
       rclcpp::spin_until_future_complete(node, response_future1));
 
     auto response1 = response_future1.get();
@@ -112,7 +112,7 @@ TEST_F(GazeboRosFactoryTest, SpawnDeleteList)
 
     auto response_future2 = spawn_client->async_send_request(request2);
     EXPECT_EQ(
-      rclcpp::executor::FutureReturnCode::SUCCESS,
+      rclcpp::FutureReturnCode::SUCCESS,
       rclcpp::spin_until_future_complete(node, response_future2));
 
     auto response2 = response_future2.get();
@@ -124,7 +124,7 @@ TEST_F(GazeboRosFactoryTest, SpawnDeleteList)
 
     auto response_future3 = model_list_client->async_send_request(request3);
     EXPECT_EQ(
-      rclcpp::executor::FutureReturnCode::SUCCESS,
+      rclcpp::FutureReturnCode::SUCCESS,
       rclcpp::spin_until_future_complete(node, response_future3));
 
     auto response3 = response_future3.get();
@@ -164,7 +164,7 @@ TEST_F(GazeboRosFactoryTest, SpawnDeleteList)
 
     auto response_future = spawn_client->async_send_request(request);
     EXPECT_EQ(
-      rclcpp::executor::FutureReturnCode::SUCCESS,
+      rclcpp::FutureReturnCode::SUCCESS,
       rclcpp::spin_until_future_complete(node, response_future));
 
     auto response = response_future.get();
@@ -209,7 +209,7 @@ TEST_F(GazeboRosFactoryTest, SpawnDeleteList)
 
     auto response_future = spawn_client->async_send_request(request);
     EXPECT_EQ(
-      rclcpp::executor::FutureReturnCode::SUCCESS,
+      rclcpp::FutureReturnCode::SUCCESS,
       rclcpp::spin_until_future_complete(node, response_future));
 
     auto response = response_future.get();
@@ -248,7 +248,7 @@ TEST_F(GazeboRosFactoryTest, SpawnDeleteList)
 
     auto response_future = spawn_client->async_send_request(request);
     EXPECT_EQ(
-      rclcpp::executor::FutureReturnCode::SUCCESS,
+      rclcpp::FutureReturnCode::SUCCESS,
       rclcpp::spin_until_future_complete(node, response_future));
 
     auto response = response_future.get();
@@ -273,7 +273,7 @@ TEST_F(GazeboRosFactoryTest, SpawnDeleteList)
 
     auto response_future = delete_client->async_send_request(request);
     EXPECT_EQ(
-      rclcpp::executor::FutureReturnCode::SUCCESS,
+      rclcpp::FutureReturnCode::SUCCESS,
       rclcpp::spin_until_future_complete(node, response_future));
 
     auto response = response_future.get();
@@ -295,7 +295,7 @@ TEST_F(GazeboRosFactoryTest, SpawnDeleteList)
 
     auto response_future = delete_client->async_send_request(request);
     EXPECT_EQ(
-      rclcpp::executor::FutureReturnCode::SUCCESS,
+      rclcpp::FutureReturnCode::SUCCESS,
       rclcpp::spin_until_future_complete(node, response_future));
 
     auto response = response_future.get();

--- a/gazebo_ros/test/test_gazebo_ros_init.cpp
+++ b/gazebo_ros/test/test_gazebo_ros_init.cpp
@@ -54,7 +54,7 @@ TEST_F(GazeboRosInitTest, Commands)
 
     auto response_future = unpause_physics_client->async_send_request(request);
     EXPECT_EQ(
-      rclcpp::executor::FutureReturnCode::SUCCESS,
+      rclcpp::FutureReturnCode::SUCCESS,
       rclcpp::spin_until_future_complete(node, response_future));
 
     auto response = response_future.get();
@@ -71,7 +71,7 @@ TEST_F(GazeboRosInitTest, Commands)
     // Request
     response_future = pause_physics_client->async_send_request(request);
     EXPECT_EQ(
-      rclcpp::executor::FutureReturnCode::SUCCESS,
+      rclcpp::FutureReturnCode::SUCCESS,
       rclcpp::spin_until_future_complete(node, response_future));
 
     response = response_future.get();
@@ -100,7 +100,7 @@ TEST_F(GazeboRosInitTest, Commands)
 
     auto response_future = reset_simulation_client->async_send_request(request);
     EXPECT_EQ(
-      rclcpp::executor::FutureReturnCode::SUCCESS,
+      rclcpp::FutureReturnCode::SUCCESS,
       rclcpp::spin_until_future_complete(node, response_future));
 
     auto response = response_future.get();
@@ -127,7 +127,7 @@ TEST_F(GazeboRosInitTest, Commands)
 
     response_future = reset_world_client->async_send_request(request);
     EXPECT_EQ(
-      rclcpp::executor::FutureReturnCode::SUCCESS,
+      rclcpp::FutureReturnCode::SUCCESS,
       rclcpp::spin_until_future_complete(node, response_future));
 
     response = response_future.get();

--- a/gazebo_ros/test/test_gazebo_ros_joint_effort.cpp
+++ b/gazebo_ros/test/test_gazebo_ros_joint_effort.cpp
@@ -55,7 +55,7 @@ TEST_F(GazeboRosJointEffortTest, JointEffortTest)
 
   auto apply_response_future = apply_joint_effort->async_send_request(apply_request);
   EXPECT_EQ(
-    rclcpp::executor::FutureReturnCode::SUCCESS,
+    rclcpp::FutureReturnCode::SUCCESS,
     rclcpp::spin_until_future_complete(node, apply_response_future));
 
   auto apply_response = apply_response_future.get();
@@ -72,7 +72,7 @@ TEST_F(GazeboRosJointEffortTest, JointEffortTest)
 
   auto clear_response_future = clear_joint_efforts->async_send_request(clear_request);
   EXPECT_EQ(
-    rclcpp::executor::FutureReturnCode::SUCCESS,
+    rclcpp::FutureReturnCode::SUCCESS,
     rclcpp::spin_until_future_complete(node, clear_response_future));
 
   auto clear_response = clear_response_future.get();

--- a/gazebo_ros/test/test_gazebo_ros_link_wrench.cpp
+++ b/gazebo_ros/test/test_gazebo_ros_link_wrench.cpp
@@ -60,7 +60,7 @@ TEST_F(GazeboRosLinkWrenchTest, LinkWrenchTest)
 
   auto apply_response_future = apply_link_wrench->async_send_request(apply_request);
   EXPECT_EQ(
-    rclcpp::executor::FutureReturnCode::SUCCESS,
+    rclcpp::FutureReturnCode::SUCCESS,
     rclcpp::spin_until_future_complete(node, apply_response_future));
 
   auto apply_response = apply_response_future.get();
@@ -82,7 +82,7 @@ TEST_F(GazeboRosLinkWrenchTest, LinkWrenchTest)
 
   auto clear_response_future = clear_link_wrenches->async_send_request(clear_request);
   EXPECT_EQ(
-    rclcpp::executor::FutureReturnCode::SUCCESS,
+    rclcpp::FutureReturnCode::SUCCESS,
     rclcpp::spin_until_future_complete(node, clear_response_future));
 
   auto clear_response = clear_response_future.get();

--- a/gazebo_ros/test/test_gazebo_ros_properties.cpp
+++ b/gazebo_ros/test/test_gazebo_ros_properties.cpp
@@ -167,7 +167,7 @@ void GazeboRosPropertiesTest::GetModelProperties(
 
   auto response_future = get_model_properties_client_->async_send_request(request);
   EXPECT_EQ(
-    rclcpp::executor::FutureReturnCode::SUCCESS,
+    rclcpp::FutureReturnCode::SUCCESS,
     rclcpp::spin_until_future_complete(node_, response_future));
 
   auto response = response_future.get();
@@ -215,7 +215,7 @@ void GazeboRosPropertiesTest::GetJointProperties(
 
   auto response_future = get_joint_properties_client_->async_send_request(request);
   EXPECT_EQ(
-    rclcpp::executor::FutureReturnCode::SUCCESS,
+    rclcpp::FutureReturnCode::SUCCESS,
     rclcpp::spin_until_future_complete(node_, response_future));
 
   auto response = response_future.get();
@@ -250,7 +250,7 @@ void GazeboRosPropertiesTest::SetJointProperties(
 
   auto response_future = set_joint_properties_client_->async_send_request(request);
   EXPECT_EQ(
-    rclcpp::executor::FutureReturnCode::SUCCESS,
+    rclcpp::FutureReturnCode::SUCCESS,
     rclcpp::spin_until_future_complete(node_, response_future));
 
   auto response = response_future.get();
@@ -274,7 +274,7 @@ void GazeboRosPropertiesTest::GetLinkProperties(
 
   auto response_future = get_link_properties_client_->async_send_request(request);
   EXPECT_EQ(
-    rclcpp::executor::FutureReturnCode::SUCCESS,
+    rclcpp::FutureReturnCode::SUCCESS,
     rclcpp::spin_until_future_complete(node_, response_future));
 
   auto response = response_future.get();
@@ -315,7 +315,7 @@ void GazeboRosPropertiesTest::SetLinkProperties(
 
   auto response_future = set_link_properties_client_->async_send_request(request);
   EXPECT_EQ(
-    rclcpp::executor::FutureReturnCode::SUCCESS,
+    rclcpp::FutureReturnCode::SUCCESS,
     rclcpp::spin_until_future_complete(node_, response_future));
 
   auto response = response_future.get();
@@ -335,7 +335,7 @@ void GazeboRosPropertiesTest::GetLightProperties(
 
   auto response_future = get_light_properties_client_->async_send_request(request);
   EXPECT_EQ(
-    rclcpp::executor::FutureReturnCode::SUCCESS,
+    rclcpp::FutureReturnCode::SUCCESS,
     rclcpp::spin_until_future_complete(node_, response_future));
 
   auto response = response_future.get();
@@ -371,7 +371,7 @@ void GazeboRosPropertiesTest::SetLightProperties(
 
   auto response_future = set_light_properties_client_->async_send_request(request);
   EXPECT_EQ(
-    rclcpp::executor::FutureReturnCode::SUCCESS,
+    rclcpp::FutureReturnCode::SUCCESS,
     rclcpp::spin_until_future_complete(node_, response_future));
 
   auto response = response_future.get();

--- a/gazebo_ros/test/test_gazebo_ros_state.cpp
+++ b/gazebo_ros/test/test_gazebo_ros_state.cpp
@@ -96,7 +96,7 @@ void GazeboRosStateTest::GetState(
 
   auto response_future = get_state_client_->async_send_request(request);
   EXPECT_EQ(
-    rclcpp::executor::FutureReturnCode::SUCCESS,
+    rclcpp::FutureReturnCode::SUCCESS,
     rclcpp::spin_until_future_complete(node_, response_future));
 
   auto response = response_future.get();
@@ -137,7 +137,7 @@ void GazeboRosStateTest::SetState(
 
   auto response_future = set_state_client_->async_send_request(request);
   EXPECT_EQ(
-    rclcpp::executor::FutureReturnCode::SUCCESS,
+    rclcpp::FutureReturnCode::SUCCESS,
     rclcpp::spin_until_future_complete(node_, response_future));
 
   auto response = response_future.get();


### PR DESCRIPTION
* `rclcpp::executors::FutureReturnCode` is deprecated

* `_sdf->GetElement("deadline")->Get<size_t>();` lead to compiler errors, replaced it with a more explicit `uint64_t`.
<details>
<summary>Verbose stderr output</summary>

```
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/src/qos.cpp:15:
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/include/gazebo_ros/qos.hpp:18:
In file included from /usr/local/Cellar/sdformat9/9.3.0~pre1/include/sdformat-9.3/sdf/sdf.hh:2:
In file included from /usr/local/Cellar/sdformat9/9.3.0~pre1/include/sdformat-9.3/sdf/Actor.hh:20:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory:663:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/tuple:1012:5: error: static_assert failed "type not found in type list"
    static_assert(value != __not_found, "type not found in type list" );
/Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/src/qos.cpp:154:48: note: in instantiation of function template specialization 'sdf::v9::Element::Get<unsigned long>' requested here
        qos_overrides.depth = history_element->Get<size_t>("depth");
```
</details>

* Gazebo11 has a handful of warnings with inconsistent `override` function declarations. Warning is explicitly marked as ignored to guarantee a compilation even with `-Werror`.
<details>
<summary>Verbose stderr output</summary>

```
--- stderr: gazebo_ros
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_utils.cpp:17:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:53:28: error: 'Load' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual void Load(const std::string &_worldName);
                           ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:69:28: note: overridden virtual function is here
      public: virtual void Load(const std::string &_worldName);
                           ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_utils.cpp:17:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:56:28: error: 'Init' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual void Init();
                           ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:72:28: note: overridden virtual function is here
      public: virtual void Init();
                           ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_utils.cpp:17:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:70:35: error: 'Topic' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual std::string Topic() const;
                                  ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:144:35: note: overridden virtual function is here
      public: virtual std::string Topic() const;
                                  ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_utils.cpp:17:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:112:28: error: 'IsActive' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual bool IsActive() const;
                           ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:123:28: note: overridden virtual function is here
      public: virtual bool IsActive() const;
                           ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_utils.cpp:17:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:115:31: error: 'UpdateImpl' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      protected: virtual bool UpdateImpl(const bool _force);
                              ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:198:31: note: overridden virtual function is here
      protected: virtual bool UpdateImpl(const bool /*_force*/) {return false;}
                              ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_utils.cpp:17:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:118:31: error: 'Fini' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      protected: virtual void Fini();
                              ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:97:28: note: overridden virtual function is here
      public: virtual void Fini();
                           ^
6 errors generated.
make[2]: *** [test/CMakeFiles/test_utils.dir/test_utils.cpp.o] Error 1
make[1]: *** [test/CMakeFiles/test_utils.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_init.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:53:28: error: 'Load' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual void Load(const std::string &_worldName);
                           ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:69:28: note: overridden virtual function is here
      public: virtual void Load(const std::string &_worldName);
                           ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_init.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:56:28: error: 'Init' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual void Init();
                           ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:72:28: note: overridden virtual function is here
      public: virtual void Init();
                           ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_init.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:70:35: error: 'Topic' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual std::string Topic() const;
                                  ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:144:35: note: overridden virtual function is here
      public: virtual std::string Topic() const;
                                  ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_init.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:112:28: error: 'IsActive' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual bool IsActive() const;
                           ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:123:28: note: overridden virtual function is here
      public: virtual bool IsActive() const;
                           ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_init.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:115:31: error: 'UpdateImpl' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      protected: virtual bool UpdateImpl(const bool _force);
                              ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:198:31: note: overridden virtual function is here
      protected: virtual bool UpdateImpl(const bool /*_force*/) {return false;}
                              ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_init.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:118:31: error: 'Fini' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      protected: virtual void Fini();
                              ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:97:28: note: overridden virtual function is here
      public: virtual void Fini();
                           ^
6 errors generated.
make[2]: *** [test/CMakeFiles/test_gazebo_ros_init.dir/test_gazebo_ros_init.cpp.o] Error 1
make[1]: *** [test/CMakeFiles/test_gazebo_ros_init.dir/all] Error 2
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_link_wrench.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:53:28: error: 'Load' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual void Load(const std::string &_worldName);
                           ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:69:28: note: overridden virtual function is here
      public: virtual void Load(const std::string &_worldName);
                           ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_link_wrench.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:56:28: error: 'Init' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual void Init();
                           ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:72:28: note: overridden virtual function is here
      public: virtual void Init();
                           ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_link_wrench.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:70:35: error: 'Topic' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual std::string Topic() const;
                                  ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:144:35: note: overridden virtual function is here
      public: virtual std::string Topic() const;
                                  ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_link_wrench.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:112:28: error: 'IsActive' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual bool IsActive() const;
                           ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:123:28: note: overridden virtual function is here
      public: virtual bool IsActive() const;
                           ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_link_wrench.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:115:31: error: 'UpdateImpl' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      protected: virtual bool UpdateImpl(const bool _force);
                              ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:198:31: note: overridden virtual function is here
      protected: virtual bool UpdateImpl(const bool /*_force*/) {return false;}
                              ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_link_wrench.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:118:31: error: 'Fini' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      protected: virtual void Fini();
                              ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:97:28: note: overridden virtual function is here
      public: virtual void Fini();
                           ^
6 errors generated.
make[2]: *** [test/CMakeFiles/test_gazebo_ros_link_wrench.dir/test_gazebo_ros_link_wrench.cpp.o] Error 1
make[1]: *** [test/CMakeFiles/test_gazebo_ros_link_wrench.dir/all] Error 2
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_factory.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:53:28: error: 'Load' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual void Load(const std::string &_worldName);
                           ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:69:28: note: overridden virtual function is here
      public: virtual void Load(const std::string &_worldName);
                           ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_factory.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:56:28: error: 'Init' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual void Init();
                           ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:72:28: note: overridden virtual function is here
      public: virtual void Init();
                           ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_factory.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:70:35: error: 'Topic' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual std::string Topic() const;
                                  ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:144:35: note: overridden virtual function is here
      public: virtual std::string Topic() const;
                                  ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_factory.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:112:28: error: 'IsActive' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual bool IsActive() const;
                           ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:123:28: note: overridden virtual function is here
      public: virtual bool IsActive() const;
                           ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_factory.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:115:31: error: 'UpdateImpl' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      protected: virtual bool UpdateImpl(const bool _force);
                              ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:198:31: note: overridden virtual function is here
      protected: virtual bool UpdateImpl(const bool /*_force*/) {return false;}
                              ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_factory.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:118:31: error: 'Fini' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      protected: virtual void Fini();
                              ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:97:28: note: overridden virtual function is here
      public: virtual void Fini();
                           ^
6 errors generated.
make[2]: *** [test/CMakeFiles/test_gazebo_ros_factory.dir/test_gazebo_ros_factory.cpp.o] Error 1
make[1]: *** [test/CMakeFiles/test_gazebo_ros_factory.dir/all] Error 2
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_joint_effort.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:53:28: error: 'Load' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual void Load(const std::string &_worldName);
                           ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:69:28: note: overridden virtual function is here
      public: virtual void Load(const std::string &_worldName);
                           ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_joint_effort.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:56:28: error: 'Init' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual void Init();
                           ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:72:28: note: overridden virtual function is here
      public: virtual void Init();
                           ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_joint_effort.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:70:35: error: 'Topic' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual std::string Topic() const;
                                  ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:144:35: note: overridden virtual function is here
      public: virtual std::string Topic() const;
                                  ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_joint_effort.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:112:28: error: 'IsActive' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual bool IsActive() const;
                           ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:123:28: note: overridden virtual function is here
      public: virtual bool IsActive() const;
                           ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_joint_effort.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:115:31: error: 'UpdateImpl' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      protected: virtual bool UpdateImpl(const bool _force);
                              ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:198:31: note: overridden virtual function is here
      protected: virtual bool UpdateImpl(const bool /*_force*/) {return false;}
                              ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_joint_effort.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:118:31: error: 'Fini' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      protected: virtual void Fini();
                              ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:97:28: note: overridden virtual function is here
      public: virtual void Fini();
                           ^
6 errors generated.
make[2]: *** [test/CMakeFiles/test_gazebo_ros_joint_effort.dir/test_gazebo_ros_joint_effort.cpp.o] Error 1
make[1]: *** [test/CMakeFiles/test_gazebo_ros_joint_effort.dir/all] Error 2
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_properties.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:53:28: error: 'Load' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual void Load(const std::string &_worldName);
                           ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:69:28: note: overridden virtual function is here
      public: virtual void Load(const std::string &_worldName);
                           ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_properties.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:56:28: error: 'Init' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual void Init();
                           ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:72:28: note: overridden virtual function is here
      public: virtual void Init();
                           ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_properties.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:70:35: error: 'Topic' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual std::string Topic() const;
                                  ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:144:35: note: overridden virtual function is here
      public: virtual std::string Topic() const;
                                  ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_properties.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:112:28: error: 'IsActive' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual bool IsActive() const;
                           ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:123:28: note: overridden virtual function is here
      public: virtual bool IsActive() const;
                           ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_properties.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:115:31: error: 'UpdateImpl' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      protected: virtual bool UpdateImpl(const bool _force);
                              ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:198:31: note: overridden virtual function is here
      protected: virtual bool UpdateImpl(const bool /*_force*/) {return false;}
                              ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_properties.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:118:31: error: 'Fini' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      protected: virtual void Fini();
                              ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:97:28: note: overridden virtual function is here
      public: virtual void Fini();
                           ^
6 errors generated.
make[2]: *** [test/CMakeFiles/test_gazebo_ros_properties.dir/test_gazebo_ros_properties.cpp.o] Error 1
make[1]: *** [test/CMakeFiles/test_gazebo_ros_properties.dir/all] Error 2
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_state.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:53:28: error: 'Load' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual void Load(const std::string &_worldName);
                           ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:69:28: note: overridden virtual function is here
      public: virtual void Load(const std::string &_worldName);
                           ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_state.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:56:28: error: 'Init' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual void Init();
                           ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:72:28: note: overridden virtual function is here
      public: virtual void Init();
                           ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_state.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:70:35: error: 'Topic' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual std::string Topic() const;
                                  ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:144:35: note: overridden virtual function is here
      public: virtual std::string Topic() const;
                                  ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_state.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:112:28: error: 'IsActive' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      public: virtual bool IsActive() const;
                           ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:123:28: note: overridden virtual function is here
      public: virtual bool IsActive() const;
                           ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_state.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:115:31: error: 'UpdateImpl' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      protected: virtual bool UpdateImpl(const bool _force);
                              ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:198:31: note: overridden virtual function is here
      protected: virtual bool UpdateImpl(const bool /*_force*/) {return false;}
                              ^
In file included from /Users/karsten/workspace/ros2/ros2_control_ws/src/gazebo_ros_pkgs/gazebo_ros/test/test_gazebo_ros_state.cpp:15:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/test/ServerFixture.hh:52:
In file included from /usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/sensors.hh:13:
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/MultiCameraSensor.hh:118:31: error: 'Fini' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
      protected: virtual void Fini();
                              ^
/usr/local/Cellar/gazebo11/11.1.0/include/gazebo-11/gazebo/sensors/Sensor.hh:97:28: note: overridden virtual function is here
      public: virtual void Fini();
                           ^
6 errors generated.
make[2]: *** [test/CMakeFiles/test_gazebo_ros_state.dir/test_gazebo_ros_state.cpp.o] Error 1
make[1]: *** [test/CMakeFiles/test_gazebo_ros_state.dir/all] Error 2
make: *** [all] Error 2
```
</details>