### PR TITLE
Fix unit tests: need to expect performance_metrics topic, adjust expected range minimum

### DIFF
--- a/gazebo_plugins/scripts/test_range.py
+++ b/gazebo_plugins/scripts/test_range.py
@@ -12,7 +12,12 @@ class TestRangePlugin(unittest.TestCase):
 
   def test_inside_range(self):
     msg = rospy.wait_for_message('/sonar', Range)
-    self.assertTrue(msg.range < 0.25 and msg.range > 0.22, 'actual value: {0}'.format(msg.range))
+    # Nominal value is 0.225
+    # TODO(lucasw) could have this average over 10 samples or so
+    min_range = rospy.get_param("~min_range", 0.20)
+    max_range = rospy.get_param("~max_range", 0.25)
+    self.assertGreater(msg.range, min_range, 'range too small: {} < {}'.format(msg.range, min_range))
+    self.assertLess(msg.range, max_range, 'range too big: {} > {}'.format(msg.range, max_range))
 
 if __name__ == '__main__':
   import rostest

--- a/gazebo_plugins/test/test_worlds/gazebo_ros_range.world
+++ b/gazebo_plugins/test/test_worlds/gazebo_ros_range.world
@@ -104,7 +104,9 @@
             </range>
           </ray>
           <plugin filename="libgazebo_ros_range.so" name="gazebo_ros_range">
-            <gaussianNoise>0.005</gaussianNoise>
+            <!-- The unit test depends on the range value being within bounds,
+                 so any noise means the test might get unlucky and fail-->
+            <gaussianNoise>0.001</gaussianNoise>
             <alwaysOn>true</alwaysOn>
             <updateRate>5</updateRate>
             <topicName>sonar</topicName>

--- a/gazebo_ros/test/ros_network/gazebo_network_api.yaml
+++ b/gazebo_ros/test/ros_network/gazebo_network_api.yaml
@@ -45,6 +45,11 @@ topics:
     num_publishers: 1
     num_subscribers: -1
 
+  - topic: /gazebo/performance_metrics
+    type: gazebo_msgs/PerformanceMetrics
+    num_publishers: 1
+    num_subscribers: -1
+
 ##########################################################
 # Published services
 services:

--- a/gazebo_ros/test/ros_network/ros_api_checker
+++ b/gazebo_ros/test/ros_network/ros_api_checker
@@ -25,7 +25,7 @@ class Tester(unittest.TestCase):
         topics_actual = set(out.split('\n')) - set([''])
         topics_expected = set([x['topic'] for x in topics])
         topics_extra = topics_actual - topics_expected
-        self.assertEqual(topics_extra, set([]))
+        self.assertEqual(topics_extra, set([]), "\nactual topics: {}\nexpected topics: {}".format(topics_actual, topics_expected))
 
     def _test_extra_services(self, services):
         cmd = ['rosservice', 'list']


### PR DESCRIPTION
Maybe `ros_network_default.test` has been broken since the performance_metrics topic was introduced in 1ab2668215c2bd582868cd988ce2e579037b188a ?