### PR TITLE
[GazeboRosBumper] Do not publish empty contact messages

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_bumper.cpp
+++ b/gazebo_plugins/src/gazebo_ros_bumper.cpp
@@ -135,6 +135,9 @@ void GazeboRosBumper::OnContact()
   if (this->contact_pub_.getNumSubscribers() <= 0)
     return;
 
+  if (this->parentSensor->Contacts().contact_size() <= 0)
+    return;
+
   msgs::Contacts contacts;
   contacts = this->parentSensor->Contacts();
   /// \TODO: need a time for each Contact in i-loop, they may differ


### PR DESCRIPTION
Rationale:
- It's useless, just consumes resources
- As contact sensor runs at gazebo real_time_update_rate, that can be very fast (typically 1000 Hz), I found that often gazebo messages don't make their way as ROS messages, I suppose because [callback](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/05168e73c0599f2f286a66ccd88a3fb1ac8737ab/gazebo_plugins/src/gazebo_ros_bumper.cpp#L133) cannot run fast enough. With this simple change, it does, and I don't suffer missed collision anymore.