### PR TITLE
Fix tests for cyclonedds

### DIFF
--- a/gazebo_plugins/test/test_gazebo_ros_joint_state_publisher.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_joint_state_publisher.cpp
@@ -56,14 +56,16 @@ TEST_F(GazeboRosJointStatePublisherTest, Publishing)
   executor.add_node(node);
 
   // Step a bit before starting
-  world->Step(500);
-  executor.spin_once(500ms);
+  for (unsigned int i = 0; i < 10; ++i) {
+    world->Step(1);
+    executor.spin_once(1ms);
+  }
   gazebo::common::Time::MSleep(100);
 
   // Create subscriber
   sensor_msgs::msg::JointState::SharedPtr latestMsg;
   auto sub = node->create_subscription<sensor_msgs::msg::JointState>(
-    "test/joint_states_test", rclcpp::SensorDataQoS(),
+    "test/joint_states_test", rclcpp::QoS(1),
     [&latestMsg](const sensor_msgs::msg::JointState::SharedPtr msg) {
       latestMsg = msg;
     });

--- a/gazebo_ros/test/plugins/args_init.cpp
+++ b/gazebo_ros/test/plugins/args_init.cpp
@@ -56,8 +56,9 @@ void ProperInit::Load(int argc, char ** argv)
   auto node = gazebo_ros::Node::Get();
 
   // Create a publisher
-  auto pub = node->create_publisher<std_msgs::msg::String>("test",
-      rclcpp::QoS(rclcpp::KeepLast(1)).transient_local());
+  auto pub = node->create_publisher<std_msgs::msg::String>(
+    "test",
+    rclcpp::QoS(rclcpp::KeepLast(1)).transient_local());
 
   // Run lambda every 1 second
   using namespace std::chrono_literals;

--- a/gazebo_ros/test/plugins/args_init.cpp
+++ b/gazebo_ros/test/plugins/args_init.cpp
@@ -56,7 +56,8 @@ void ProperInit::Load(int argc, char ** argv)
   auto node = gazebo_ros::Node::Get();
 
   // Create a publisher
-  auto pub = node->create_publisher<std_msgs::msg::String>("test", rclcpp::SystemDefaultsQoS());
+  auto pub = node->create_publisher<std_msgs::msg::String>("test",
+      rclcpp::QoS(rclcpp::KeepLast(1)).transient_local());
 
   // Run lambda every 1 second
   using namespace std::chrono_literals;

--- a/gazebo_ros/test/plugins/create_node_without_init.cpp
+++ b/gazebo_ros/test/plugins/create_node_without_init.cpp
@@ -40,7 +40,8 @@ void CreateBeforeInit::Load(int, char **)
   assert(nullptr != node);
 
   // Create a publisher
-  auto pub = node->create_publisher<std_msgs::msg::String>("test", rclcpp::SystemDefaultsQoS());
+  auto pub = node->create_publisher<std_msgs::msg::String>("test",
+      rclcpp::QoS(rclcpp::KeepLast(1)).transient_local());
 
   // Run lambda every 1 second
   using namespace std::chrono_literals;

--- a/gazebo_ros/test/plugins/create_node_without_init.cpp
+++ b/gazebo_ros/test/plugins/create_node_without_init.cpp
@@ -40,8 +40,9 @@ void CreateBeforeInit::Load(int, char **)
   assert(nullptr != node);
 
   // Create a publisher
-  auto pub = node->create_publisher<std_msgs::msg::String>("test",
-      rclcpp::QoS(rclcpp::KeepLast(1)).transient_local());
+  auto pub = node->create_publisher<std_msgs::msg::String>(
+    "test",
+    rclcpp::QoS(rclcpp::KeepLast(1)).transient_local());
 
   // Run lambda every 1 second
   using namespace std::chrono_literals;

