### PR TITLE
Reverse order of rotation offset (rpyOffset) calculation in p3d and imu plugins

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_imu.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_imu.h
@@ -77,6 +77,9 @@ namespace gazebo
     /// \brief allow specifying constant xyz and rpy offsets
     private: ignition::math::Pose3d offset_;
 
+    // \brief Flag to indicate if rotation calculation needs to be reversed
+    private: bool correctedOffsets_ = false;
+
     /// \brief A mutex to lock access to fields
     /// that are used in message callbacks
     private: boost::mutex lock_;

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_p3d.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_p3d.h
@@ -91,6 +91,9 @@ namespace gazebo
     /// \brief allow specifying constant xyz and rpy offsets
     private: ignition::math::Pose3d offset_;
 
+    // \brief Flag to indicate if rotation calculation needs to be reversed
+    private: bool correctedOffsets_ = false;
+
     /// \brief mutex to lock access to fields used in message callbacks
     private: boost::mutex lock;
 

--- a/gazebo_plugins/src/gazebo_ros_imu.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu.cpp
@@ -244,7 +244,7 @@ void GazeboRosIMU::UpdateChild()
     rot = pose.Rot();
 
     // apply rpy offsets
-    rot = this->offset_.Rot()*rot;
+    rot = rot*this->offset_.Rot();
     rot.Normalize();
 
     // get Rates

--- a/gazebo_plugins/src/gazebo_ros_imu.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu.cpp
@@ -115,7 +115,7 @@ void GazeboRosIMU::LoadThread()
   else
     this->offset_.Rot() = ignition::math::Quaterniond(this->sdf->Get<ignition::math::Vector3d>("rpyOffset"));
 
-  if (!this->sdf->HasElement("ignition::corrected_offsets"))
+  if (this->sdf->HasElement("ignition::corrected_offsets"))
     this->correctedOffsets_ = this->sdf->Get<bool>("ignition::corrected_offsets");
 
   if (!this->sdf->HasElement("updateRate"))

--- a/gazebo_plugins/src/gazebo_ros_imu.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu.cpp
@@ -20,6 +20,8 @@
  * Date: 1 June 2008
  */
 
+#include <sdf/sdf_config.h>
+
 #include <gazebo_plugins/gazebo_ros_imu.h>
 #include <ignition/math/Rand.hh>
 
@@ -244,7 +246,13 @@ void GazeboRosIMU::UpdateChild()
     rot = pose.Rot();
 
     // apply rpy offsets
+    // rotation calculation needs to be reversed for sdformat versions > 6.2.0,
+    // see https://github.com/osrf/sdformat/pull/500
+#if SDF_MAJOR_VERSION < 6 || (SDF_MAJOR_VERSION == 6 && SDF_MINOR_VERSION <= 2)
+    rot = this->offset_.Rot()*rot;
+#else
     rot = rot*this->offset_.Rot();
+#endif
     rot.Normalize();
 
     // get Rates

--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -19,8 +19,6 @@
 #include <tf/tf.h>
 #include <stdlib.h>
 
-#include <sdf/sdf_config.h>
-
 #include "gazebo_plugins/gazebo_ros_p3d.h"
 #include <ignition/math/Rand.hh>
 
@@ -109,7 +107,7 @@ void GazeboRosP3D::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf)
   else
     this->offset_.Rot() = ignition::math::Quaterniond(_sdf->GetElement("rpyOffset")->Get<ignition::math::Vector3d>());
 
-  if (!_sdf->HasElement("ignition::corrected_offsets"))
+  if (_sdf->HasElement("ignition::corrected_offsets"))
     this->correctedOffsets_ = _sdf->Get<bool>("ignition::corrected_offsets");
 
   if (!_sdf->HasElement("gaussianNoise"))

--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -19,6 +19,8 @@
 #include <tf/tf.h>
 #include <stdlib.h>
 
+#include <sdf/sdf_config.h>
+
 #include "gazebo_plugins/gazebo_ros_p3d.h"
 #include <ignition/math/Rand.hh>
 
@@ -292,6 +294,13 @@ void GazeboRosP3D::UpdateChild()
         // apply xyz offsets and get position and rotation components
         pose.Pos() = pose.Pos() + this->offset_.Pos();
         // apply rpy offsets
+        // rotation calculation needs to be reversed for sdformat versions
+        // > 6.2.0, see https://github.com/osrf/sdformat/pull/500
+#if SDF_MAJOR_VERSION < 6 || (SDF_MAJOR_VERSION == 6 && SDF_MINOR_VERSION <= 2)
+        pose.Rot() = this->offset_.Rot()*pose.Rot();
+#else
+        pose.Rot() = pose.Rot()*this->offset_.Rot();
+#endif
         pose.Rot() = pose.Rot()*this->offset_.Rot();
         pose.Rot().Normalize();
 

--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -292,7 +292,7 @@ void GazeboRosP3D::UpdateChild()
         // apply xyz offsets and get position and rotation components
         pose.Pos() = pose.Pos() + this->offset_.Pos();
         // apply rpy offsets
-        pose.Rot() = this->offset_.Rot()*pose.Rot();
+        pose.Rot() = pose.Rot()*this->offset_.Rot();
         pose.Rot().Normalize();
 
         // compute accelerations (not used)


### PR DESCRIPTION
See [this comment](https://github.com/osrf/sdformat/pull/500#issuecomment-785302490) in sdformat. Ran into an issue with calculation of `rpyOffset` in urdf to sdf conversion, which seems to suggest that the `rpyOffset` should be post multiplied in the gazebo ros plugins.

There isn't really much documentation on the `xyzOffset` and `rpyOffset` params and what frames they are in. All the example I found online have been using 0s for `rpyOffset`. The changes here will however affect user's code if they are manually specifying `rpyOffset`.

Signed-off-by: Ian Chen <ichen@osrfoundation.org>