### PR TITLE
Backport #1202 to melodic-devel: fix performance metrics

### DIFF
--- a/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
+++ b/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
@@ -391,8 +391,7 @@ private:
   ros::Publisher     pub_performance_metrics_;
   int                pub_link_states_connection_count_;
   int                pub_model_states_connection_count_;
-  // use static variable to avoid ABI break
-  static int         pub_performance_metrics_connection_count_;
+  int                pub_performance_metrics_connection_count_;
 
   // ROS comm
   boost::shared_ptr<ros::AsyncSpinner> async_ros_spin_;

--- a/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
+++ b/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
@@ -138,16 +138,16 @@ public:
   /// \brief advertise services
   void advertiseServices();
 
-  /// \brief
+  /// \brief Callback for a subscriber connecting to LinkStates ros topic.
   void onLinkStatesConnect();
 
-  /// \brief
+  /// \brief Callback for a subscriber connecting to ModelStates ros topic.
   void onModelStatesConnect();
 
-  /// \brief
+  /// \brief Callback for a subscriber disconnecting from LinkStates ros topic.
   void onLinkStatesDisconnect();
 
-  /// \brief
+  /// \brief Callback for a subscriber disconnecting from ModelStates ros topic.
   void onModelStatesDisconnect();
 
   /// \brief Function for inserting a URDF into Gazebo from ROS Service Call

--- a/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
+++ b/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
@@ -150,6 +150,14 @@ public:
   /// \brief Callback for a subscriber disconnecting from ModelStates ros topic.
   void onModelStatesDisconnect();
 
+#ifdef GAZEBO_ROS_HAS_PERFORMANCE_METRICS
+  /// \brief Callback for a subscriber connecting to PerformanceMetrics ros topic.
+  void onPerformanceMetricsConnect();
+
+  /// \brief Callback for a subscriber disconnecting from PerformanceMetrics ros topic.
+  void onPerformanceMetricsDisconnect();
+#endif
+
   /// \brief Function for inserting a URDF into Gazebo from ROS Service Call
   bool spawnURDFModel(gazebo_msgs::SpawnModel::Request &req,
                       gazebo_msgs::SpawnModel::Response &res);
@@ -383,6 +391,7 @@ private:
   ros::Publisher     pub_performance_metrics_;
   int                pub_link_states_connection_count_;
   int                pub_model_states_connection_count_;
+  int                pub_performance_metrics_connection_count_;
 
   // ROS comm
   boost::shared_ptr<ros::AsyncSpinner> async_ros_spin_;

--- a/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
+++ b/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
@@ -101,6 +101,13 @@
 
 #include <boost/algorithm/string.hpp>
 
