### PR TITLE
Fix line length in gazebo_ros/test/CMakeLists.txt

### DIFF
--- a/gazebo_ros/test/CMakeLists.txt
+++ b/gazebo_ros/test/CMakeLists.txt
@@ -90,5 +90,7 @@ ament_target_dependencies(mock_gazebo_ros_factory
   "gazebo_msgs"
 )
 add_launch_test(mock_entity_spawner.test.py
-  ARGS "mock_robot_state_publisher:=${CMAKE_CURRENT_BINARY_DIR}/mock_robot_state_publisher" "mock_gazebo_ros_factory:=${CMAKE_CURRENT_BINARY_DIR}/mock_gazebo_ros_factory"
+  ARGS
+    "mock_robot_state_publisher:=${CMAKE_CURRENT_BINARY_DIR}/mock_robot_state_publisher"
+    "mock_gazebo_ros_factory:=${CMAKE_CURRENT_BINARY_DIR}/mock_gazebo_ros_factory"
 )


### PR DESCRIPTION
I noticed a complaint about line length in `gazebo_ros/test/CMakeLists.txt` in CI for #1246. Let's see if CI is happy with this.