### PR TITLE
Deprecate -spawn_service_timeout option

### DIFF
--- a/gazebo_ros/scripts/spawn_entity.py
+++ b/gazebo_ros/scripts/spawn_entity.py
@@ -80,7 +80,7 @@ class SpawnEntityNode(Node):
         parser.add_argument('-wait', type=str, metavar='ENTITY_NAME',
                             help='Wait for entity to exist')
         parser.add_argument('-spawn_service_timeout', type=float, metavar='TIMEOUT',
-                            default=5.0, help='Spawn service wait timeout in seconds')
+                            help="DEPRECATED: Use '-timeout' instead.")
         parser.add_argument('-x', type=float, default=0,
                             help='x component of initial position, meters')
         parser.add_argument('-y', type=float, default=0,
@@ -220,7 +220,12 @@ class SpawnEntityNode(Node):
         initial_pose.orientation.y = q[2]
         initial_pose.orientation.z = q[3]
 
-        success = self._spawn_entity(entity_xml, initial_pose, self.args.spawn_service_timeout)
+        spawn_service_timeout = self.args.timeout 
+        if self.args.spawn_service_timeout is not None:
+            self.get_logger().warning(
+                "'-spawn_service_timeout' is deprecated, use '-timeout' instead")
+            spawn_service_timeout = self.args.spawn_service_timeout
+        success = self._spawn_entity(entity_xml, initial_pose, spawn_service_timeout)
         if not success:
             self.get_logger().error('Spawn service failed. Exiting.')
             return 1

--- a/gazebo_ros/scripts/spawn_entity.py
+++ b/gazebo_ros/scripts/spawn_entity.py
@@ -220,7 +220,7 @@ class SpawnEntityNode(Node):
         initial_pose.orientation.y = q[2]
         initial_pose.orientation.z = q[3]
 
-        spawn_service_timeout = self.args.timeout 
+        spawn_service_timeout = self.args.timeout
         if self.args.spawn_service_timeout is not None:
             self.get_logger().warning(
                 "'-spawn_service_timeout' is deprecated, use '-timeout' instead")

--- a/gazebo_ros/test/entity_spawner.test.py
+++ b/gazebo_ros/test/entity_spawner.test.py
@@ -52,11 +52,54 @@ class TestTerminatingProc(unittest.TestCase):
         """Test terminating_proc without command line arguments."""
         print('Running spawn entity test on /mock_robot_description topic')
         entity_spawner_action = launch.actions.ExecuteProcess(
-            cmd=['ros2', 'run', 'gazebo_ros', 'spawn_entity.py', '-entity',
-                 'mock_robot_state_entity', '-topic', '/mock_robot_description'],
+            cmd=['ros2', 'run', 'gazebo_ros', 'spawn_entity.py',
+                 '-entity', 'mock_entity_test_spawn_entity', '-topic', '/mock_robot_description'],
             output='screen'
         )
         with launch_testing.tools.launch_process(
               launch_service, entity_spawner_action, proc_info, proc_output) as command:
             assert command.wait_for_shutdown(timeout=10)
         assert command.exit_code == launch_testing.asserts.EXIT_OK
+
+    def test_spawn_entity_timeout(self, launch_service, proc_info, proc_output):
+        """Test terminating_proc without command line arguments."""
+        print('Running spawn entity test on /mock_robot_description topic')
+        entity_spawner_action = launch.actions.ExecuteProcess(
+            cmd=['ros2', 'run', 'gazebo_ros', 'spawn_entity.py',
+                 '-entity', 'mock_entity_test_spawn_entity_timeout',
+                 '-topic', '/mock_robot_description',
+                 '-timeout', '10'],
+            output='screen'
+        )
+        with launch_testing.tools.launch_process(
+              launch_service, entity_spawner_action, proc_info, proc_output) as command:
+            assert command.wait_for_shutdown(timeout=10)
+        assert command.exit_code == launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=['Waiting for service /spawn_entity, timeout = 10'],
+            text=command.output,
+            strict=False
+        )
+
+    def test_spawn_entity_deprecated_timeout(self, launch_service, proc_info, proc_output):
+        """Test terminating_proc without command line arguments."""
+        print('Running spawn entity test on /mock_robot_description topic')
+        entity_spawner_action = launch.actions.ExecuteProcess(
+            cmd=['ros2', 'run', 'gazebo_ros', 'spawn_entity.py',
+                 '-entity', 'mock_entity_test_spawn_entity_deprecated_timeout',
+                 '-topic', '/mock_robot_description',
+                 '-spawn_service_timeout', '10'],
+            output='screen'
+        )
+        with launch_testing.tools.launch_process(
+              launch_service, entity_spawner_action, proc_info, proc_output) as command:
+            assert command.wait_for_shutdown(timeout=10)
+        assert command.exit_code == launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=[
+                "'-spawn_service_timeout' is deprecated, use '-timeout' instead",
+                'Waiting for service /spawn_entity, timeout = 10',
+            ],
+            text=command.output,
+            strict=False
+        )

