### PR TITLE
Cherry-pick to noetic of gazebo_ros_api_plugin cleanup (#1137)

### DIFF
--- a/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
+++ b/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
@@ -241,8 +241,9 @@ private:
   /// \brief
   void forceJointSchedulerSlot();
 
-  /// \brief
-  void publishSimTime(const boost::shared_ptr<gazebo::msgs::WorldStatistics const> &msg);
+  /// \brief Callback to WorldUpdateBegin that publishes /clock.
+  /// If pub_clock_frequency_ <= 0 (default behavior), it publishes every time step.
+  /// Otherwise, it attempts to publish at that frequency in Hz.
   void publishSimTime();
 
   /// \brief


### PR DESCRIPTION
This is a cherry-pick of #1137. Use rebase and merge when merging.

gazebo_ros_api_plugin cleanup (#1137)

Remove an unused overload of publishSimTime and add doxygen
for the remaining publishSimTime function.

* Remove duplicate code for /clock advertisement

The /clock topic is advertised in both loadGazeboRosApiPlugin
and advertiseServices. This removes the code from advertiseServices
and moves it earlier in loadGazeboRosApiPlugin.

Signed-off-by: Steve Peters <scpeters@openrobotics.org>

Co-authored-by: Alejandro Hernández Cordero <ahcorde@gmail.com>