### PR TITLE
Fix warnings when building against the latest sources.

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # we dont use add_compile_options with pedantic in message packages
   # because the Python C extensions dont comply with it
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wno-inconsistent-missing-override")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
 endif()
 
 if(WIN32)

--- a/gazebo_plugins/src/gazebo_ros_ackermann_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ackermann_drive.cpp
@@ -31,7 +31,7 @@
 #include <std_msgs/msg/float32.hpp>
 #include <sdf/sdf.hh>
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
@@ -73,7 +73,7 @@
 #include <ignition/common/Profiler.hh>
 #endif
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/gazebo_plugins/src/gazebo_ros_hand_of_god.cpp
+++ b/gazebo_plugins/src/gazebo_ros_hand_of_god.cpp
@@ -50,7 +50,7 @@
 #endif
 #include <sdf/sdf.hh>
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>
 #include <tf2_ros/buffer.h>

--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -26,7 +26,7 @@
 #undef NO_ERROR
 #endif
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/gazebo_plugins/src/gazebo_ros_planar_move.cpp
+++ b/gazebo_plugins/src/gazebo_ros_planar_move.cpp
@@ -34,7 +34,7 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_ros/transform_broadcaster.h>
 
 #include <memory>

--- a/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
@@ -61,7 +61,7 @@
 #include <ignition/math/Vector3.hh>
 #include <sdf/sdf.hh>
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/gazebo_plugins/test/test_gazebo_ros_hand_of_god.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_hand_of_god.cpp
@@ -14,7 +14,7 @@
 
 #include <gazebo/test/ServerFixture.hh>
 #include <rclcpp/rclcpp.hpp>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_ros/transform_broadcaster.h>
 
 #include <memory>


### PR DESCRIPTION
Post-Galactic, we have deprecated the tf2_geometry_msgs.h
header file in preference to tf2_geometry_msgs.hpp.  While
we are in here, also remove a command-line option that gcc
does not understand.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Note that we are going to need to branch off `galactic` to merge this, as this is not compatible with Galactic.  Also FYI @karsten1987, this is partially undoing an earlier commit from you.