### PR TITLE
Add method to get ROS node from GazeboRosCameraPlugin

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera.hpp
@@ -18,6 +18,7 @@
 #include <gazebo/plugins/CameraPlugin.hh>
 #include <gazebo/plugins/DepthCameraPlugin.hh>
 #include <gazebo_plugins/multi_camera_plugin.hpp>
+#include <gazebo_ros/node.hpp>
 #include <std_msgs/msg/empty.hpp>
 
 #include <memory>
@@ -171,6 +172,10 @@ protected:
 
   // Get number of cameras
   uint64_t GetNumCameras() const;
+
+  /// Get the ROS node associated with this plugin
+  /// The returned pointer is null if the plugin has not been loaded.
+  gazebo_ros::Node::SharedPtr GetRosNode() const;
 
 private:
   /// Private data pointer

--- a/gazebo_plugins/src/gazebo_ros_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera.cpp
@@ -852,6 +852,11 @@ uint64_t GazeboRosCamera::GetNumCameras() const
   return impl_->num_cameras_;
 }
 
+gazebo_ros::Node::SharedPtr GazeboRosCamera::GetRosNode() const
+{
+  return impl_->ros_node_;
+}
+
 extern "C" GZ_PLUGIN_VISIBLE gazebo::SensorPlugin * RegisterPlugin();
 gazebo::SensorPlugin * RegisterPlugin()
 {


### PR DESCRIPTION
This helps avoid an issue with duplicate node names if this class is subclassed and wants access to a ROS node.