### PR TITLE
Fix add_custom_target called with invalid target name error in gazebo_ros

### DIFF
--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -36,7 +36,7 @@ link_directories(
   ${gazebo_dev_LIBRARY_DIRS}
 )
 
-ament_python_install_package(scripts/)
+ament_python_install_package(scripts)
 
 # gazebo_ros_node
 add_library(gazebo_ros_node SHARED


### PR DESCRIPTION
Signed-off-by: Sarthak Mittal <sarthakmittal2608@gmail.com>