### PR TITLE
Use pkg="gazebo_ros" instead of pkg="gazebo" in test launch files

### DIFF
--- a/gazebo_plugins/test/bumper_test/test_bumper.launch
+++ b/gazebo_plugins/test/bumper_test/test_bumper.launch
@@ -1,5 +1,5 @@
 <launch>
-  <node name="bumper" pkg="gazebo" type="gazebo" args="$(find gazebo_plugins)/test/bumper_test/gazebo_ros_bumper.world"/>
+  <node name="bumper" pkg="gazebo_ros" type="gazebo" args="$(find gazebo_plugins)/test/bumper_test/gazebo_ros_bumper.world"/>
   <test test-name="test_bumper" pkg="gazebo_plugins" type="test_bumper.py">
     <param name="bumper_topic_name" value="/test_bumper"/>
   </test>

--- a/gazebo_plugins/test/p3d_test/test_3_double_pendulums.launch
+++ b/gazebo_plugins/test/p3d_test/test_3_double_pendulums.launch
@@ -1,5 +1,5 @@
 <launch>
-  <node name="pendulums" pkg="gazebo" type="gazebo" args="$(find gazebo_plugins)/test/p3d_test/worlds/3_double_pendulums.world"/>
+  <node name="pendulums" pkg="gazebo_ros" type="gazebo" args="$(find gazebo_plugins)/test/p3d_test/worlds/3_double_pendulums.world"/>
   <test test-name="test_3_double_pendulums_model_1_link_1_errors" pkg="gazebo_plugins" type="test_link_pose.py">
     <param name="link_pose_topic_name" value="/model_1/link_1/pose"/>
   </test>

--- a/gazebo_plugins/test/p3d_test/test_3_single_pendulums.launch
+++ b/gazebo_plugins/test/p3d_test/test_3_single_pendulums.launch
@@ -1,5 +1,5 @@
 <launch>
-  <node name="pendulums" pkg="gazebo" type="gazebo" args="$(find gazebo_plugins)/test/p3d_test/worlds/3_single_pendulums.world"/>
+  <node name="pendulums" pkg="gazebo_ros" type="gazebo" args="$(find gazebo_plugins)/test/p3d_test/worlds/3_single_pendulums.world"/>
   <test test-name="test_3_single_pendulums_model_1_link_1_errors" pkg="gazebo_plugins" type="test_link_pose.py">
     <param name="link_pose_topic_name" value="/model_1/link_1/pose"/>
   </test>

--- a/gazebo_plugins/test/p3d_test/test_double_pendulum.launch
+++ b/gazebo_plugins/test/p3d_test/test_double_pendulum.launch
@@ -1,5 +1,5 @@
 <launch>
-  <node name="pendulums" pkg="gazebo" type="gazebo" args="$(find gazebo_plugins)/test/p3d_test/worlds/double_pendulum.world"/>
+  <node name="pendulums" pkg="gazebo_ros" type="gazebo" args="$(find gazebo_plugins)/test/p3d_test/worlds/double_pendulum.world"/>
   <test test-name="test_double_pendulum_link_1_errors" pkg="gazebo_plugins" type="test_link_pose.py">
     <param name="link_pose_topic_name" value="/model_1/link_1/pose"/>
   </test>

--- a/gazebo_plugins/test/p3d_test/test_single_pendulum.launch
+++ b/gazebo_plugins/test/p3d_test/test_single_pendulum.launch
@@ -1,5 +1,5 @@
 <launch>
-  <node name="pendulums" pkg="gazebo" type="gazebo" args="$(find gazebo_plugins)/test/p3d_test/worlds/single_pendulum.world"/>
+  <node name="pendulums" pkg="gazebo_ros" type="gazebo" args="$(find gazebo_plugins)/test/p3d_test/worlds/single_pendulum.world"/>
   <test test-name="test_single_pendulum_link_1_errors" pkg="gazebo_plugins" type="test_link_pose.py">
     <param name="link_pose_topic_name" value="/model_1/link_1/pose"/>
   </test>

--- a/gazebo_plugins/test2/contact_tolerance/contact_tolerance.launch
+++ b/gazebo_plugins/test2/contact_tolerance/contact_tolerance.launch
@@ -3,7 +3,7 @@
   <!-- start gazebo with an empty plane -->
   <param name="/use_sim_time" value="true" />
 
-  <node name="gazebo" pkg="gazebo" type="gazebo" args="$(find gazebo_tests)/test/worlds/empty.world" respawn="false" output="screen"/>
+  <node name="gazebo" pkg="gazebo_ros" type="gazebo" args="$(find gazebo_tests)/test/worlds/empty.world" respawn="false" output="screen"/>
 
   <test test-name="gazebo_tests" pkg="gazebo_tests" type="contact_tolerance" args="$(find gazebo_tests)/test/urdf/box.urdf" />
 

--- a/gazebo_plugins/test2/large_models/smaller_large_model.launch
+++ b/gazebo_plugins/test2/large_models/smaller_large_model.launch
@@ -9,17 +9,17 @@
   </group>
 
   <!-- start empty world -->
-  <node name="empty_world_server" pkg="gazebo" type="gazebo" args="-u $(find gazebo_tests)/test/large_models/large_models.world" respawn="false" output="screen"/>
+  <node name="empty_world_server" pkg="gazebo_ros" type="gazebo" args="-u $(find gazebo_tests)/test/large_models/large_models.world" respawn="false" output="screen"/>
 
   <!-- start gui -->
   <group if="$(arg gui)">