--- a/gazebo_ros/test/entity_spawner.test.py
+++ b/gazebo_ros/test/entity_spawner.test.py
@@ -49,8 +49,7 @@ def generate_test_description():
 class TestTerminatingProc(unittest.TestCase):
 
     def test_spawn_entity(self, launch_service, proc_info, proc_output):
-        """Test terminating_proc without command line arguments."""
-        print('Running spawn entity test on /mock_robot_description topic')
+        """Test spawn entity from topic."""
         entity_spawner_action = launch.actions.ExecuteProcess(
             cmd=['ros2', 'run', 'gazebo_ros', 'spawn_entity.py',
                  '-entity', 'mock_entity_test_spawn_entity', '-topic', '/mock_robot_description'],
@@ -62,8 +61,7 @@ class TestTerminatingProc(unittest.TestCase):
         assert command.exit_code == launch_testing.asserts.EXIT_OK
 
     def test_spawn_entity_timeout(self, launch_service, proc_info, proc_output):
-        """Test terminating_proc without command line arguments."""
-        print('Running spawn entity test on /mock_robot_description topic')
+        """Test spawn entity from topic and output with -timeout option."""
         entity_spawner_action = launch.actions.ExecuteProcess(
             cmd=['ros2', 'run', 'gazebo_ros', 'spawn_entity.py',
                  '-entity', 'mock_entity_test_spawn_entity_timeout',
@@ -82,8 +80,7 @@ class TestTerminatingProc(unittest.TestCase):
         )
 
     def test_spawn_entity_deprecated_timeout(self, launch_service, proc_info, proc_output):
-        """Test terminating_proc without command line arguments."""
-        print('Running spawn entity test on /mock_robot_description topic')
+        """Test spawn entity from topic and deprecation with -spawn_service_timeout option."""
         entity_spawner_action = launch.actions.ExecuteProcess(
             cmd=['ros2', 'run', 'gazebo_ros', 'spawn_entity.py',
                  '-entity', 'mock_entity_test_spawn_entity_deprecated_timeout',


### PR DESCRIPTION
The spawn_entity.py script has two options for setting service timeouts:

1. '-timeout': Sets the duration to wait for all services to be ready
2. '-spawn_service_timeout': Sets the duration to wait for the spawn_entity service to be ready

(1) is available in all ROS distros since Dashing (except Eloquent for some reason).
(2) was introduced in Eloquent, and replaced (1) in Foxy as the way to control the timeout specifically for the spawn_entity service.

This change deprecates (2) and assumes (1) is used for all service timeouts again.

This change also adds smoke tests for the two options.

---

For reference, `-timeout` was added in  #1072 and #1073, and `-spawn_service_timeout` was added in https://github.com/ros-simulation/gazebo_ros_pkgs/pull/1090.