### PR TITLE
gazebo_ros[2]: Add missing exec dependencies

### DIFF
--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -32,7 +32,12 @@
   <depend>std_srvs</depend>
   <depend>tinyxml_vendor</depend>
 
+  <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>launch_ros</exec_depend>
+  <exec_depend>python3-catkin-pkg</exec_depend>
+  <exec_depend>ros2pkg</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
 
   <build_export_depend>geometry_msgs</build_export_depend>
   <build_export_depend>sensor_msgs</build_export_depend>


### PR DESCRIPTION
The libraries imported by the `gazebo_ros` [scripts](https://github.com/ros-simulation/gazebo_ros_pkgs/tree/foxy/gazebo_ros/scripts) are not declared as dependencies. I noticed this issue when I got the following error while testing a package depending on it:
```bash
...
File "/opt/ros/foxy/lib/python3.8/site-packages/scripts/gazebo_ros_paths.py", line 33, in <module>
  from ros2pkg.api import get_package_names
ModuleNotFoundError: No module named 'ros2pkg'
```
I added the `ros2pkg` and all the other ROS packages imported in the scripts as dependencies.

I was not sure which distro I should target. I'm pushing to the oldest distro with support, which is the one I'm using.