### PR TITLE
gazebo_ros: use lxml in spawn_entity.py

### DIFF
--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -33,6 +33,7 @@
   <depend>tinyxml_vendor</depend>
 
   <exec_depend>launch_ros</exec_depend>
+  <exec_depend>python3-lxml</exec_depend>
 
   <build_export_depend>geometry_msgs</build_export_depend>
   <build_export_depend>sensor_msgs</build_export_depend>

--- a/gazebo_ros/scripts/spawn_entity.py
+++ b/gazebo_ros/scripts/spawn_entity.py
@@ -22,7 +22,7 @@ import math
 import os
 import sys
 from urllib.parse import SplitResult, urlsplit
-from xml.etree import ElementTree
+from lxml import etree as ElementTree
 
 from gazebo_msgs.msg import ModelStates
 from gazebo_msgs.srv import DeleteEntity

--- a/gazebo_ros/test/CMakeLists.txt
+++ b/gazebo_ros/test/CMakeLists.txt
@@ -81,3 +81,14 @@ ament_target_dependencies(mock_robot_state_publisher
 add_launch_test(entity_spawner.test.py
   ARGS "mock_robot_state_publisher:=${CMAKE_CURRENT_BINARY_DIR}/mock_robot_state_publisher"
 )
+
+add_executable(mock_gazebo_ros_factory
+  mock_gazebo_ros_factory/gazebo_ros_factory.cpp
+)
+ament_target_dependencies(mock_gazebo_ros_factory
+  "rclcpp"
+  "gazebo_msgs"
+)
+add_launch_test(mock_entity_spawner.test.py
+  ARGS "mock_robot_state_publisher:=${CMAKE_CURRENT_BINARY_DIR}/mock_robot_state_publisher" "mock_gazebo_ros_factory:=${CMAKE_CURRENT_BINARY_DIR}/mock_gazebo_ros_factory"
+)

--- a/gazebo_ros/test/mock_entity_spawner.test.py
+++ b/gazebo_ros/test/mock_entity_spawner.test.py
@@ -1,0 +1,64 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import launch
+import launch.actions
+
+import launch_testing
+import launch_testing.asserts
+import launch_testing.markers
+import launch_testing.tools
+import pytest
+
+
+@pytest.mark.launch_test
+@launch_testing.markers.keep_alive
+def generate_test_description():
+    return launch.LaunchDescription([
+        launch.actions.DeclareLaunchArgument(
+            'mock_gazebo_ros_factory',
+            description='Path to mock gazebo ros factory executable',
+        ),
+        launch.actions.DeclareLaunchArgument(
+            'mock_robot_state_publisher',
+            description='Path to mock robot state publisher executable',
+        ),
+        launch.actions.ExecuteProcess(
+            cmd=[launch.substitutions.LaunchConfiguration('mock_robot_state_publisher')],
+            output='screen',
+        ),
+        launch.actions.ExecuteProcess(
+            cmd=[launch.substitutions.LaunchConfiguration('mock_gazebo_ros_factory')],
+            output='screen',
+        ),
+        launch_testing.actions.ReadyToTest()
+    ])
+
+
+class TestTerminatingProc(unittest.TestCase):
+
+    def test_spawn_entity(self, launch_service, proc_info, proc_output):
+        """Test terminating_proc without command line arguments."""
+        print('Running spawn entity test on /mock_robot_description topic')
+        entity_spawner_action = launch.actions.ExecuteProcess(
+            cmd=['ros2', 'run', 'gazebo_ros', 'spawn_entity.py', '-entity',
+                 'mock_robot_state_entity', '-topic', '/mock_robot_description'],
+            output='screen'
+        )
+        with launch_testing.tools.launch_process(
+              launch_service, entity_spawner_action, proc_info, proc_output) as command:
+            assert command.wait_for_shutdown(timeout=10)
+        assert command.exit_code == launch_testing.asserts.EXIT_OK

--- a/gazebo_ros/test/mock_gazebo_ros_factory/gazebo_ros_factory.cpp
+++ b/gazebo_ros/test/mock_gazebo_ros_factory/gazebo_ros_factory.cpp
@@ -1,0 +1,51 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <iostream>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "gazebo_msgs/srv/spawn_entity.hpp"
+
+using namespace std::chrono_literals;
+
+void SpawnEntityRequest(
+  gazebo_msgs::srv::SpawnEntity::Request::SharedPtr req,
+  gazebo_msgs::srv::SpawnEntity::Response::SharedPtr res)
+{
+  const std::string xmlnsParam = "<test:parameter>content</test:parameter>";
+  if (std::string::npos == req->xml.find(xmlnsParam)) {
+    res->status_message = "Unable to find '" + xmlnsParam + "' in " + req->xml;
+    res->success = false;
+    return;
+  }
+  res->status_message = "Success";
+  res->success = true;
+}
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("mock_gazebo_ros_factory");
+  auto service = node->create_service<gazebo_msgs::srv::SpawnEntity>(
+    "/spawn_entity",
+    std::bind(
+      &SpawnEntityRequest, std::placeholders::_1, std::placeholders::_2));
+
+  RCLCPP_INFO(node->get_logger(), "Listening to /spawn_entity");
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/gazebo_ros/test/mock_gazebo_ros_factory/gazebo_ros_factory.cpp
+++ b/gazebo_ros/test/mock_gazebo_ros_factory/gazebo_ros_factory.cpp
@@ -14,6 +14,7 @@
 
 #include <chrono>
 #include <iostream>
+#include <string>
 
 #include "rclcpp/rclcpp.hpp"
 

--- a/gazebo_ros/test/mock_robot_state_publisher/robot_state_publisher.cpp
+++ b/gazebo_ros/test/mock_robot_state_publisher/robot_state_publisher.cpp
@@ -40,6 +40,10 @@ int main(int argc, char * argv[])
     "</geometry>"
     "</visual>"
     "</link>"
+    "<plugin name='test_xmlns' filename='not-found'"
+    "        xmlns:test='http://example.org/schema'>"
+    "<test:parameter>content</test:parameter>"
+    "</plugin>"
     "</model>"
     "</sdf>";
 


### PR DESCRIPTION
The python `xml.etree.ElementTree` library does not handle xml namespaces well, replacing namespaces of prefixed elements
(like `<gazebo:custom_tag/>`) with `ns0`, `ns1`, etc. (like `<ns0:custom_tag/>`). I noticed this problem while debugging a model with custom elements spawned using `spawn_entity.py`.

Based on a [hint from stackoverflow](https://stackoverflow.com/a/14853417), this switches to using lxml instead, which has the same syntax and is already used by other ros2 packages (such as [urdf_parser_py](https://github.com/ros/urdf_parser_py/blob/ros2/package.xml)).