--- a/gazebo_ros/test/plugins/ros_world_plugin.cpp
+++ b/gazebo_ros/test/plugins/ros_world_plugin.cpp
@@ -40,7 +40,8 @@ void RosWorldPlugin::Load(gazebo::physics::WorldPtr, sdf::ElementPtr _sdf)
   assert(nullptr != node);
 
   // Create a publisher
-  auto pub = node->create_publisher<std_msgs::msg::String>("test", rclcpp::SystemDefaultsQoS());
+  auto pub = node->create_publisher<std_msgs::msg::String>("test",
+      rclcpp::QoS(rclcpp::KeepLast(1)).transient_local());
 
   // Run lambda every 1 second
   using namespace std::chrono_literals;

--- a/gazebo_ros/test/plugins/ros_world_plugin.cpp
+++ b/gazebo_ros/test/plugins/ros_world_plugin.cpp
@@ -40,8 +40,9 @@ void RosWorldPlugin::Load(gazebo::physics::WorldPtr, sdf::ElementPtr _sdf)
   assert(nullptr != node);
 
   // Create a publisher
-  auto pub = node->create_publisher<std_msgs::msg::String>("test",
-      rclcpp::QoS(rclcpp::KeepLast(1)).transient_local());
+  auto pub = node->create_publisher<std_msgs::msg::String>(
+    "test",
+    rclcpp::QoS(rclcpp::KeepLast(1)).transient_local());
 
   // Run lambda every 1 second
   using namespace std::chrono_literals;

--- a/gazebo_ros/test/plugins/sdf_node.cpp
+++ b/gazebo_ros/test/plugins/sdf_node.cpp
@@ -55,8 +55,9 @@ void SDFNode::Load(gazebo::physics::WorldPtr, sdf::ElementPtr _sdf)
   // If any of them fail, messages will not publish so test will fail
 
   // Create a publisher
-  auto pub = node->create_publisher<std_msgs::msg::String>("test",
-      rclcpp::QoS(rclcpp::KeepLast(1)).transient_local());
+  auto pub = node->create_publisher<std_msgs::msg::String>(
+    "test",
+    rclcpp::QoS(rclcpp::KeepLast(1)).transient_local());
 
   {
     auto param = node->get_parameter("declared_string");

--- a/gazebo_ros/test/plugins/sdf_node.cpp
+++ b/gazebo_ros/test/plugins/sdf_node.cpp
@@ -55,7 +55,8 @@ void SDFNode::Load(gazebo::physics::WorldPtr, sdf::ElementPtr _sdf)
   // If any of them fail, messages will not publish so test will fail
 
   // Create a publisher
-  auto pub = node->create_publisher<std_msgs::msg::String>("test", rclcpp::SystemDefaultsQoS());
+  auto pub = node->create_publisher<std_msgs::msg::String>("test",
+      rclcpp::QoS(rclcpp::KeepLast(1)).transient_local());
 
   {
     auto param = node->get_parameter("declared_string");

--- a/gazebo_ros/test/test_sim_time.cpp
+++ b/gazebo_ros/test/test_sim_time.cpp
@@ -69,9 +69,9 @@ TEST_F(TestSimTime, TestClock)
     });
 
   unsigned int sleep{0};
-  unsigned int max_sleep{30};
+  unsigned int max_sleep{100};
   while (msgs.size() < 5 && sleep++ < max_sleep) {
-    executor.spin_once(200ms);
+    executor.spin_once(100ms);
   }
   EXPECT_LT(sleep, max_sleep);
   EXPECT_EQ(5u, msgs.size());


### PR DESCRIPTION
There are some QoS incompatibilities in some tests that use
SystemDefaultsQoS, so this changes them to use KeepLast(1)
with transient_local instead. This fixes some of the test
failures but not all.

See [get_message_or_timeout in testing_utils.hpp](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/ros2/gazebo_ros/include/gazebo_ros/testing_utils.hpp#L135) to see what QoS parameters the test subscribers are using.