+#ifndef GAZEBO_ROS_HAS_PERFORMANCE_METRICS
+#if (GAZEBO_MAJOR_VERSION == 11 && GAZEBO_MINOR_VERSION > 1) || \
+    (GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION > 14)
+#define GAZEBO_ROS_HAS_PERFORMANCE_METRICS
+#endif
+#endif  // ifndef GAZEBO_ROS_HAS_PERFORMANCE_METRICS
+
 namespace gazebo
 {
 
@@ -293,7 +300,7 @@ private:
   /// \brief Unused
   void onResponse(ConstResponsePtr &response);
 
-#if (GAZEBO_MAJOR_VERSION == 11 && GAZEBO_MINOR_VERSION > 1) || (GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION > 14)
+#ifdef GAZEBO_ROS_HAS_PERFORMANCE_METRICS
   /// \brief Subscriber callback for performance metrics. This will be send in the ROS network
   void onPerformanceMetrics(const boost::shared_ptr<gazebo::msgs::PerformanceMetrics const> &msg);
 #endif

--- a/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
+++ b/gazebo_ros/include/gazebo_ros/gazebo_ros_api_plugin.h
@@ -391,7 +391,8 @@ private:
   ros::Publisher     pub_performance_metrics_;
   int                pub_link_states_connection_count_;
   int                pub_model_states_connection_count_;
-  int                pub_performance_metrics_connection_count_;
+  // use static variable to avoid ABI break
+  static int         pub_performance_metrics_connection_count_;
 
   // ROS comm
   boost::shared_ptr<ros::AsyncSpinner> async_ros_spin_;

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -29,12 +29,13 @@
 namespace gazebo
 {
 
+int GazeboRosApiPlugin::pub_performance_metrics_connection_count_ = 0;
+
 GazeboRosApiPlugin::GazeboRosApiPlugin() :
   plugin_loaded_(false),
   stop_(false),
   pub_link_states_connection_count_(0),
   pub_model_states_connection_count_(0),
-  pub_performance_metrics_connection_count_(0),
   physics_reconfigure_initialized_(false),
   pub_clock_frequency_(0),
   world_created_(false),

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -29,13 +29,12 @@
 namespace gazebo
 {
 
-int GazeboRosApiPlugin::pub_performance_metrics_connection_count_ = 0;
-
 GazeboRosApiPlugin::GazeboRosApiPlugin() :
   plugin_loaded_(false),
   stop_(false),
   pub_link_states_connection_count_(0),
   pub_model_states_connection_count_(0),
+  pub_performance_metrics_connection_count_(0),
   physics_reconfigure_initialized_(false),
   pub_clock_frequency_(0),
   world_created_(false),

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -198,7 +198,7 @@ void GazeboRosApiPlugin::loadGazeboRosApiPlugin(std::string world_name)
   light_modify_pub_ = gazebonode_->Advertise<gazebo::msgs::Light>("~/light/modify");
   request_pub_ = gazebonode_->Advertise<gazebo::msgs::Request>("~/request");
   response_sub_ = gazebonode_->Subscribe("~/response",&GazeboRosApiPlugin::onResponse, this);
-#if (GAZEBO_MAJOR_VERSION == 11 && GAZEBO_MINOR_VERSION > 1) || (GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION > 14)
+#ifdef GAZEBO_ROS_HAS_PERFORMANCE_METRICS
   performance_metric_sub_ = gazebonode_->Subscribe("/gazebo/performance_metrics",
     &GazeboRosApiPlugin::onPerformanceMetrics, this);
 #endif
@@ -234,7 +234,7 @@ void GazeboRosApiPlugin::onResponse(ConstResponsePtr &response)
 {
 
 }
-#if (GAZEBO_MAJOR_VERSION == 11 && GAZEBO_MINOR_VERSION > 1) || (GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION > 14)
+#ifdef GAZEBO_ROS_HAS_PERFORMANCE_METRICS
 void GazeboRosApiPlugin::onPerformanceMetrics(const boost::shared_ptr<gazebo::msgs::PerformanceMetrics const> &msg)
 {
   gazebo_msgs::PerformanceMetrics msg_ros;
@@ -414,7 +414,7 @@ void GazeboRosApiPlugin::advertiseServices()
                                                             ros::VoidPtr(), &gazebo_queue_);
   pub_model_states_ = nh_->advertise(pub_model_states_ao);
 
-#if (GAZEBO_MAJOR_VERSION == 11 && GAZEBO_MINOR_VERSION > 1) || (GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION > 14)
+#ifdef GAZEBO_ROS_HAS_PERFORMANCE_METRICS
   // publish performance metrics
   pub_performance_metrics_ = nh_->advertise<gazebo_msgs::PerformanceMetrics>("performance_metrics", 10);
 #endif

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -584,7 +584,7 @@ void GazeboRosApiPlugin::onLinkStatesDisconnect()
   {
     pub_link_states_event_.reset();
     if (pub_link_states_connection_count_ < 0) // should not be possible
-      ROS_ERROR_NAMED("api_plugin", "One too mandy disconnect from pub_link_states_ in gazebo_ros.cpp? something weird");
+      ROS_ERROR_NAMED("api_plugin", "One too many disconnect from pub_link_states_ in gazebo_ros.cpp? something weird");
   }
 }
 
@@ -595,7 +595,7 @@ void GazeboRosApiPlugin::onModelStatesDisconnect()
   {
     pub_model_states_event_.reset();
     if (pub_model_states_connection_count_ < 0) // should not be possible
-      ROS_ERROR_NAMED("api_plugin", "One too mandy disconnect from pub_model_states_ in gazebo_ros.cpp? something weird");
+      ROS_ERROR_NAMED("api_plugin", "One too many disconnect from pub_model_states_ in gazebo_ros.cpp? something weird");
   }
 }
 

--- a/gazebo_ros/src/gazebo_ros_api_plugin.cpp
+++ b/gazebo_ros/src/gazebo_ros_api_plugin.cpp
@@ -34,6 +34,7 @@ GazeboRosApiPlugin::GazeboRosApiPlugin() :
   stop_(false),
   pub_link_states_connection_count_(0),
   pub_model_states_connection_count_(0),
+  pub_performance_metrics_connection_count_(0),
   physics_reconfigure_initialized_(false),
   pub_clock_frequency_(0),
   world_created_(false),
@@ -198,13 +199,10 @@ void GazeboRosApiPlugin::loadGazeboRosApiPlugin(std::string world_name)
   light_modify_pub_ = gazebonode_->Advertise<gazebo::msgs::Light>("~/light/modify");
   request_pub_ = gazebonode_->Advertise<gazebo::msgs::Request>("~/request");
   response_sub_ = gazebonode_->Subscribe("~/response",&GazeboRosApiPlugin::onResponse, this);
-#ifdef GAZEBO_ROS_HAS_PERFORMANCE_METRICS
-  performance_metric_sub_ = gazebonode_->Subscribe("/gazebo/performance_metrics",
-    &GazeboRosApiPlugin::onPerformanceMetrics, this);
-#endif
   // reset topic connection counts
   pub_link_states_connection_count_ = 0;
   pub_model_states_connection_count_ = 0;
+  pub_performance_metrics_connection_count_ = 0;
 
   // Manage clock for simulated ros time
   pub_clock_ = nh_->advertise<rosgraph_msgs::Clock>("/clock", 10);
@@ -416,7 +414,13 @@ void GazeboRosApiPlugin::advertiseServices()
 
 #ifdef GAZEBO_ROS_HAS_PERFORMANCE_METRICS
   // publish performance metrics
-  pub_performance_metrics_ = nh_->advertise<gazebo_msgs::PerformanceMetrics>("performance_metrics", 10);
+  ros::AdvertiseOptions pub_performance_metrics_ao =
+    ros::AdvertiseOptions::create<gazebo_msgs::PerformanceMetrics>(
+                                                                   "performance_metrics",10,
+                                                                   boost::bind(&GazeboRosApiPlugin::onPerformanceMetricsConnect,this),
+                                                                   boost::bind(&GazeboRosApiPlugin::onPerformanceMetricsDisconnect,this),
+                                                                   ros::VoidPtr(), &gazebo_queue_);
+  pub_performance_metrics_ = nh_->advertise(pub_performance_metrics_ao);
 #endif
 
   // Advertise more services on the custom queue
@@ -576,6 +580,29 @@ void GazeboRosApiPlugin::onModelStatesConnect()
   if (pub_model_states_connection_count_ == 1) // connect on first subscriber
     pub_model_states_event_   = gazebo::event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboRosApiPlugin::publishModelStates,this));
 }
