### PR TITLE
Update test worlds to use the correct element names for xyzOffset and rpyOffset

### DIFF
--- a/gazebo_plugins/test/p3d_test/worlds/3_double_pendulums.world
+++ b/gazebo_plugins/test/p3d_test/worlds/3_double_pendulums.world
@@ -150,8 +150,8 @@
           <bodyName>link_1</bodyName>
           <topicName>/model_1/link_1/pose</topicName>
           <frameName>world</frameName>
-          <xyzOffsets>0 0 -2.1</xyzOffsets>
-          <rpyOffsets>0 0  0.0</rpyOffsets>
+          <xyzOffset>0 0 -2.1</xyzOffset>
+          <rpyOffset>0 0  0.0</rpyOffset>
       </plugin>
       <plugin name="p3d_link_2_controller" filename="libgazebo_ros_p3d.so">
           <alwaysOn>true</alwaysOn>
@@ -159,8 +159,8 @@
           <bodyName>link_2</bodyName>
           <topicName>/model_1/link_2/pose</topicName>
           <frameName>link_1</frameName>
-          <xyzOffsets>0 0  1.0</xyzOffsets>
-          <rpyOffsets>0 0  0.0</rpyOffsets>
+          <xyzOffset>0 0  1.0</xyzOffset>
+          <rpyOffset>0 0  0.0</rpyOffset>
       </plugin>
     </model>
 
@@ -297,8 +297,8 @@
           <bodyName>link_1</bodyName>
           <topicName>/model_2/link_1/pose</topicName>
           <frameName>world</frameName>
-          <xyzOffsets>0 -1.5 -2.1</xyzOffsets>
-          <rpyOffsets>0 0  0.0</rpyOffsets>
+          <xyzOffset>0 -1.5 -2.1</xyzOffset>
+          <rpyOffset>0 0  0.0</rpyOffset>
       </plugin>
       <plugin name="p3d_link_2_controller" filename="libgazebo_ros_p3d.so">
           <alwaysOn>true</alwaysOn>
@@ -306,8 +306,8 @@
           <bodyName>link_2</bodyName>
           <topicName>/model_2/link_2/pose</topicName>
           <frameName>link_1</frameName>
-          <xyzOffsets>0 0  1.0</xyzOffsets>
-          <rpyOffsets>0 0  0.0</rpyOffsets>
+          <xyzOffset>0 0  1.0</xyzOffset>
+          <rpyOffset>0 0  0.0</rpyOffset>
       </plugin>
     </model>
 
@@ -442,8 +442,8 @@
           <bodyName>link_1</bodyName>
           <topicName>/model_3/link_1/pose</topicName>
           <frameName>world</frameName>
-          <xyzOffsets>0 2 -2.1</xyzOffsets>
-          <rpyOffsets>0 0  0.0</rpyOffsets>
+          <xyzOffset>0 2 -2.1</xyzOffset>
+          <rpyOffset>0 0  0.0</rpyOffset>
       </plugin>
       <plugin name="p3d_link_2_controller" filename="libgazebo_ros_p3d.so">
           <alwaysOn>true</alwaysOn>
@@ -451,8 +451,8 @@
           <bodyName>link_2</bodyName>
           <topicName>/model_3/link_2/pose</topicName>
           <frameName>link_1</frameName>
-          <xyzOffsets>0 0  1.0</xyzOffsets>
-          <rpyOffsets>0 0  0.0</rpyOffsets>
+          <xyzOffset>0 0  1.0</xyzOffset>
+          <rpyOffset>0 0  0.0</rpyOffset>
       </plugin>
     </model>
   </world>

--- a/gazebo_plugins/test/p3d_test/worlds/3_single_pendulums.world
+++ b/gazebo_plugins/test/p3d_test/worlds/3_single_pendulums.world
@@ -89,8 +89,8 @@
           <bodyName>link_1</bodyName>
           <topicName>/model_1/link_1/pose</topicName>
           <frameName>world</frameName>
-          <xyzOffsets>0 0 -2.1</xyzOffsets>
-          <rpyOffsets>0 0 0.0</rpyOffsets>
+          <xyzOffset>0 0 -2.1</xyzOffset>
+          <rpyOffset>0 0 0.0</rpyOffset>
       </plugin>
     </model>
 
