### PR TITLE
gazebo_ros_camera: set LOD bias parameter via xml

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera.cpp
@@ -396,7 +396,7 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
     // Allow the user to override the level-of-detail (LOD) bias factor for
     // the camera.
     if (_sdf->HasElement("lod_bias")) {
-      auto lod_bias = _sdf->Get<bool>("lod_bias", 1.0).first;
+      auto lod_bias = _sdf->Get<double>("lod_bias", 1.0).first;
       auto ogre_camera = impl_->camera_[i]->OgreCamera();
       if (ogre_camera) {
         ogre_camera->setLodBias(lod_bias);

--- a/gazebo_plugins/src/gazebo_ros_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera.cpp
@@ -384,6 +384,22 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
         focal_length, _sensor->Name().c_str(), width[i], impl_->hfov_[i], computed_focal_length);
     }
 
+    // Allow the user to override the level-of-detail (LOD) bias factor for
+    // the camera.
+    if (_sdf->HasElement("lod_bias")) {
+      auto lod_bias = _sdf->Get<bool>("lod_bias", 1.0).first;
+      auto ogre_camera = impl_->camera_[i]->OgreCamera();
+      if (ogre_camera) {
+        ogre_camera->setLodBias(lod_bias);
+      } else {
+        RCLCPP_WARN(
+          impl_->ros_node_->get_logger(),
+          "Unable to get an Ogre::Camera pointer for camera [%s]"
+          " to set <lod_bias> parameter.",
+          _sensor->Name().c_str());
+      }
+    }
+
     // CameraInfo
     sensor_msgs::msg::CameraInfo camera_info_msg;
     camera_info_msg.header.frame_id = impl_->frame_name_;

--- a/gazebo_plugins/src/gazebo_ros_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera.cpp
@@ -410,7 +410,7 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
       // Set lod_bias on each env camera if this is a wide-angle camera.
       if (impl_->is_wide_angle_camera_type_) {
         auto wide_angle_camera =
-            boost::dynamic_pointer_cast<gazebo::rendering::WideAngleCamera>(impl_->camera_[i]);
+          boost::dynamic_pointer_cast<gazebo::rendering::WideAngleCamera>(impl_->camera_[i]);
         if (wide_angle_camera) {
           auto env_cameras = wide_angle_camera->OgreEnvCameras();
           for (auto & env_camera : env_cameras) {


### PR DESCRIPTION
Level of Detail (LOD) is a feature of OGRE that can improve performance when rendering large scenes. Parameters can be set for an entire scene using gazebo's [HeightmapLODPlugin](https://github.com/osrf/gazebo/blob/gazebo11/plugins/HeightmapLODPlugin.cc) for example. In some cases, it may be useful for the LOD behavior to vary for different cameras  in a scene. For example, you may wish to adjust LOD to reduce the computational demands of the user camera in `gzclient`, while preferring greater detail in a triggered camera sensor. The LOD bias parameter allows tuning individual cameras in this way. This pull request adds a `<lod_bias>` parameter to `gazebo_ros_camera` that will be passed to any attached cameras. Special logic for the `WideAngleCamera` was added to ensure that this parameter is applied to all its env cameras.

cc @mogumbo @ kjeppesen1 @williamlewww