### PR TITLE
Use sensor's max_range instead of numeric limit

### DIFF
--- a/gazebo_ros/include/gazebo_ros/conversions/sensor_msgs.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/sensor_msgs.hpp
@@ -27,7 +27,6 @@
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 
 #include <algorithm>
-#include <limits>
 
 #include "gazebo_ros/conversions/builtin_interfaces.hpp"
 #include "gazebo_ros/conversions/generic.hpp"
@@ -301,7 +300,7 @@ sensor_msgs::msg::Range Convert(const gazebo::msgs::LaserScanStamped & in, doubl
 
   // Set range to the minimum of the ray ranges
   // For single rays, this will just be the range of the ray
-  range_msg.range = std::numeric_limits<sensor_msgs::msg::Range::_range_type>::max();
+  range_msg.range = range_msg.max_range;
   for (double range : in.scan().ranges()) {
     if (range < range_msg.range) {
       range_msg.range = range;


### PR DESCRIPTION
When a range sensor reaches its maximum range instead of publishing its maximum range, it's publishing a very big value.