### PR TITLE
Revert "Fix executor to avoid random exceptions when shutting down (#1212)"

### DIFF
--- a/gazebo_ros/src/executor.cpp
+++ b/gazebo_ros/src/executor.cpp
@@ -22,22 +22,15 @@ namespace gazebo_ros
 Executor::Executor()
 : spin_thread_(std::bind(&Executor::run, this))
 {
-  using namespace std::chrono_literals;
   sigint_handle_ = gazebo::event::Events::ConnectSigInt(std::bind(&Executor::shutdown, this));
-  while (!this->spinning) {
-    // TODO(ivanpauno): WARN Terrible hack here!!!!
-    // We cannot call rclcpp::shutdown asynchronously, because it generates exceptions that
-    // cannot be caught properly (see https://github.com/ros2/rclcpp/issues/1139).
-    // Executor::cancel() doesn't cause this problem, but it has a race.
-    // Wait until the launched thread starts spinning to avoid the race ...
-    std::this_thread::sleep_for(100ms);
-  }
 }
 
 Executor::~Executor()
 {
   // If ros was not already shutdown by SIGINT handler, do it now
-  this->shutdown();
+  if (rclcpp::ok()) {
+    rclcpp::shutdown();
+  }
   spin_thread_.join();
 }
 
@@ -48,9 +41,7 @@ void Executor::run()
 
 void Executor::shutdown()
 {
-  if (this->spinning) {
-    this->cancel();
-  }
+  rclcpp::shutdown();
 }
 
 }  // namespace gazebo_ros


### PR DESCRIPTION
Trying to confirm if #1212 is responsible for the recent CI test failures.

cc/ @scpeters 