+
+#ifdef GAZEBO_ROS_HAS_PERFORMANCE_METRICS
+void GazeboRosApiPlugin::onPerformanceMetricsConnect()
+{
+  pub_performance_metrics_connection_count_++;
+  if (pub_performance_metrics_connection_count_ == 1) // connect on first subscriber
+  {
+    performance_metric_sub_ = gazebonode_->Subscribe("/gazebo/performance_metrics",
+      &GazeboRosApiPlugin::onPerformanceMetrics, this);
+  }
+}
+
+void GazeboRosApiPlugin::onPerformanceMetricsDisconnect()
+{
+  pub_performance_metrics_connection_count_--;
+  if (pub_performance_metrics_connection_count_ <= 0) // disconnect with no subscribers
+  {
+    performance_metric_sub_.reset();
+    if (pub_performance_metrics_connection_count_ < 0) // should not be possible
+      ROS_ERROR_NAMED("api_plugin", "One too many disconnect from pub_performance_metrics_ in gazebo_ros.cpp? something weird");
+  }
+}
+#endif
 
 void GazeboRosApiPlugin::onLinkStatesDisconnect()
 {


### PR DESCRIPTION
Backport of #1202 to `melodic-devel`:

We are currently subscribing to the `/gazebo/performance_metrics` topic even if there are no subscribers to the ROS topic forwarding this data. The `link_states` and `model_states` topics currently use an advertise mechanism with callbacks when a subscriber connects or disconnects, so I've used that same pattern for the `performance_metrics` topic.

This also helps workaround the deadlock documented in #1175 and osrf/gazebo#2902.

I've also added the `GAZEBO_ROS_HAS_PERFORMANCE_METRICS` macro to de-duplicate the gazebo version checking logic and made some minor doc-string and spelling fixes.