### PR TITLE
PublishSimTime: changed Throttler to use simTime instead of realTime

### DIFF
--- a/gazebo_ros/src/gazebo_ros_init.cpp
+++ b/gazebo_ros/src/gazebo_ros_init.cpp
@@ -270,7 +270,7 @@ GazeboRosInitPrivate::GazeboRosInitPrivate()
 
 void GazeboRosInitPrivate::PublishSimTime(const gazebo::common::UpdateInfo & _info)
 {
-  if (!throttler_.IsReady(_info.realTime)) {
+  if (!throttler_.IsReady(_info.simTime)) {
     return;
   }
 


### PR DESCRIPTION
Changed `Throttler` for the clock publisher in [gazebo_ros_init.cpp](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/3310d0d01cfcd4a2710d834d2abf8bb6a620a888/gazebo_ros/src/gazebo_ros_init.cpp#L271-L292) to use `simTime` instead of `realTime`. This should fix #1324 and should allow ROS applications to continue to cooperate with Gazebo when the simulation is paused and is being stepped. 

If this doesn't break anything, I can open new PRs for the rest of the ros2 distro-specific branches (foxy, galactic, etc) that have the same issue.