### PR TITLE
Add repos file with dependencies

### DIFF
--- a/gazebo_ros_pkgs.repos
+++ b/gazebo_ros_pkgs.repos
@@ -1,0 +1,13 @@
+repositories:
+  gazebo_ros_pkgs:
+    type: git
+    url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
+    version: ros2
+  image_common:
+    type: git
+    url: https://github.com/ros-perception/image_common.git
+    version: ros2
+  vision_opencv:
+    type: git
+    url: https://github.com/ros-perception/vision_opencv.git
+    version: ros2


### PR DESCRIPTION
We can then have the installation instructions reference this file.

If this looks reasonable, I can backport to Dashing, Eloquent, and Foxy.