### PR TITLE
Detecting outdated last_time on handling update_rate

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -96,8 +96,12 @@ void gazebo::GazeboRosImuSensor::UpdateChild(const gazebo::common::UpdateInfo &/
 #endif
   common::Time current_time = sensor->LastUpdateTime();
 
-  if(update_rate>0 && (current_time-last_time).Double() < 1.0/update_rate) //update rate check
+  if(update_rate>0 && (current_time-last_time).Double() < 1.0/update_rate) { //update rate check
+    // last_time could be outdated when the world is reset
+    if (current_time < last_time)
+      last_time = common::Time(0, 0);
     return;
+  }
 
   if(imu_data_publisher.getNumSubscribers() > 0)
   {


### PR DESCRIPTION
In `gazebo_ros_imu_sensor.cpp`, it checks whether it should work or not by comparing difference of `current_time` and `last_time` with inverse of `update_rate`.
```cpp
void gazebo::GazeboRosImuSensor::UpdateChild(const gazebo::common::UpdateInfo &/*_info*/)
{
  common::Time current_time = sensor->LastUpdateTime();

  if(update_rate>0 && (current_time-last_time).Double() < 1.0/update_rate) { //update rate check
    return;
  }

  // ...work

  last_time = current_time;
}
```

I think this `last_time` value can be outdated by world reset (e.g. 'gazebo/reset_simulation'). So, actually I experienced that plugin had stopped working because `last_time` was too big, but `current_time` couldn't reach the value of `last_time`.

I suggest detecting outdated `last_time`, and resetting it