@@ -166,8 +166,8 @@
           <bodyName>link_1</bodyName>
           <topicName>/model_2/link_1/pose</topicName>
           <frameName>world</frameName>
-          <xyzOffsets>0 -1.5 -2.1</xyzOffsets>
-          <rpyOffsets>0 0 0.0</rpyOffsets>
+          <xyzOffset>0 -1.5 -2.1</xyzOffset>
+          <rpyOffset>0 0 0.0</rpyOffset>
       </plugin>
     </model>
 
@@ -241,8 +241,8 @@
           <bodyName>link_1</bodyName>
           <topicName>/model_3/link_1/pose</topicName>
           <frameName>world</frameName>
-          <xyzOffsets>0 2.0 -2.1</xyzOffsets>
-          <rpyOffsets>0 0    0.0</rpyOffsets>
+          <xyzOffset>0 2.0 -2.1</xyzOffset>
+          <rpyOffset>0 0    0.0</rpyOffset>
       </plugin>
     </model>
   </world>

--- a/gazebo_plugins/test/p3d_test/worlds/double_pendulum.world
+++ b/gazebo_plugins/test/p3d_test/worlds/double_pendulum.world
@@ -147,8 +147,8 @@
           <bodyName>link_1</bodyName>
           <topicName>/model_1/link_1/pose</topicName>
           <frameName>world</frameName>
-          <xyzOffsets>0 0 -2.1</xyzOffsets>
-          <rpyOffsets>0 0  0.0</rpyOffsets>
+          <xyzOffset>0 0 -2.1</xyzOffset>
+          <rpyOffset>0 0  0.0</rpyOffset>
       </plugin>
       <plugin name="p3d_link_2_controller" filename="libgazebo_ros_p3d.so">
           <alwaysOn>true</alwaysOn>
@@ -156,8 +156,8 @@
           <bodyName>link_2</bodyName>
           <topicName>/model_1/link_2/pose</topicName>
           <frameName>link_1</frameName>
-          <xyzOffsets>0 0  1.0</xyzOffsets>
-          <rpyOffsets>0 0  0.0</rpyOffsets>
+          <xyzOffset>0 0  1.0</xyzOffset>
+          <rpyOffset>0 0  0.0</rpyOffset>
       </plugin>
     </model>
 

--- a/gazebo_plugins/test/p3d_test/worlds/single_pendulum.world
+++ b/gazebo_plugins/test/p3d_test/worlds/single_pendulum.world
@@ -87,8 +87,8 @@
           <bodyName>link_1</bodyName>
           <topicName>/model_1/link_1/pose</topicName>
           <frameName>world</frameName>
-          <xyzOffsets>0 0 -2.1</xyzOffsets>
-          <rpyOffsets>0 0 0.0</rpyOffsets>
+          <xyzOffset>0 0 -2.1</xyzOffset>
+          <rpyOffset>0 0 0.0</rpyOffset>
       </plugin>
     </model>
 


### PR DESCRIPTION
The test worlds add an extra 's' character, but the real names are singular.

The names actually used:

https://github.com/ros-simulation/gazebo_ros_pkgs/blob/a63566be22361fa1f02ebcca4a9857d233e1c2ac/gazebo_plugins/src/gazebo_ros_p3d.cpp#L94

https://github.com/ros-simulation/gazebo_ros_pkgs/blob/a63566be22361fa1f02ebcca4a9857d233e1c2ac/gazebo_plugins/src/gazebo_ros_p3d.cpp#L102

---

Side note, **this changed in ROS 2 to be plural**:

https://github.com/ros-simulation/gazebo_ros_pkgs/blob/a73abf58afde5b4e9d2d8c8085a20a99e0773923/gazebo_plugins/src/gazebo_ros_p3d.cpp#L132

https://github.com/ros-simulation/gazebo_ros_pkgs/blob/a73abf58afde5b4e9d2d8c8085a20a99e0773923/gazebo_plugins/src/gazebo_ros_p3d.cpp#L138

And the migration guide mixes both plural and singular :confused: https://github.com/ros-simulation/gazebo_ros_pkgs/wiki/ROS-2-Migration:-P3D

I think it makes sense to continue to use singular names in ROS 2, `xyz_offset` and `rpy_offset`. I'll open a PR proposing that change.