### PR TITLE
publish with QoS reliable as default

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_bumper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_bumper.cpp
@@ -89,7 +89,7 @@ void GazeboRosBumper::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
 
   // Contact state publisher
   impl_->pub_ = impl_->ros_node_->create_publisher<gazebo_msgs::msg::ContactsState>(
-    "bumper_states", qos.get_publisher_qos("bumper_states", rclcpp::SensorDataQoS()));
+    "bumper_states", qos.get_publisher_qos("bumper_states", rclcpp::SensorDataQoS().reliable()));
 
   RCLCPP_INFO(
     impl_->ros_node_->get_logger(), "Publishing contact states to [%s]",

--- a/gazebo_plugins/src/gazebo_ros_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera.cpp
@@ -187,9 +187,8 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
     const std::string camera_topic = impl_->camera_name_ + "/image_raw";
     impl_->image_pub_.push_back(
       image_transport::create_publisher(
-        impl_->ros_node_.get(),
-        camera_topic,
-        qos.get_publisher_qos(camera_topic, rclcpp::SensorDataQoS().reliable()).get_rmw_qos_profile()));
+        impl_->ros_node_.get(), camera_topic, qos.get_publisher_qos(
+          camera_topic, rclcpp::SensorDataQoS().reliable()).get_rmw_qos_profile()));
 
     // TODO(louise) Uncomment this once image_transport::Publisher has a function to return the
     // full topic.
@@ -201,7 +200,8 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
     const std::string camera_info_topic = impl_->camera_name_ + "/camera_info";
     impl_->camera_info_pub_.push_back(
       impl_->ros_node_->create_publisher<sensor_msgs::msg::CameraInfo>(
-        camera_info_topic, qos.get_publisher_qos(camera_info_topic, rclcpp::SensorDataQoS().reliable())));
+        camera_info_topic, qos.get_publisher_qos(
+          camera_info_topic, rclcpp::SensorDataQoS().reliable())));
 
     RCLCPP_INFO(
       impl_->ros_node_->get_logger(), "Publishing camera info to [%s]",
@@ -214,9 +214,8 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
       // Image publisher
       impl_->image_pub_.push_back(
         image_transport::create_publisher(
-          impl_->ros_node_.get(),
-          camera_topic,
-          qos.get_publisher_qos(camera_topic, rclcpp::SensorDataQoS().reliable()).get_rmw_qos_profile()));
+          impl_->ros_node_.get(), camera_topic, qos.get_publisher_qos(
+            camera_topic, rclcpp::SensorDataQoS().reliable()).get_rmw_qos_profile()));
 
       // RCLCPP_INFO(
       //   impl_->ros_node_->get_logger(), "Publishing %s camera images to [%s]",
@@ -228,7 +227,8 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
       // Camera info publisher
       impl_->camera_info_pub_.push_back(
         impl_->ros_node_->create_publisher<sensor_msgs::msg::CameraInfo>(
-          camera_info_topic, qos.get_publisher_qos(camera_info_topic, rclcpp::SensorDataQoS().reliable())));
+          camera_info_topic, qos.get_publisher_qos(
+            camera_info_topic, rclcpp::SensorDataQoS().reliable())));
 
       RCLCPP_INFO(
         impl_->ros_node_->get_logger(), "Publishing %s camera info to [%s]",
@@ -241,9 +241,8 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
     const std::string depth_topic = impl_->camera_name_ + "/depth/image_raw";
     // Depth image publisher
     impl_->depth_image_pub_ = image_transport::create_publisher(
-      impl_->ros_node_.get(),
-      depth_topic,
-      qos.get_publisher_qos(depth_topic, rclcpp::SensorDataQoS().reliable()).get_rmw_qos_profile());
+      impl_->ros_node_.get(), depth_topic, qos.get_publisher_qos(
+        depth_topic, rclcpp::SensorDataQoS().reliable()).get_rmw_qos_profile());
 
     // RCLCPP_INFO(impl_->ros_node_->get_logger(), "Publishing depth images to [%s]",
     //   impl_->depth_image_pub_.getTopic().c_str());

--- a/gazebo_plugins/src/gazebo_ros_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera.cpp
@@ -189,7 +189,7 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
       image_transport::create_publisher(
         impl_->ros_node_.get(),
         camera_topic,
-        qos.get_publisher_qos(camera_topic, rclcpp::SensorDataQoS()).get_rmw_qos_profile()));
+        qos.get_publisher_qos(camera_topic, rclcpp::SensorDataQoS().reliable()).get_rmw_qos_profile()));
 
     // TODO(louise) Uncomment this once image_transport::Publisher has a function to return the
     // full topic.
@@ -201,7 +201,7 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
     const std::string camera_info_topic = impl_->camera_name_ + "/camera_info";
     impl_->camera_info_pub_.push_back(
       impl_->ros_node_->create_publisher<sensor_msgs::msg::CameraInfo>(
-        camera_info_topic, qos.get_publisher_qos(camera_info_topic, rclcpp::SensorDataQoS())));
+        camera_info_topic, qos.get_publisher_qos(camera_info_topic, rclcpp::SensorDataQoS().reliable())));
 
     RCLCPP_INFO(
       impl_->ros_node_->get_logger(), "Publishing camera info to [%s]",
@@ -216,7 +216,7 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
         image_transport::create_publisher(
           impl_->ros_node_.get(),
           camera_topic,
-          qos.get_publisher_qos(camera_topic, rclcpp::SensorDataQoS()).get_rmw_qos_profile()));
+          qos.get_publisher_qos(camera_topic, rclcpp::SensorDataQoS().reliable()).get_rmw_qos_profile()));
 
       // RCLCPP_INFO(
       //   impl_->ros_node_->get_logger(), "Publishing %s camera images to [%s]",
