### PR TITLE
Replace executor with a thread safe implementation

### DIFF
--- a/gazebo_ros/include/gazebo_ros/executor.hpp
+++ b/gazebo_ros/include/gazebo_ros/executor.hpp
@@ -42,8 +42,8 @@ public:
    *
    * \see rclcpp::Executor::add_node
    */
-  virtual void
-  add_node(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr, bool notify = true);
+  void add_node(
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr, bool notify = true) override;
 
   /// Convenience function which takes Node and forwards NodeBaseInterface.
   /**
@@ -51,7 +51,7 @@ public:
    *
    * \see rclcpp::Executor::add_node
    */
-  virtual void add_node(std::shared_ptr<rclcpp::Node> node_ptr, bool notify = true);
+  void add_node(std::shared_ptr<rclcpp::Node> node_ptr, bool notify = true) override;
 
   /// Remove a node from the executor.
   /**
@@ -59,8 +59,8 @@ public:
    *
    * \see rclcpp::Executor::remove_node
    */
-  virtual void
-  remove_node(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr, bool notify = true);
+  void remove_node(
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr, bool notify = true) override;
 
   /// Convenience function which takes Node and forwards NodeBaseInterface.
   /**
@@ -68,7 +68,7 @@ public:
    *
    * \see rclcpp::Executor::remove_node
    */
-  virtual void remove_node(std::shared_ptr<rclcpp::Node> node_ptr, bool notify = true);
+  void remove_node(std::shared_ptr<rclcpp::Node> node_ptr, bool notify = true) override;
 
   /**
    * \sa rclcpp::Executor:spin() for more details

--- a/gazebo_ros/include/gazebo_ros/executor.hpp
+++ b/gazebo_ros/include/gazebo_ros/executor.hpp
@@ -87,8 +87,13 @@ private:
   std::thread spin_thread_;
 
   std::mutex wait_mutex_;
+  // Use three mutexes to give priority to threads adding/removing nodes
+  // This avoids delays due to quick spinning threads
+  std::mutex add_remove_node_mutex_;
+  std::mutex add_remove_node_high_priority_mutex_;
+  std::mutex add_remove_node_low_priority_mutex_;
+
   size_t number_of_threads_;
-  std::chrono::nanoseconds next_exec_timeout_;
   std::set<rclcpp::TimerBase::SharedPtr> scheduled_timers_;
 
   /// Connection to gazebo sigint event

--- a/gazebo_ros/include/gazebo_ros/executor.hpp
+++ b/gazebo_ros/include/gazebo_ros/executor.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Open Source Robotics Foundation, Inc.
+// Copyright 2014 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,17 +15,19 @@
 #ifndef GAZEBO_ROS__EXECUTOR_HPP_
 #define GAZEBO_ROS__EXECUTOR_HPP_
 
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/executor.hpp>
 #include <gazebo/common/Events.hh>
+
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <thread>
 
 namespace gazebo_ros
 {
 
-/// Executor run in a separate thread to handle events from all #gazebo_ros::Node instances
-/**
- * \class Executor executor.hpp <gazebo_ros/executor.hpp>
- */
-class Executor : public rclcpp::executors::MultiThreadedExecutor
+class Executor : public rclcpp::Executor
 {
 public:
   /// Create an instance and start the internal thread
@@ -34,18 +36,65 @@ public:
   /// Stops the internal executor and joins with the internal thread
   virtual ~Executor();
 
-private:
-  /// Thread where the executor spins until destruction
-  std::thread spin_thread_;
+  /// Add a node to the executor.
+  /**
+   * This is a thread-safe wrapper around rclcpp::Executor::add_node.
+   *
+   * \see rclcpp::Executor::add_node
+   */
+  virtual void
+  add_node(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr, bool notify = true);
 
+  /// Convenience function which takes Node and forwards NodeBaseInterface.
+  /**
+   * This is a thread-safe wrapper around rclcpp::Executor::add_node.
+   *
+   * \see rclcpp::Executor::add_node
+   */
+  virtual void add_node(std::shared_ptr<rclcpp::Node> node_ptr, bool notify = true);
+
+  /// Remove a node from the executor.
+  /**
+   * This is a thread-safe wrapper around rclcpp::Executor::remove_node.
+   *
+   * \see rclcpp::Executor::remove_node
+   */
+  virtual void
+  remove_node(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr, bool notify = true);
+
+  /// Convenience function which takes Node and forwards NodeBaseInterface.
+  /**
+   * This is a thread-safe wrapper around rclcpp::Executor::remove_node.
+   *
+   * \see rclcpp::Executor::remove_node
+   */
+  virtual void remove_node(std::shared_ptr<rclcpp::Node> node_ptr, bool notify = true);
+
+  /**
+   * \sa rclcpp::Executor:spin() for more details
+   * \throws std::runtime_error when spin() called while already spinning
+   */
+  void spin() override;
+
+private:
   /// Spin executor, called in #spin_thread_
   void run();
 
   /// Shutdown ROS, called when gazebo sigint handle arrives so ROS is shutdown cleanly
   void shutdown();
 
+  /// Thread where the executor spins until destruction
+  std::thread spin_thread_;
+
+  std::mutex wait_mutex_;
+  size_t number_of_threads_;
+  std::chrono::nanoseconds next_exec_timeout_;
+  std::set<rclcpp::TimerBase::SharedPtr> scheduled_timers_;
+
   /// Connection to gazebo sigint event
   gazebo::event::ConnectionPtr sigint_handle_;
 };
