### PR TITLE
Foxy backports

### DIFF
--- a/gazebo_dev/colcon.pkg
+++ b/gazebo_dev/colcon.pkg
@@ -1,0 +1,8 @@
+# Configuration file for colcon (https://colcon.readthedocs.io).
+#
+# Please see the doc for the details of the spec:
+#   - https://colcon.readthedocs.io/en/released/user/configuration.html#colcon-pkg-files
+
+{
+  "dependencies": ["Gazebo"],
+}

--- a/gazebo_plugins/colcon.pkg
+++ b/gazebo_plugins/colcon.pkg
@@ -1,0 +1,8 @@
+# Configuration file for colcon (https://colcon.readthedocs.io).
+#
+# Please see the doc for the details of the spec:
+#   - https://colcon.readthedocs.io/en/released/user/configuration.html#colcon-pkg-files
+
+{
+  "dependencies": ["Gazebo"],
+}

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_p3d.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_p3d.hpp
@@ -52,10 +52,10 @@ class GazeboRosP3DPrivate;
       <update_rate>1</update_rate>
 
       <!-- Translation offset to be added to the pose. -->
-      <xyz_offsets>10 10 10</xyz_offsets>
+      <xyz_offset>10 10 10</xyz_offset>
 
       <!-- Rotation offset to be added to the pose, in Euler angles. -->
-      <rpy_offsets>0.1 0.1 0.1</rpy_offsets>
+      <rpy_offset>0.1 0.1 0.1</rpy_offset>
 
       <!-- Standard deviation of the noise to be added to the reported velocities. -->
       <gaussian_noise>0.01</gaussian_noise>

--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -129,17 +129,32 @@ void GazeboRosP3D::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf)
   RCLCPP_DEBUG(
     impl_->ros_node_->get_logger(), "Publishing on topic [%s]", impl_->topic_name_.c_str());
 
