### PR TITLE
Add covariance matrix for published twist message in the diff_drive

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_diff_drive.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_diff_drive.h
@@ -142,6 +142,10 @@ namespace gazebo {
       double update_period_;
       common::Time last_update_time_;
 
+      double covariance_x_;
+      double covariance_y_;
+      double covariance_yaw_;
+
       OdomSource odom_source_;
       geometry_msgs::Pose2D pose_encoder_;
       common::Time last_odom_update_;

--- a/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
@@ -97,6 +97,9 @@ void GazeboRosDiffDrive::Load ( physics::ModelPtr _parent, sdf::ElementPtr _sdf 
     gazebo_ros_->getParameter<double> ( wheel_accel, "wheelAcceleration", 0.0 );
     gazebo_ros_->getParameter<double> ( wheel_torque, "wheelTorque", 5.0 );
     gazebo_ros_->getParameter<double> ( update_rate_, "updateRate", 100.0 );
+    gazebo_ros_->getParameter<double> ( covariance_x_, "covariance_x", 0.00001 );
+    gazebo_ros_->getParameter<double> ( covariance_y_, "covariance_y", 0.00001 );
+    gazebo_ros_->getParameter<double> ( covariance_yaw_, "covariance_yaw", 0.001 );
     std::map<std::string, OdomSource> odomOptions;
     odomOptions["encoder"] = ENCODER;
     odomOptions["world"] = WORLD;
@@ -449,12 +452,19 @@ void GazeboRosDiffDrive::publishOdometry ( double step_time )
 
 
     // set covariance
-    odom_.pose.covariance[0] = 0.00001;
-    odom_.pose.covariance[7] = 0.00001;
+    odom_.pose.covariance[0] = covariance_x_;
+    odom_.pose.covariance[7] = covariance_y_;
     odom_.pose.covariance[14] = 1000000000000.0;
     odom_.pose.covariance[21] = 1000000000000.0;
     odom_.pose.covariance[28] = 1000000000000.0;
-    odom_.pose.covariance[35] = 0.001;
+    odom_.pose.covariance[35] = covariance_yaw_;
+
+    odom_.twist.covariance[0] = covariance_x_;
+    odom_.twist.covariance[7] = covariance_y_;
+    odom_.twist.covariance[14] = 1000000000000.0;
+    odom_.twist.covariance[21] = 1000000000000.0;
+    odom_.twist.covariance[28] = 1000000000000.0;
+    odom_.twist.covariance[35] = covariance_yaw_;
 
 
     // set header


### PR DESCRIPTION
Add covariance matrix for published twist message in the diff_drive plugin, as packages such as robot_localization require an associated non-zero covariance matrix. Make pose and twist covariance matrices configurable.
This PR repeats similar [commit](https://github.com/ros-simulation/gazebo_ros_pkgs/commit/f05d8aafd093619ba38ac263476406e29e1b72db) to skid_steer plugin a while ago.
The only difference is default values, which are kept untouched for consistency.