### PR TITLE
backport #1135 to melodic: colcon.pkg: build gazebo first in colcon workspace

### DIFF
--- a/gazebo_dev/colcon.pkg
+++ b/gazebo_dev/colcon.pkg
@@ -1,0 +1,8 @@
+# Configuration file for colcon (https://colcon.readthedocs.io).
+#
+# Please see the doc for the details of the spec:
+#   - https://colcon.readthedocs.io/en/released/user/configuration.html#colcon-pkg-files
+
+{
+  "dependencies": ["Gazebo"],
+}

--- a/gazebo_plugins/colcon.pkg
+++ b/gazebo_plugins/colcon.pkg
@@ -1,0 +1,8 @@
+# Configuration file for colcon (https://colcon.readthedocs.io).
+#
+# Please see the doc for the details of the spec:
+#   - https://colcon.readthedocs.io/en/released/user/configuration.html#colcon-pkg-files
+
+{
+  "dependencies": ["Gazebo"],
+}

--- a/gazebo_ros/colcon.pkg
+++ b/gazebo_ros/colcon.pkg
@@ -1,0 +1,8 @@
+# Configuration file for colcon (https://colcon.readthedocs.io).
+#
+# Please see the doc for the details of the spec:
+#   - https://colcon.readthedocs.io/en/released/user/configuration.html#colcon-pkg-files
+
+{
+  "dependencies": ["Gazebo"],
+}

--- a/gazebo_ros_control/colcon.pkg
+++ b/gazebo_ros_control/colcon.pkg
@@ -1,0 +1,8 @@
+# Configuration file for colcon (https://colcon.readthedocs.io).
+#
+# Please see the doc for the details of the spec:
+#   - https://colcon.readthedocs.io/en/released/user/configuration.html#colcon-pkg-files
+
+{
+  "dependencies": ["Gazebo"],
+}


### PR DESCRIPTION
Backport of #1135 to melodic. Use rebase and merge after review.

colcon.pkg: build gazebo first in colcon workspace (#1135)

Add a colcon.pkg file to gazebo_dev with gazebo's cmake project
name "Gazebo" listed as a dependency to support building
gazebo from source in a colcon workspace.

* Add colcon.pkg files for other packages

Copy colcon.pkg to gazebo_ros, gazebo_plugins, and
gazebo_ros_control so that --merge-install won't be required.

Signed-off-by: Steve Peters <scpeters@openrobotics.org>