+
 }  // namespace gazebo_ros
+
 #endif  // GAZEBO_ROS__EXECUTOR_HPP_

--- a/gazebo_ros/src/executor.cpp
+++ b/gazebo_ros/src/executor.cpp
@@ -145,4 +145,4 @@ Executor::run()
   }
 }
 
-} // namespace gazebo_ros
+}  // namespace gazebo_ros

--- a/gazebo_ros/src/executor.cpp
+++ b/gazebo_ros/src/executor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Open Source Robotics Foundation, Inc.
+// Copyright 2015 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,14 +14,29 @@
 
 #include <gazebo_ros/executor.hpp>
 
-#include <iostream>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "rclcpp/node.hpp"
+#include "rclcpp/utilities.hpp"
+#include "rclcpp/scope_exit.hpp"
 
 namespace gazebo_ros
 {
 
 Executor::Executor()
-: spin_thread_(std::bind(&Executor::run, this))
+: next_exec_timeout_(std::chrono::nanoseconds(100))
 {
+  number_of_threads_ = std::thread::hardware_concurrency();
+  if (number_of_threads_ == 0) {
+    number_of_threads_ = 1;
+  }
+
+  spin_thread_ = std::thread(std::bind(&Executor::spin, this));
+
   sigint_handle_ = gazebo::event::Events::ConnectSigInt(std::bind(&Executor::shutdown, this));
 }
 
@@ -34,14 +49,100 @@ Executor::~Executor()
   spin_thread_.join();
 }
 
-void Executor::run()
-{
-  spin();
-}
-
 void Executor::shutdown()
 {
   rclcpp::shutdown();
 }
 
