### PR TITLE
Fix sdf ros topic naming bug

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_force.cpp
+++ b/gazebo_plugins/src/gazebo_ros_force.cpp
@@ -105,7 +105,9 @@ void GazeboRosForce::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
 
   if (this->topic_name_.find(':') != std::string::npos)
   {
+    std::string _topic_name = this->topic_name_;
     std::replace(this->topic_name_.begin(), this->topic_name_.end(), ':', '_');
+    ROS_WARN_STREAM("Ros topic " << _topic_name << " has been renamed to " << this->topic_name_);
   }
 
   // Custom Callback Queue

--- a/gazebo_plugins/src/gazebo_ros_force.cpp
+++ b/gazebo_plugins/src/gazebo_ros_force.cpp
@@ -103,6 +103,11 @@ void GazeboRosForce::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
 
   this->rosnode_ = new ros::NodeHandle(this->robot_namespace_);
 
+  if (this->topic_name_.find(':') != std::string::npos)
+  {
+    std::replace(this->topic_name_.begin(), this->topic_name_.end(), ':', '_');
+  }
+
   // Custom Callback Queue
   ros::SubscribeOptions so = ros::SubscribeOptions::create<geometry_msgs::Wrench>(
     this->topic_name_,1,


### PR DESCRIPTION
When using .sdfs gazebo might automatically generate invalid ros topic names (names which contain "::"). This checks if the topic name has any ":" and replaces it with a "_" to generate valid names.