### PR TITLE
Use namespace of the spawn entity as the default robot namespace

### DIFF
--- a/gazebo_ros/scripts/spawn_entity.py
+++ b/gazebo_ros/scripts/spawn_entity.py
@@ -67,10 +67,11 @@ class SpawnEntityNode(Node):
         parser.add_argument('-reference_frame', type=str, default='',
                             help='Name of the model/body where initial pose is defined.\
                             If left empty or specified as "world", gazebo world frame is used')
-        parser.add_argument('-gazebo_namespace', type=str, default=self.get_namespace(),
+        parser.add_argument('-gazebo_namespace', type=str, default='',
                             help='ROS namespace of gazebo offered ROS interfaces. \
                             Default is without any namespace')
-        parser.add_argument('-robot_namespace', type=str, default='',
+        entity_namespace = self.get_namespace() if self.get_namespace() != '/' else ''
+        parser.add_argument('-robot_namespace', type=str, default=entity_namespace,
                             help='change ROS namespace of gazebo-plugins')
         parser.add_argument('-timeout', type=float, default=30.0,
                             help='Number of seconds to wait for the spawn and delete services to \

--- a/gazebo_ros/scripts/spawn_entity.py
+++ b/gazebo_ros/scripts/spawn_entity.py
@@ -67,7 +67,7 @@ class SpawnEntityNode(Node):
         parser.add_argument('-reference_frame', type=str, default='',
                             help='Name of the model/body where initial pose is defined.\
                             If left empty or specified as "world", gazebo world frame is used')
-        parser.add_argument('-gazebo_namespace', type=str, default='',
+        parser.add_argument('-gazebo_namespace', type=str, default=self.get_namespace(),
                             help='ROS namespace of gazebo offered ROS interfaces. \
                             Default is without any namespace')
         parser.add_argument('-robot_namespace', type=str, default='',


### PR DESCRIPTION
This is analogous to ROS 1, where launching the spawn_model script would start plugins in the same namespace as the spawn_model script in the launch file.

This should simplify some instances where the spawn_entity script is used in launch files,

For example, in situations where we might be including a launch script in a namespace we currently have to also pass the namespace for plugins independently:

```xml
<launch>
  <push-ros-namespace namespace="/my_namespace" />
  <node name="spawn_entity" pkg="gazebo_ros" exec="spawn_entity.py" output="screen"
        args="-entity foo -file foo.urdf -robot_namespace /my_namespace" />
  ...
</launch>
```

This could be reduced to:

```xml
<launch>
  <push-ros-namespace namespace="/my_namespace" />
  <node name="spawn_entity" pkg="gazebo_ros" exec="spawn_entity.py" output="screen"
        args="-entity foo -file foo.urdf" />
  ...
</launch>
```