-}  // namespace gazebo_ros
+void
+Executor::add_node(
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr, bool notify)
+{
+  std::lock_guard<std::mutex> wait_lock(wait_mutex_);
+  rclcpp::Executor::add_node(node_ptr, notify);
+}
+
+void
+Executor::add_node(std::shared_ptr<rclcpp::Node> node_ptr, bool notify)
+{
+  this->add_node(node_ptr->get_node_base_interface(), notify);
+}
+
+void
+Executor::remove_node(
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr, bool notify)
+{
+  std::lock_guard<std::mutex> wait_lock(wait_mutex_);
+  rclcpp::Executor::remove_node(node_ptr, notify);
+}
+
+void
+Executor::remove_node(std::shared_ptr<rclcpp::Node> node_ptr, bool notify)
+{
+  this->remove_node(node_ptr->get_node_base_interface(), notify);
+}
+
+void
+Executor::spin()
+{
+  if (spinning.exchange(true)) {
+    throw std::runtime_error("spin() called while already spinning");
+  }
+  RCLCPP_SCOPE_EXIT(this->spinning.store(false); );
+  std::vector<std::thread> threads;
+  size_t thread_id = 0;
+  {
+    for (; thread_id < number_of_threads_ - 1; ++thread_id) {
+      auto func = std::bind(&Executor::run, this);
+      threads.emplace_back(func);
+    }
+  }
+
+  run();
+  for (auto & thread : threads) {
+    thread.join();
+  }
+}
+
+void
+Executor::run()
+{
+  while (rclcpp::ok(this->context_) && spinning.load()) {
+    rclcpp::AnyExecutable any_exec;
+    std::lock_guard<std::mutex> wait_lock(wait_mutex_);
+    if (!rclcpp::ok(this->context_) || !spinning.load()) {
+      return;
+    }
+
+    if (!get_next_executable(any_exec, next_exec_timeout_)) {
+      continue;
+    }
+
+    if (any_exec.timer) {
+      // Guard against multiple threads getting the same timer.
+      if (scheduled_timers_.count(any_exec.timer) != 0) {
+        // Make sure that any_exec's callback group is reset before
+        // the lock is released.
+        if (any_exec.callback_group) {
+          any_exec.callback_group->can_be_taken_from().store(true);
+        }
+        continue;
+      }
+      scheduled_timers_.insert(any_exec.timer);
+    }
+
+    execute_any_executable(any_exec);
+
+    if (any_exec.timer) {
+      auto it = scheduled_timers_.find(any_exec.timer);
+      if (it != scheduled_timers_.end()) {
+        scheduled_timers_.erase(it);
+      }
+    }
+    // Clear the callback_group to prevent the AnyExecutable destructor from
+    // resetting the callback group `can_be_taken_from`
+    any_exec.callback_group.reset();
+  }
+}
+
+} // namespace gazebo_ros

--- a/gazebo_ros/test/CMakeLists.txt
+++ b/gazebo_ros/test/CMakeLists.txt
@@ -32,6 +32,7 @@ file(COPY worlds DESTINATION .)
 # Tests
 set(tests
   test_conversions
+  test_executor
   test_gazebo_ros_factory
   test_gazebo_ros_init
   test_gazebo_ros_joint_effort

--- a/gazebo_ros/test/test_executor.cpp
+++ b/gazebo_ros/test/test_executor.cpp
@@ -1,0 +1,50 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <thread>
+#include <sstream>
+
+#include <gtest/gtest.h>
+#include <gazebo_ros/executor.hpp>
+#include <rclcpp/node.hpp>
+
+// Regression test for https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1169
+TEST(TestExecutor, AddRemoveNodes)
+{
+  rclcpp::init(0, nullptr);
+
+  // Create an Executor
+  auto executor = std::make_shared<gazebo_ros::Executor>();
+
+  // Add and remove nodes repeatedly
+  // Test that this does not cause a segfault
+  size_t num_nodes = 100;
+  for (size_t i = 0; i < num_nodes; ++i) {
+    std::ostringstream name;
+    name << "node_" << i;
+    auto node = std::make_shared<rclcpp::Node>(name.str());
+    executor->add_node(node);
+    // Sleeping here helps exaggerate the issue
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    executor->remove_node(node);
+  }
+  rclcpp::shutdown();
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
The rclcpp::MultiThreadedExecutor is not thread safe, and so it is possible to hit races that cause gazebo_ros to crash. Specifically, there's a race when adding and removing nodes, which can happen when node are created and destroyed during runtime.

This is a copy of rclcpp::Executor with some modifications to make it thread safe. A lock was added to the spin implementation and also to the add_node and remove_node methods. In order to avoid deadlock, we must have a timeout in the spin loop while waiting for work.

Fixes #1169

Replaces https://github.com/ros-simulation/gazebo_ros_pkgs/pull/1196