### PR TITLE
[JointStatePublisher] remove unused tf_prefix_

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_joint_state_publisher.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_joint_state_publisher.h
@@ -72,7 +72,6 @@ private:
     boost::shared_ptr<ros::NodeHandle> rosnode_;
     sensor_msgs::JointState joint_state_;
     ros::Publisher joint_state_publisher_;
-    std::string tf_prefix_;
     std::string robot_namespace_;
     std::vector<std::string> joint_names_;
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_joint_state_publisher.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_joint_state_publisher.h
@@ -30,15 +30,17 @@
 #ifndef JOINT_STATE_PUBLISHER_PLUGIN_HH
 #define JOINT_STATE_PUBLISHER_PLUGIN_HH
 
-#include <boost/bind.hpp>
-#include <gazebo/gazebo.hh>
-#include <gazebo/physics/physics.hh>
+#include <string>
+#include <vector>
+
+#include <boost/shared_ptr.hpp>
+
 #include <gazebo/common/common.hh>
-#include <stdio.h>
+#include <gazebo/physics/physics.hh>
 
 // ROS
-#include <ros/ros.h>
-#include <tf/transform_broadcaster.h>
+#include <ros/node_handle.h>
+#include <ros/publisher.h>
 #include <sensor_msgs/JointState.h>
 
 // Usage in URDF:

--- a/gazebo_plugins/src/gazebo_ros_joint_state_publisher.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_state_publisher.cpp
@@ -95,7 +95,6 @@ void GazeboRosJointStatePublisher::Load ( physics::ModelPtr _parent, sdf::Elemen
 
     ROS_INFO_NAMED("joint_state_publisher", "Starting GazeboRosJointStatePublisher Plugin (ns = %s)!, parent name: %s", this->robot_namespace_.c_str(), parent_->GetName ().c_str() );
 
-    tf_prefix_ = tf::getPrefixParam ( *rosnode_ );
     joint_state_publisher_ = rosnode_->advertise<sensor_msgs::JointState> ( "joint_states",1000 );
 
 #if GAZEBO_MAJOR_VERSION >= 8

--- a/gazebo_plugins/src/gazebo_ros_joint_state_publisher.cpp
+++ b/gazebo_plugins/src/gazebo_ros_joint_state_publisher.cpp
@@ -25,10 +25,21 @@
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  **/
+#include <string>
+#include <vector>
+
 #include <boost/algorithm/string.hpp>
+#include <boost/bind.hpp>
+#include <boost/shared_ptr.hpp>
+
+#include <gazebo/common/common.hh>
+#include <gazebo/physics/physics.hh>
+
+#include <ros/console.h>
+#include <ros/node_handle.h>
+#include <sensor_msgs/JointState.h>
+
 #include <gazebo_plugins/gazebo_ros_joint_state_publisher.h>
-#include <tf/transform_broadcaster.h>
-#include <tf/transform_listener.h>
 
 using namespace gazebo;
 


### PR DESCRIPTION
In the joint state publisher plugin, the member variable tf_prefix_ exists but never used.  I simply remove it.