-  if (!sdf->HasElement("xyz_offsets")) {
-    RCLCPP_DEBUG(impl_->ros_node_->get_logger(), "Missing <xyz_offsets>, defaults to 0s");
-  } else {
+  if (sdf->HasElement("xyz_offsets")) {
+    RCLCPP_WARN(
+      impl_->ros_node_->get_logger(), "<xyz_offsets> is deprecated, use <xyz_offset> instead.");
     impl_->offset_.Pos() = sdf->GetElement("xyz_offsets")->Get<ignition::math::Vector3d>();
   }
-
-  if (!sdf->HasElement("rpy_offsets")) {
-    RCLCPP_DEBUG(impl_->ros_node_->get_logger(), "Missing <rpy_offsets>, defaults to 0s");
+  if (!sdf->HasElement("xyz_offset")) {
+    if (!sdf->HasElement("xyz_offsets")) {
+      RCLCPP_DEBUG(impl_->ros_node_->get_logger(), "Missing <xyz_offset>, defaults to 0s");
+    }
   } else {
+    impl_->offset_.Pos() = sdf->GetElement("xyz_offset")->Get<ignition::math::Vector3d>();
+  }
+
+  if (sdf->HasElement("rpy_offsets")) {
+    RCLCPP_WARN(
+      impl_->ros_node_->get_logger(), "<rpy_offsets> is deprecated, use <rpy_offset> instead.");
     impl_->offset_.Rot() = ignition::math::Quaterniond(
       sdf->GetElement("rpy_offsets")->Get<ignition::math::Vector3d>());
+  }
+  if (!sdf->HasElement("rpy_offset")) {
+    if (!sdf->HasElement("rpy_offsets")) {
+      RCLCPP_DEBUG(impl_->ros_node_->get_logger(), "Missing <rpy_offset>, defaults to 0s");
+    }
+  } else {
+    impl_->offset_.Rot() = ignition::math::Quaterniond(
+      sdf->GetElement("rpy_offset")->Get<ignition::math::Vector3d>());
   }
 
   if (!sdf->HasElement("gaussian_noise")) {

--- a/gazebo_plugins/test/test_gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_p3d.cpp
@@ -100,6 +100,79 @@ TEST_F(GazeboRosP3dTest, Publishing)
   EXPECT_NEAR(0.0, latest_msg->twist.twist.angular.z, tol);
 }
 
+TEST_F(GazeboRosP3dTest, DeprecatedOffsetElements)
+{
+  // Load test world and start paused
+  this->Load("worlds/gazebo_ros_p3d.world", true);
+
+  // World
+  auto world = gazebo::physics::get_world();
+  ASSERT_NE(nullptr, world);
+
+  // Model
+  auto model = world->ModelByName("the_model");
+  ASSERT_NE(nullptr, model);
+
+  // Link
+  auto link = model->GetLink("box_link");
+  ASSERT_NE(nullptr, link);
+
+  // Reference link
+  auto ref_link = model->GetLink("sphere_link");
+  ASSERT_NE(nullptr, ref_link);
+
+  // Step a bit for model to settle
+  world->Step(100);
+
+  // Create node and executor
+  auto node = std::make_shared<rclcpp::Node>("gazebo_ros_p3d_test");
+  ASSERT_NE(nullptr, node);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+
+  // Create subscriber
+  nav_msgs::msg::Odometry::SharedPtr latest_msg{nullptr};
+  auto sub = node->create_subscription<nav_msgs::msg::Odometry>(
+    "test_deprecated/p3d_test_deprecated", rclcpp::SensorDataQoS(),
+    [&latest_msg](const nav_msgs::msg::Odometry::SharedPtr _msg) {
+      latest_msg = _msg;
+    });
+
+  // Wait for a message
+  world->Step(1000);
+  unsigned int max_sleep{30u};
+  for (auto sleep = 0u; !latest_msg && sleep < max_sleep; ++sleep) {
+    executor.spin_once(100ms);
+    gazebo::common::Time::MSleep(100);
+  }
+
+  // Check message
+  ASSERT_NE(nullptr, latest_msg);
+  EXPECT_EQ("sphere_link", latest_msg->header.frame_id);
+  EXPECT_EQ("box_link", latest_msg->child_frame_id);
+
+  EXPECT_NEAR(
+    latest_msg->pose.pose.position.x,
+    -ref_link->WorldPose().Pos().X() + link->WorldPose().Pos().X() + 5, tol);
+  EXPECT_NEAR(
+    latest_msg->pose.pose.position.y,
+    -ref_link->WorldPose().Pos().Y() + link->WorldPose().Pos().Y() + 5, tol);
+  EXPECT_NEAR(
+    latest_msg->pose.pose.position.z,
+    -ref_link->WorldPose().Pos().Z() + link->WorldPose().Pos().Z() + 5, tol);
+  EXPECT_NEAR(latest_msg->pose.pose.orientation.x, link->WorldPose().Rot().X(), tol);
+  EXPECT_NEAR(latest_msg->pose.pose.orientation.y, link->WorldPose().Rot().Y(), tol);
+  EXPECT_NEAR(latest_msg->pose.pose.orientation.z, link->WorldPose().Rot().Z(), tol);
+
+  EXPECT_NEAR(0.0, latest_msg->twist.twist.linear.x, tol);
+  EXPECT_NEAR(0.0, latest_msg->twist.twist.linear.y, tol);
+  EXPECT_NEAR(0.0, latest_msg->twist.twist.linear.z, tol);
+  EXPECT_NEAR(0.0, latest_msg->twist.twist.angular.x, tol);
+  EXPECT_NEAR(0.0, latest_msg->twist.twist.angular.y, tol);
+  EXPECT_NEAR(0.0, latest_msg->twist.twist.angular.z, tol);
+}
+
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);

--- a/gazebo_plugins/test/worlds/gazebo_ros_p3d.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_p3d.world
@@ -50,7 +50,19 @@
         <body_name>box_link</body_name>
         <frame_name>sphere_link</frame_name>
         <update_rate>0</update_rate>
-        <xyz_offsets>10 10 10</xyz_offsets>
+        <xyz_offset>10 10 10</xyz_offset>
+        <rpy_offset>0 0 0</rpy_offset>
+        <gaussian_noise>0</gaussian_noise>
+      </plugin>
+      <plugin name="gazebo_ros_p3d_deprecated" filename="libgazebo_ros_p3d.so">
+        <ros>
+          <namespace>/test_deprecated</namespace>
+          <remapping>odom:=p3d_test_deprecated</remapping>
+        </ros>
+        <body_name>box_link</body_name>
+        <frame_name>sphere_link</frame_name>
+        <update_rate>0</update_rate>
+        <xyz_offsets>5 5 5</xyz_offsets>
         <rpy_offsets>0 0 0</rpy_offsets>
         <gaussian_noise>0</gaussian_noise>
       </plugin>

--- a/gazebo_plugins/worlds/gazebo_ros_p3d_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_p3d_demo.world
@@ -57,8 +57,8 @@
         <body_name>box_link</body_name>
         <frame_name>sphere_link</frame_name>
         <update_rate>1</update_rate>
-        <xyz_offsets>10 10 10</xyz_offsets>
-        <rpy_offsets>0.1 0.1 0.1</rpy_offsets>
+        <xyz_offset>10 10 10</xyz_offset>
+        <rpy_offset>0.1 0.1 0.1</rpy_offset>
         <gaussian_noise>0.01</gaussian_noise>
       </plugin>
     </model>

--- a/gazebo_ros/colcon.pkg
+++ b/gazebo_ros/colcon.pkg
@@ -1,0 +1,8 @@
+# Configuration file for colcon (https://colcon.readthedocs.io).
+#
+# Please see the doc for the details of the spec:
+#   - https://colcon.readthedocs.io/en/released/user/configuration.html#colcon-pkg-files
+
+{
+  "dependencies": ["Gazebo"],
+}

--- a/gazebo_ros_control/colcon.pkg
+++ b/gazebo_ros_control/colcon.pkg
@@ -1,0 +1,8 @@
+# Configuration file for colcon (https://colcon.readthedocs.io).
+#
+# Please see the doc for the details of the spec:
+#   - https://colcon.readthedocs.io/en/released/user/configuration.html#colcon-pkg-files
+
+{
+  "dependencies": ["Gazebo"],
+}


### PR DESCRIPTION
Backporting the following changes to Foxy:

- colcon.pkg: build gazebo first in colcon workspace (#1192)
- ros2: Only subscribe to /gazebo/performance_metrics when necessary (#1205)
- Make p3d offset element names singular (#1210)
- Fix executor to avoid random exceptions when shutting down (#1212)