### PR TITLE
Publish odometry with twist relative to child_frame_id as specification

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -236,8 +236,8 @@ void GazeboRosP3DPrivate::OnUpdate(const gazebo::common::UpdateInfo & info)
   pose_msg.child_frame_id = link_->GetName();
 
   // Get inertial rates
-  ignition::math::Vector3d vpos = link_->WorldLinearVel();
-  ignition::math::Vector3d veul = link_->WorldAngularVel();
+  ignition::math::Vector3d vpos = link_->RelativeLinearVel();
+  ignition::math::Vector3d veul = link_->RelativeAngularVel();
 
   // Get pose/orientation
   auto pose = link_->WorldPose();
@@ -246,15 +246,9 @@ void GazeboRosP3DPrivate::OnUpdate(const gazebo::common::UpdateInfo & info)
   if (reference_link_) {
     // Convert to relative pose, rates
     auto frame_pose = reference_link_->WorldPose();
-    auto frame_vpos = reference_link_->WorldLinearVel();
-    auto frame_veul = reference_link_->WorldAngularVel();
-
     pose.Pos() = pose.Pos() - frame_pose.Pos();
     pose.Pos() = frame_pose.Rot().RotateVectorReverse(pose.Pos());
     pose.Rot() *= frame_pose.Rot().Inverse();
-
-    vpos = frame_pose.Rot().RotateVector(vpos - frame_vpos);
-    veul = frame_pose.Rot().RotateVector(veul - frame_veul);
   }
 
   // Apply constant offsets


### PR DESCRIPTION
fixes https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1026 and https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1136
As specified in the [Odometry msg](http://docs.ros.org/en/noetic/api/nav_msgs/html/msg/Odometry.html)

> The twist in this message should be specified in the coordinate frame given by the child_frame_id

I understand this is a significant change and may not be accepted, we've always had our own implementation to solve this issue in https://github.com/pal-robotics/pal_gazebo_plugins/blob/melodic-devel/src/gazebo_world_odometry.cpp but would like to apply the fix for everyone.

What is the would be an appropriate way of applying this fix in `gazebo_ros_pkgs`? Only enabled with a bool flag in the plugin configuration?