### PR TITLE
Remove slash from gazebo_ros scripts Python package name

### DIFF
--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -36,7 +36,7 @@ link_directories(
   ${gazebo_dev_LIBRARY_DIRS}
 )
 
-ament_python_install_package(scripts/)
+ament_python_install_package(scripts)
 
 # gazebo_ros_node
 add_library(gazebo_ros_node SHARED


### PR DESCRIPTION
Precisely what the title says. Quick fix, transparent to users. 