### PR TITLE
Default slip values fix for wheel slip plugin

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_wheel_slip.cpp
+++ b/gazebo_plugins/src/gazebo_ros_wheel_slip.cpp
@@ -86,6 +86,7 @@ void GazeboRosWheelSlip::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr 
             this->SetSlipComplianceLateral(slip);
           } else {
             result.successful = false;
+            result.reason = "Slip compliance values cannot be negative";
           }
         } else if (param_name == "slip_compliance_unitless_longitudinal") {
           double slip = parameter.as_double();
@@ -96,6 +97,7 @@ void GazeboRosWheelSlip::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr 
             this->SetSlipComplianceLongitudinal(slip);
           } else {
             result.successful = false;
+            result.reason = "Slip compliance values cannot be negative";
           }
         }
       }

--- a/gazebo_plugins/src/gazebo_ros_wheel_slip.cpp
+++ b/gazebo_plugins/src/gazebo_ros_wheel_slip.cpp
@@ -50,6 +50,20 @@ void GazeboRosWheelSlip::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr 
   // Initialize the WheelSlipPlugin first so its values are preferred unless the ros
   // parameters are overridden by a launch file.
   WheelSlipPlugin::Load(_model, _sdf);
+  double slip_lateral_default = -1.0;
+  double slip_longitudinal_default = -1.0;
+
+  std::cout << "Plugin name: " << _sdf->Get<std::string>("name") << std::endl;
+
+  if (_sdf->HasElement("wheel")) {
+    auto wheel_element = _sdf->GetElement("wheel");
+    while (wheel_element) {
+      // auto wheel_name = wheel_element->Get<std::string>("link_name");
+      slip_lateral_default = wheel_element->Get<double>("slip_compliance_lateral");
+      slip_longitudinal_default = wheel_element->Get<double>("slip_compliance_longitudinal");
+      wheel_element = wheel_element->GetNextElement("wheel");
+    }
+  }
 
   // Initialize ROS node
   impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
@@ -87,8 +101,10 @@ void GazeboRosWheelSlip::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr 
   // Declare parameters after adding callback so that callback will trigger immediately.
   // Set negative values by default, which are ignored by the callback.
   // This approach allows values specified in a launch file to override the SDF/URDF values.
-  impl_->ros_node_->declare_parameter("slip_compliance_unitless_lateral", -1.);
-  impl_->ros_node_->declare_parameter("slip_compliance_unitless_longitudinal", -1.);
+  impl_->ros_node_->declare_parameter("slip_compliance_unitless_lateral", slip_lateral_default);
+  impl_->ros_node_->declare_parameter(
+    "slip_compliance_unitless_longitudinal",
+    slip_longitudinal_default);
 }
 
 GZ_REGISTER_MODEL_PLUGIN(GazeboRosWheelSlip)

--- a/gazebo_plugins/src/gazebo_ros_wheel_slip.cpp
+++ b/gazebo_plugins/src/gazebo_ros_wheel_slip.cpp
@@ -50,8 +50,8 @@ void GazeboRosWheelSlip::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr 
   // Initialize the WheelSlipPlugin first so its values are preferred unless the ros
   // parameters are overridden by a launch file.
   WheelSlipPlugin::Load(_model, _sdf);
-  double slip_lateral_default = -1.0;
-  double slip_longitudinal_default = -1.0;
+  double slip_lateral_default = 0.0;
+  double slip_longitudinal_default = 0.0;
 
   if (_sdf->HasElement("wheel")) {
     auto wheel_element = _sdf->GetElement("wheel");
@@ -84,6 +84,8 @@ void GazeboRosWheelSlip::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr 
               impl_->ros_node_->get_logger(),
               "New lateral slip compliance: %.3e", slip);
             this->SetSlipComplianceLateral(slip);
+          } else {
+            result.successful = false;
           }
         } else if (param_name == "slip_compliance_unitless_longitudinal") {
           double slip = parameter.as_double();
@@ -92,6 +94,8 @@ void GazeboRosWheelSlip::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr 
               impl_->ros_node_->get_logger(),
               "New longitudinal slip compliance: %.3e", slip);
             this->SetSlipComplianceLongitudinal(slip);
+          } else {
+            result.successful = false;
           }
         }
       }

--- a/gazebo_plugins/src/gazebo_ros_wheel_slip.cpp
+++ b/gazebo_plugins/src/gazebo_ros_wheel_slip.cpp
@@ -56,8 +56,14 @@ void GazeboRosWheelSlip::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr 
   if (_sdf->HasElement("wheel")) {
     auto wheel_element = _sdf->GetElement("wheel");
     while (wheel_element) {
-      slip_lateral_default = wheel_element->Get<double>("slip_compliance_lateral");
-      slip_longitudinal_default = wheel_element->Get<double>("slip_compliance_longitudinal");
+      double slip_lateral = wheel_element->Get<double>("slip_compliance_lateral");
+      if (slip_lateral >= 0.) {
+        slip_lateral_default = slip_lateral;
+      }
+      double slip_longitudinal = wheel_element->Get<double>("slip_compliance_longitudinal");
+      if (slip_longitudinal >= 0.) {
+        slip_longitudinal_default = slip_longitudinal;
+      }
       wheel_element = wheel_element->GetNextElement("wheel");
     }
   }

--- a/gazebo_plugins/src/gazebo_ros_wheel_slip.cpp
+++ b/gazebo_plugins/src/gazebo_ros_wheel_slip.cpp
@@ -53,12 +53,9 @@ void GazeboRosWheelSlip::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr 
   double slip_lateral_default = -1.0;
   double slip_longitudinal_default = -1.0;
 
-  std::cout << "Plugin name: " << _sdf->Get<std::string>("name") << std::endl;
-
   if (_sdf->HasElement("wheel")) {
     auto wheel_element = _sdf->GetElement("wheel");
     while (wheel_element) {
-      // auto wheel_name = wheel_element->Get<std::string>("link_name");
       slip_lateral_default = wheel_element->Get<double>("slip_compliance_lateral");
       slip_longitudinal_default = wheel_element->Get<double>("slip_compliance_longitudinal");
       wheel_element = wheel_element->GetNextElement("wheel");


### PR DESCRIPTION
This PR makes sure that the default values for ``slip_compliance_unitless_lateral`` and ``slip_compliance_unitless_longitudinal`` in ``GazeboRosWheelSlip`` plugin are taken from the supplied sdf file, and not simply initialized to  ``-1``  always.

Thus, one can query the parameters using ``ros2 param get`` and restore them later if needed


* If the plugin has more than one wheel, how should the slip parameters be handled ? Currently the each plugin instance has one pair of lateral, longitudinal slip values and it is assumed that all wheels in it would have have the same values. For e.g. 
```
<plugin name="wheel_slip_rear" filename="libgazebo_ros_wheel_slip.so">
        <ros>
          <namespace>trisphere_cycle_slip1</namespace>
       </ros>

        <wheel link_name="wheel_rear_left">
          <slip_compliance_lateral>1</slip_compliance_lateral>
          <slip_compliance_longitudinal>1</slip_compliance_longitudinal>
          <wheel_normal_force>32</wheel_normal_force>
        </wheel>

        <wheel link_name="wheel_rear_right">
          <slip_compliance_lateral>1</slip_compliance_lateral>
          <slip_compliance_longitudinal>1</slip_compliance_longitudinal>
          <wheel_normal_force>32</wheel_normal_force>
        </wheel>
      </plugin>
```

This will be handled in a separate PR to upstream ``WheelSlipPlugin``