### PR TITLE
Avoid encoding errors when loading urdf file

### DIFF
--- a/gazebo_ros/scripts/spawn_entity.py
+++ b/gazebo_ros/scripts/spawn_entity.py
@@ -147,7 +147,7 @@ class SpawnEntityNode(Node):
                 return 1
             # load file
             try:
-                f = open(self.args.file, 'r')
+                f = open(self.args.file, 'rb')
                 entity_xml = f.read()
             except IOError as e:
                 self.get_logger().error('Error reading file {}: {}'.format(self.args.file, e))


### PR DESCRIPTION
The recomended way of loading a file that is going to be later passed to `ElementTree.fromstring()` is to do it in binary mode.

It avoids possible encoding errors, for example https://stackoverflow.com/questions/47883390/parse-xml-in-python-with-encoding-other-than-utf-8.