### PR TITLE
[gazebo_plugins] Fixed target for steering command in steering speed mode

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
@@ -566,7 +566,7 @@ void GazeboRosTricycleDrivePrivate::MotorController(
     if (fabs(diff_angle) < max_steering_angle_tol_) {
       // we're withing angle tolerance
       applied_steering_speed = 0;
-    } else if (diff_angle < target_speed) {
+    } else if (diff_angle < target_angle) {
       // steer toward target angle
       applied_steering_speed = max_steering_speed_;
     } else {


### PR DESCRIPTION
The steering was not working properly with the robot moving as `target_speed` was being used instead of `target_angle`