### PR TITLE
gazebo_ros_utils: don't set tf_prefix if empty

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_utils.cpp
@@ -85,11 +85,6 @@ void GazeboRos ::readCommonParameter() {
 
 
     tf_prefix_ = tf::getPrefixParam(*rosnode_);
-    if(tf_prefix_.empty())
-    {
-        tf_prefix_ = namespace_;
-        boost::trim_right_if(tf_prefix_,boost::is_any_of("/"));
-    }
     ROS_INFO_NAMED("utils", "%s: <tf_prefix> = %s", info(), tf_prefix_.c_str());
 }
 


### PR DESCRIPTION
Similar changes were made in #1143 to address #554, but `gazebo_ros_utils` wasn't included. I'm not sure what the consequences of this change are.