@@ -228,7 +228,7 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
       // Camera info publisher
       impl_->camera_info_pub_.push_back(
         impl_->ros_node_->create_publisher<sensor_msgs::msg::CameraInfo>(
-          camera_info_topic, qos.get_publisher_qos(camera_info_topic, rclcpp::SensorDataQoS())));
+          camera_info_topic, qos.get_publisher_qos(camera_info_topic, rclcpp::SensorDataQoS().reliable())));
 
       RCLCPP_INFO(
         impl_->ros_node_->get_logger(), "Publishing %s camera info to [%s]",
@@ -243,7 +243,7 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
     impl_->depth_image_pub_ = image_transport::create_publisher(
       impl_->ros_node_.get(),
       depth_topic,
-      qos.get_publisher_qos(depth_topic, rclcpp::SensorDataQoS()).get_rmw_qos_profile());
+      qos.get_publisher_qos(depth_topic, rclcpp::SensorDataQoS().reliable()).get_rmw_qos_profile());
 
     // RCLCPP_INFO(impl_->ros_node_->get_logger(), "Publishing depth images to [%s]",
     //   impl_->depth_image_pub_.getTopic().c_str());

--- a/gazebo_plugins/src/gazebo_ros_gps_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_gps_sensor.cpp
@@ -72,7 +72,7 @@ void GazeboRosGpsSensor::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPt
   }
 
   impl_->pub_ = impl_->ros_node_->create_publisher<sensor_msgs::msg::NavSatFix>(
-    "~/out", qos.get_publisher_qos("~/out", rclcpp::SensorDataQoS()));
+    "~/out", qos.get_publisher_qos("~/out", rclcpp::SensorDataQoS().reliable()));
 
   // Create message to be reused
   auto msg = std::make_shared<sensor_msgs::msg::NavSatFix>();

--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -93,7 +93,7 @@ void GazeboRosImuSensor::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPt
   }
 
   impl_->pub_ = impl_->ros_node_->create_publisher<sensor_msgs::msg::Imu>(
-    "~/out", qos.get_publisher_qos("~/out", rclcpp::SensorDataQoS()));
+    "~/out", qos.get_publisher_qos("~/out", rclcpp::SensorDataQoS().reliable()));
 
   // Create message to be reused
   auto msg = std::make_shared<sensor_msgs::msg::Imu>();

--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -124,7 +124,7 @@ void GazeboRosP3D::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf)
   }
 
   impl_->pub_ = impl_->ros_node_->create_publisher<nav_msgs::msg::Odometry>(
-    impl_->topic_name_, qos.get_publisher_qos(impl_->topic_name_, rclcpp::SensorDataQoS()));
+    impl_->topic_name_, qos.get_publisher_qos(impl_->topic_name_, rclcpp::SensorDataQoS().reliable()));
   impl_->topic_name_ = impl_->pub_->get_topic_name();
   RCLCPP_DEBUG(
     impl_->ros_node_->get_logger(), "Publishing on topic [%s]", impl_->topic_name_.c_str());

--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -124,7 +124,8 @@ void GazeboRosP3D::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf)
   }
 
   impl_->pub_ = impl_->ros_node_->create_publisher<nav_msgs::msg::Odometry>(
-    impl_->topic_name_, qos.get_publisher_qos(impl_->topic_name_, rclcpp::SensorDataQoS().reliable()));
+    impl_->topic_name_, qos.get_publisher_qos(
+      impl_->topic_name_, rclcpp::SensorDataQoS().reliable()));
   impl_->topic_name_ = impl_->pub_->get_topic_name();
   RCLCPP_DEBUG(
     impl_->ros_node_->get_logger(), "Publishing on topic [%s]", impl_->topic_name_.c_str());

--- a/gazebo_plugins/src/gazebo_ros_ray_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ray_sensor.cpp
@@ -107,7 +107,7 @@ void GazeboRosRaySensor::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPt
   const gazebo_ros::QoS & qos = impl_->ros_node_->get_qos();
 
   // Get QoS profile for the publisher
-  rclcpp::QoS pub_qos = qos.get_publisher_qos("~/out", rclcpp::SensorDataQoS());
+  rclcpp::QoS pub_qos = qos.get_publisher_qos("~/out", rclcpp::SensorDataQoS().reliable());
 
   // Get tf frame for output
   impl_->frame_name_ = gazebo_ros::SensorFrameID(*_sensor, *_sdf);


### PR DESCRIPTION
This pull request is a minimal fix to ensure compatibility with rqt and other default (reliable) subscribers, while still allowing production systems to take advantage of best-effort transport, and still demonstrating the use of the recommended QoS profiles.

This is a revision of https://github.com/ros-simulation/gazebo_ros_pkgs/pull/1219

This applies only to publishers defaulting to `rclcpp::SensorDataQoS()`  and sets defaults to `rclcpp::SensorDataQoS().reliable()`