### PR TITLE
Avoid rejecting QoS overrides parameters

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_wheel_slip.cpp
+++ b/gazebo_plugins/src/gazebo_ros_wheel_slip.cpp
@@ -76,11 +76,6 @@ void GazeboRosWheelSlip::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr 
               "New longitudinal slip compliance: %.3e", slip);
             this->SetSlipComplianceLongitudinal(slip);
           }
-        } else {
-          RCLCPP_WARN(
-            impl_->ros_node_->get_logger(),
-            "Unrecognized parameter name[%s]", param_name.c_str());
-          result.successful = false;
         }
       }
       return result;


### PR DESCRIPTION
Some parameters are declared by the node and rejecting them can cause the gazebo plugin to crash.

See general discussion about best practice in https://github.com/ros2/rclcpp/issues/1587
IMO, we don't need to guard against unknown parameters, since they must be explicitly declared in order for us to get a callback in the first place.