-    <node name="gazebo_gui" pkg="gazebo" type="gui" respawn="false" output="screen"/>
+    <node name="gazebo_gui" pkg="gazebo_ros" type="gui" respawn="false" output="screen"/>
   </group>
 
   <!-- send urdf to param server -->
   <param name="robot_description" command="$(find xacro)/xacro.py '$(find gazebo_tests)/test/large_models/smaller_large_model.urdf.xacro'" />
 
   <!-- push robot_description to factory and spawn robot in gazebo -->
-  <node name="spawn_pr2_model" pkg="gazebo" type="spawn_model" args="$(optenv ROBOT_INITIAL_POSE) -urdf -param robot_description -model pr2" respawn="false" output="screen" />
+  <node name="spawn_pr2_model" pkg="gazebo_ros" type="spawn_model" args="$(optenv ROBOT_INITIAL_POSE) -urdf -param robot_description -model pr2" respawn="false" output="screen" />
 
 </launch>

--- a/gazebo_plugins/test2/lcp_tests/balance.launch
+++ b/gazebo_plugins/test2/lcp_tests/balance.launch
@@ -9,11 +9,11 @@
   </group>
 
   <!-- start empty world -->
-  <node name="empty_world_server" pkg="gazebo" type="debug" args="-u $(find gazebo_tests)/test/lcp_tests/balance.world" respawn="false" output="screen"/>
+  <node name="empty_world_server" pkg="gazebo_ros" type="debug" args="-u $(find gazebo_tests)/test/lcp_tests/balance.world" respawn="false" output="screen"/>
 
   <!-- start gui -->
   <group if="$(arg gui)">
-    <node name="gazebo_gui" pkg="gazebo" type="gui" respawn="false" output="screen"/>
+    <node name="gazebo_gui" pkg="gazebo_ros" type="gui" respawn="false" output="screen"/>
   </group>
 
 </launch>

--- a/gazebo_plugins/test2/lcp_tests/stack.launch
+++ b/gazebo_plugins/test2/lcp_tests/stack.launch
@@ -9,11 +9,11 @@
   </group>
 
   <!-- start empty world -->
-  <node name="empty_world_server" pkg="gazebo" type="gazebo" args="-u $(find gazebo_tests)/test/lcp_tests/stack.world" respawn="false" output="screen"/>
+  <node name="empty_world_server" pkg="gazebo_ros" type="gazebo" args="-u $(find gazebo_tests)/test/lcp_tests/stack.world" respawn="false" output="screen"/>
 
   <!-- start gui -->
   <group if="$(arg gui)">
-    <node name="gazebo_gui" pkg="gazebo" type="gui" respawn="false" output="screen"/>
+    <node name="gazebo_gui" pkg="gazebo_ros" type="gui" respawn="false" output="screen"/>
   </group>
 
 </launch>

--- a/gazebo_plugins/test2/lcp_tests/stacks.launch
+++ b/gazebo_plugins/test2/lcp_tests/stacks.launch
@@ -9,11 +9,11 @@
   </group>
 
   <!-- start empty world -->
-  <node name="empty_world_server" pkg="gazebo" type="gazebo" args="-u $(find gazebo_tests)/test/lcp_tests/stacks.world" respawn="false" output="screen"/>
+  <node name="empty_world_server" pkg="gazebo_ros" type="gazebo" args="-u $(find gazebo_tests)/test/lcp_tests/stacks.world" respawn="false" output="screen"/>
 
   <!-- start gui -->
   <group if="$(arg gui)">
-    <node name="gazebo_gui" pkg="gazebo" type="gui" respawn="false" output="screen"/>
+    <node name="gazebo_gui" pkg="gazebo_ros" type="gui" respawn="false" output="screen"/>
   </group>
 
 </launch>

--- a/gazebo_plugins/test2/trimesh_tests/test_trimesh.launch
+++ b/gazebo_plugins/test2/trimesh_tests/test_trimesh.launch
@@ -3,7 +3,7 @@
   <!-- start gazebo with an empty plane -->
   <param name="/use_sim_time" value="true" />
 
-  <node name="gazebo" pkg="gazebo" type="gazebo" args="$(find gazebo_tests)/test/worlds/empty.world" respawn="false" output="screen"/>
+  <node name="gazebo" pkg="gazebo_ros" type="gazebo" args="$(find gazebo_tests)/test/worlds/empty.world" respawn="false" output="screen"/>
 
   <test test-name="gazebo_tests" pkg="gazebo_tests" type="spawn_box" args="$(find gazebo_tests)/test/urdf/cube.urdf" />
 


### PR DESCRIPTION
> Within roslaunch files, pkg="gazebo" needs to be now renamed to pkg="gazebo_ros"

http://gazebosim.org/tutorials?tut=ros_overview#LaunchFiles

I think this has been true for a few versions now which suggests none of these tests have been run recently, so it's possible all of these tests are broken in other ways.

Without this fix the launch files end with:

    ERROR: cannot launch node of type [gazebo/gazebo]: gazebo


I only tried the bumper test

    rostest --reuse-master gazebo_plugins test_bumper.launch

and the bumper topic is never created (probably because some extra xml entries are required) so the test failed.

(This shows some similar stale launch files in `ros_controllers` and `ros_control_pkgs` also, maybe a few more related gazebo & ros_control packages to fix up

    grep -r 'pkg="gazebo"' *
)