### PR TITLE
Port #1135 to ros2: colcon.pkg files to build gazebo first in colcon workspace

### DIFF
--- a/gazebo_dev/colcon.pkg
+++ b/gazebo_dev/colcon.pkg
@@ -1,0 +1,8 @@
+# Configuration file for colcon (https://colcon.readthedocs.io).
+#
+# Please see the doc for the details of the spec:
+#   - https://colcon.readthedocs.io/en/released/user/configuration.html#colcon-pkg-files
+
+{
+  "dependencies": ["Gazebo"],
+}

--- a/gazebo_plugins/colcon.pkg
+++ b/gazebo_plugins/colcon.pkg
@@ -1,0 +1,8 @@
+# Configuration file for colcon (https://colcon.readthedocs.io).
+#
+# Please see the doc for the details of the spec:
+#   - https://colcon.readthedocs.io/en/released/user/configuration.html#colcon-pkg-files
+
+{
+  "dependencies": ["Gazebo"],
+}

--- a/gazebo_ros/colcon.pkg
+++ b/gazebo_ros/colcon.pkg
@@ -1,0 +1,8 @@
+# Configuration file for colcon (https://colcon.readthedocs.io).
+#
+# Please see the doc for the details of the spec:
+#   - https://colcon.readthedocs.io/en/released/user/configuration.html#colcon-pkg-files
+
+{
+  "dependencies": ["Gazebo"],
+}

--- a/gazebo_ros_control/colcon.pkg
+++ b/gazebo_ros_control/colcon.pkg
@@ -1,0 +1,8 @@
+# Configuration file for colcon (https://colcon.readthedocs.io).
+#
+# Please see the doc for the details of the spec:
+#   - https://colcon.readthedocs.io/en/released/user/configuration.html#colcon-pkg-files
+
+{
+  "dependencies": ["Gazebo"],
+}


### PR DESCRIPTION
This is a port of #1135 from `noetic-devel` to `ros2`. Since the cmake project name for osrf/gazebo is `Gazebo`, which doesn't match the rosdep keys `libgazebo11-dev` or `gazebo11`, packages may build in the wrong order if you put gazebo and gazebo_ros_pkgs into the same `colcon` workspace. Adding these `colcon.pkg` files ensures that gazebo is compiled first. Only one `colcon.pkg` file in `gazebo_dev` is needed if you build with `--merge-install`, but we've added additional `colcon.pkg` files in dependents of `gazebo_dev` that build / link against gazebo to support `colcon build` without `--merge-install`, since otherwise the cmake paths won't be set properly.

Copy of commit message from #1135:

## colcon.pkg: build gazebo first in colcon workspace

Add a colcon.pkg file to gazebo_dev with gazebo's cmake project
name "Gazebo" listed as a dependency to support building
gazebo from source in a colcon workspace.

* Add colcon.pkg files for other packages

Copy colcon.pkg to gazebo_ros, gazebo_plugins, and
gazebo_ros_control so that --merge-install won't be required.

Signed-off-by: Steve Peters <scpeters@openrobotics.org>