### PR TITLE
[noetic][Windows] Removing extra CameraPlugin header inclusion from gazebo_ros_camera_utils

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -208,7 +208,7 @@ add_definitions(-fPIC) # what is this for?
 ## Plugins
 add_library(gazebo_ros_camera_utils src/gazebo_ros_camera_utils.cpp)
 add_dependencies(gazebo_ros_camera_utils ${PROJECT_NAME}_gencfg)
-target_link_libraries(gazebo_ros_camera_utils ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(gazebo_ros_camera_utils ${catkin_LIBRARIES} ${Boost_LIBRARIES} CameraPlugin)
 
 add_library(MultiCameraPlugin src/MultiCameraPlugin.cpp)
 target_link_libraries(MultiCameraPlugin ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -208,7 +208,7 @@ add_definitions(-fPIC) # what is this for?
 ## Plugins
 add_library(gazebo_ros_camera_utils src/gazebo_ros_camera_utils.cpp)
 add_dependencies(gazebo_ros_camera_utils ${PROJECT_NAME}_gencfg)
-target_link_libraries(gazebo_ros_camera_utils ${catkin_LIBRARIES} ${Boost_LIBRARIES} CameraPlugin)
+target_link_libraries(gazebo_ros_camera_utils ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(MultiCameraPlugin src/MultiCameraPlugin.cpp)
 target_link_libraries(MultiCameraPlugin ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera_utils.h
@@ -47,7 +47,6 @@
 #include <gazebo/msgs/MessageTypes.hh>
 #include <gazebo/common/Time.hh>
 #include <gazebo/sensors/SensorTypes.hh>
-#include <gazebo/plugins/CameraPlugin.hh>
 #include <gazebo_plugins/gazebo_ros_utils.h>
 
 namespace gazebo


### PR DESCRIPTION
This is motivated and found during this [release](https://discourse.ros.org/t/ros-on-windows-noetic-release-v20200831-0-0-2009101215/16352).

The `gazebo_ros_camera_utils` is using some APIs from `CameraPlugin`. Without being explicit, the build will fail to link on Windows.

```
   Creating library C:\workspace\gn_ws\devel_isolated\gazebo_plugins\lib\gazebo_ros_camera_utils.lib and object C:\workspace\gn_ws\devel_isolated\gazebo_plugins\lib\gazebo_ros_camera_utils.exp
gazebo_ros_camera_utils.cpp.obj : error LNK2019: unresolved external symbol "public: virtual __cdecl gazebo::CameraPlugin::~CameraPlugin(void)" (??1CameraPlugin@gazebo@@UEAA@XZ) referenced in function "public: virtual void * __cdecl gazebo::CameraPlugin::`vector deleting destructor'(unsigned int)" (??_ECameraPlugin@gazebo@@UEAAPEAXI@Z)
gazebo_ros_camera_utils.cpp.obj : error LNK2001: unresolved external symbol "public: virtual void __cdecl gazebo::CameraPlugin::Load(class std::shared_ptr<class gazebo::sensors::Sensor>,class std::shared_ptr<class sdf::Element>)" (?Load@CameraPlugin@gazebo@@UEAAXV?$shared_ptr@VSensor@sensors@gazebo@@@std@@V?$shared_ptr@VElement@sdf@@@4@@Z)
gazebo_ros_camera_utils.cpp.obj : error LNK2001: unresolved external symbol "public: virtual void __cdecl gazebo::CameraPlugin::OnNewFrame(unsigned char const *,unsigned int,unsigned int,unsigned int,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &)" (?OnNewFrame@CameraPlugin@gazebo@@UEAAXPEBEIIIAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
```