### PR TITLE
Use ros time instead of gazebo time for plugin timestamps so use_sim_time false works better

### DIFF
--- a/gazebo_ros/test/ros_network/gazebo_network_api.yaml
+++ b/gazebo_ros/test/ros_network/gazebo_network_api.yaml
@@ -45,6 +45,11 @@ topics:
     num_publishers: 1
     num_subscribers: -1
 
+  - topic: /gazebo/performance_metrics
+    type: gazebo_msgs/PerformanceMetrics
+    num_publishers: 1
+    num_subscribers: -1
+
 ##########################################################
 # Published services
 services:

--- a/gazebo_ros/test/ros_network/ros_api_checker
+++ b/gazebo_ros/test/ros_network/ros_api_checker
@@ -25,7 +25,7 @@ class Tester(unittest.TestCase):
         topics_actual = set(out.split('\n')) - set([''])
         topics_expected = set([x['topic'] for x in topics])
         topics_extra = topics_actual - topics_expected
-        self.assertEqual(topics_extra, set([]))
+        self.assertEqual(topics_extra, set([]), "\nactual topics: {}\nexpected topics: {}".format(topics_actual, topics_expected))
 
     def _test_extra_services(self, services):
         cmd = ['rosservice', 'list']

--- a/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
+++ b/gazebo_ros_control/src/gazebo_ros_control_plugin.cpp
@@ -211,12 +211,20 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
 void GazeboRosControlPlugin::Update()
 {
   // Get the simulation time and period
+  // TODO(lucasw) not sure about all the consequences of this- controllers probably update
+  // differently, but that's okay, more like real operation- may get out of steps time-wise
+  // with slower than 1.0 real time factor but that's going to be screwy anyhow with use_sim_time false
+  // One question is whether ros::Time::now() returns a more delayed timestamp than SimTime()
+  // in the case where use_sim_time is true- instrument this to find out
+#if 0
 #if GAZEBO_MAJOR_VERSION >= 8
   gazebo::common::Time gz_time_now = parent_model_->GetWorld()->SimTime();
 #else
   gazebo::common::Time gz_time_now = parent_model_->GetWorld()->GetSimTime();
 #endif
-  ros::Time sim_time_ros(gz_time_now.sec, gz_time_now.nsec);
+  ros::Time sim_time_ros = ros::Time(gz_time_now.sec, gz_time_now.nsec);
+#endif
+  ros::Time sim_time_ros = ros::Time::now();
   ros::Duration sim_period = sim_time_ros - last_update_sim_time_ros_;
 
   robot_hw_sim_->eStopActive(e_stop_active_);


### PR DESCRIPTION
Make plugins that respect the update time sent from this update use ros::Time::now() which in turn will respect use_sim_time, mainly I wanted JointStateController joint_state_publisher output to be ros time.  Some gazebo plugins like diff drive controller already use ros::Time::now(), not sure if they don't have access to the timestamp from this update?  Maybe are running in separate thread?

Possibly there is degraded performance when use_sim_time is true (`ros::Time::now()` is maybe delayed from gazebo SimTime?), need to look into that, if it turns out there is then need more logic to check on whether the gazebo SimTime or ros::Time::now should be used.

A fun experiment could be to make gazebo `SimTime()` return ros::Time::now() converted to gazebo format, if that works then see what happens after a pause and unpause.   As it is gazebo is doing it's own thing on it's own clock (and at a deeper layer that may be true of the physics engine), this change and the current behavior of other plugins (like that diff drive controller) are just using ros time around the fringes.

There's related discussion #1234 in #889 and #1286 (some of those are ros2 but the principles are the same)- maybe ros2 got to a more internally consistent place but in noetic use_sim_time false results in a broken tf system (a mix of joint states out of gazebo with sim time stamps and ros time stamps), this PR fixes/mitigates it at least for some joint states.  Maybe someone else can find this useful regardless of merge-ability.