### PR TITLE
Fix Windows conflicting macro

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_ackermann_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ackermann_drive.cpp
@@ -31,6 +31,11 @@
 #include <std_msgs/msg/float32.hpp>
 #include <sdf/sdf.hh>
 
+#ifdef NO_ERROR
+// NO_ERROR is a macro defined in Windows that's used as an enum in tf2
+#undef NO_ERROR
+#endif
+
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>

--- a/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_diff_drive.cpp
@@ -73,6 +73,11 @@
 #include <ignition/common/Profiler.hh>
 #endif
 
+#ifdef NO_ERROR
+// NO_ERROR is a macro defined in Windows that's used as an enum in tf2
+#undef NO_ERROR
+#endif
+
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>

--- a/gazebo_plugins/src/gazebo_ros_hand_of_god.cpp
+++ b/gazebo_plugins/src/gazebo_ros_hand_of_god.cpp
@@ -50,6 +50,11 @@
 #endif
 #include <sdf/sdf.hh>
 
+#ifdef NO_ERROR
+// NO_ERROR is a macro defined in Windows that's used as an enum in tf2
+#undef NO_ERROR
+#endif
+
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>

--- a/gazebo_plugins/src/gazebo_ros_planar_move.cpp
+++ b/gazebo_plugins/src/gazebo_ros_planar_move.cpp
@@ -34,6 +34,11 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#ifdef NO_ERROR
+// NO_ERROR is a macro defined in Windows that's used as an enum in tf2
+#undef NO_ERROR
+#endif
+
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_ros/transform_broadcaster.h>
 

--- a/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
@@ -61,6 +61,11 @@
 #include <ignition/math/Vector3.hh>
 #include <sdf/sdf.hh>
 
+#ifdef NO_ERROR
+// NO_ERROR is a macro defined in Windows that's used as an enum in tf2
+#undef NO_ERROR
+#endif
+
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>


### PR DESCRIPTION
This adds on to #885 to `#undef` the `NO_ERROR` macro in other places.