### PR TITLE
[gazebo_ros_factory]: Resolve package:// urls

### DIFF
--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -22,6 +22,7 @@ if(WIN32)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_index_cpp REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(gazebo_dev REQUIRED)
 find_package(gazebo_msgs REQUIRED)
@@ -30,7 +31,7 @@ find_package(rcl REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rmw REQUIRED)
 find_package(std_srvs REQUIRED)
-find_package(tinyxml_vendor REQUIRED)
+find_package(tinyxml2_vendor REQUIRED)
 
 link_directories(
   ${gazebo_dev_LIBRARY_DIRS}
@@ -105,6 +106,7 @@ ament_target_dependencies(gazebo_ros_factory
   "rclcpp"
   "gazebo_dev"
   "gazebo_msgs"
+  "ament_index_cpp"
 )
 target_link_libraries(gazebo_ros_factory
   gazebo_ros_node

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -30,7 +30,7 @@
   <depend>rclpy</depend>
   <depend>rmw</depend>
   <depend>std_srvs</depend>
-  <depend>tinyxml_vendor</depend>
+  <depend>tinyxml2_vendor</depend>
 
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>python3-lxml</exec_depend>


### PR DESCRIPTION
In ROS2 the `SpawnEntity` method let's the SDF library handle the URDF conversion, which is good in my opinion, but introduces a problem. The `sdf::readString` method changes all `package://` urls into `model://` so they can be resolved by Gazebo. This, in turn, makes it very problematic to spawn URDF model with `package://` references without maintaining a separate SDF version of the model.
In contrast, the `gazebo_ros_api_plugin` from ROS1, [replaces the `package://` references](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/231a7219b36b8a6cdd100b59f66a3df2955df787/gazebo_ros/src/gazebo_ros_api_plugin.cpp#L664-L693) with full resolved paths when converting the model.

This PR somewhat restores this behavior by doing the following steps before `sdf::readString`:
1. Convert the XML String into XML Document (using tinyxml2).
2. Iterate through all elements of the document and resolve attributes that start with `package://` into full paths.
3. Convert the XML Document back to String

### Related issues
#1272 
#1236
#1191 
#1112
LeoRover/leo_simulator#5