### PR TITLE
revert to default update as in ROS1

### DIFF
--- a/gazebo_ros/src/gazebo_ros_init.cpp
+++ b/gazebo_ros/src/gazebo_ros_init.cpp
@@ -132,7 +132,7 @@ public:
   gazebo::transport::NodePtr gz_node_;
 
   /// Default frequency for clock publisher.
-  static constexpr double DEFAULT_PUBLISH_FREQUENCY = 10.;
+  static constexpr double DEFAULT_PUBLISH_FREQUENCY = 1000.;
 };
 
 GazeboRosInit::GazeboRosInit()

--- a/gazebo_ros/src/gazebo_ros_init.cpp
+++ b/gazebo_ros/src/gazebo_ros_init.cpp
@@ -132,7 +132,7 @@ public:
   gazebo::transport::NodePtr gz_node_;
 
   /// Default frequency for clock publisher.
-  static constexpr double DEFAULT_PUBLISH_FREQUENCY = 1000.;
+  static constexpr double DEFAULT_PUBLISH_FREQUENCY = 250.;
 };
 
 GazeboRosInit::GazeboRosInit()


### PR DESCRIPTION
This reverts the clock update frequency back to the ROS 1 value of 1kHz, in response to #1211.