### PR TITLE
adding namespaces to the tf_frames for ROS2

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_planar_move.cpp
+++ b/gazebo_plugins/src/gazebo_ros_planar_move.cpp
@@ -145,10 +145,6 @@ void GazeboRosPlanarMove::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr
 
   impl_->multi_robot_namespace_divider.erase(0, 1);
 
-  if (impl_->multi_robot_namespace_divider != "") {
-    impl_->multi_robot_namespace_divider += "/";
-  }
-
   // Odometry
   impl_->odometry_frame_ = impl_->multi_robot_namespace_divider +
     _sdf->Get<std::string>("odometry_frame", "odom").first;

--- a/gazebo_plugins/src/gazebo_ros_ray_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ray_sensor.cpp
@@ -197,9 +197,13 @@ void GazeboRosRaySensorPrivate::SubscribeGazeboLaserScan()
 void GazeboRosRaySensorPrivate::PublishLaserScan(ConstLaserScanStampedPtr & _msg)
 {
   // Convert Laser scan to ROS LaserScan
+  std::string multi_robot_namespace_divider;
+  multi_robot_namespace_divider = ros_node_->get_namespace();
+  multi_robot_namespace_divider.erase(0,1);
+  multi_robot_namespace_divider += "/";
   auto ls = gazebo_ros::Convert<sensor_msgs::msg::LaserScan>(*_msg);
   // Set tf frame
-  ls.header.frame_id = frame_name_;
+  ls.header.frame_id = multi_robot_namespace_divider + frame_name_;
   // Publish output
   boost::get<LaserScanPub>(pub_)->publish(ls);
 }
@@ -207,9 +211,14 @@ void GazeboRosRaySensorPrivate::PublishLaserScan(ConstLaserScanStampedPtr & _msg
 void GazeboRosRaySensorPrivate::PublishPointCloud(ConstLaserScanStampedPtr & _msg)
 {
   // Convert Laser scan to PointCloud
+  std::string multi_robot_namespace_divider;
+  multi_robot_namespace_divider = ros_node_->get_namespace();
+  std::cout<<multi_robot_namespace_divider<<std::endl;
+  multi_robot_namespace_divider.erase(0,1);
+  multi_robot_namespace_divider += "/";
   auto pc = gazebo_ros::Convert<sensor_msgs::msg::PointCloud>(*_msg, min_intensity_);
   // Set tf frame
-  pc.header.frame_id = frame_name_;
+  pc.header.frame_id = multi_robot_namespace_divider + frame_name_;
   // Publish output
   boost::get<PointCloudPub>(pub_)->publish(pc);
 }
@@ -217,9 +226,13 @@ void GazeboRosRaySensorPrivate::PublishPointCloud(ConstLaserScanStampedPtr & _ms
 void GazeboRosRaySensorPrivate::PublishPointCloud2(ConstLaserScanStampedPtr & _msg)
 {
   // Convert Laser scan to PointCloud2
+  std::string multi_robot_namespace_divider;
+  multi_robot_namespace_divider = ros_node_->get_namespace();
+  multi_robot_namespace_divider.erase(0,1);
+  multi_robot_namespace_divider += "/";
   auto pc2 = gazebo_ros::Convert<sensor_msgs::msg::PointCloud2>(*_msg, min_intensity_);
   // Set tf frame
-  pc2.header.frame_id = frame_name_;
+  pc2.header.frame_id = multi_robot_namespace_divider + frame_name_;
   // Publish output
   boost::get<PointCloud2Pub>(pub_)->publish(pc2);
 }
@@ -227,9 +240,15 @@ void GazeboRosRaySensorPrivate::PublishPointCloud2(ConstLaserScanStampedPtr & _m
 void GazeboRosRaySensorPrivate::PublishRange(ConstLaserScanStampedPtr & _msg)
 {
   // Convert Laser scan to range
+  std::string multi_robot_namespace_divider;
+  multi_robot_namespace_divider = ros_node_->get_namespace();
+  multi_robot_namespace_divider.erase(0,1);
+  std::cout<<multi_robot_namespace_divider<<std::endl;
+
+  multi_robot_namespace_divider += "/";
   auto range_msg = gazebo_ros::Convert<sensor_msgs::msg::Range>(*_msg);
   // Set tf frame
-  range_msg.header.frame_id = frame_name_;
+  range_msg.header.frame_id = multi_robot_namespace_divider + frame_name_;
   // Set radiation type from sdf
   range_msg.radiation_type = range_radiation_type_;
   // Publish output

--- a/gazebo_plugins/src/gazebo_ros_ray_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ray_sensor.cpp
@@ -112,11 +112,6 @@ void GazeboRosRaySensor::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPt
   impl_->multi_robot_namespace_divider = impl_->ros_node_->get_namespace();
   impl_->multi_robot_namespace_divider.erase(0, 1);
 
-  // Check if the namespace is empty
-  if (impl_->multi_robot_namespace_divider != "") {
-    impl_->multi_robot_namespace_divider += "/";
-  }
-
   // Get QoS profile for the publisher
   rclcpp::QoS pub_qos = qos.get_publisher_qos("~/out", rclcpp::SensorDataQoS().reliable());
 

--- a/gazebo_plugins/src/gazebo_ros_ray_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ray_sensor.cpp
@@ -111,7 +111,11 @@ void GazeboRosRaySensor::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPt
 
   impl_->multi_robot_namespace_divider = impl_->ros_node_->get_namespace();
   impl_->multi_robot_namespace_divider.erase(0, 1);
-  impl_->multi_robot_namespace_divider += "/";
+
+  // Check if the namespace is empty
+  if (impl_->multi_robot_namespace_divider != "") {
+    impl_->multi_robot_namespace_divider += "/";
+  }
 
   // Get QoS profile for the publisher
   rclcpp::QoS pub_qos = qos.get_publisher_qos("~/out", rclcpp::SensorDataQoS().reliable());

--- a/gazebo_plugins/test/test_gazebo_ros_planar_move.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_planar_move.cpp
@@ -100,7 +100,7 @@ TEST_F(GazeboRosPlanarMoveTest, Publishing)
 
   // Check message
   ASSERT_NE(nullptr, latestMsg);
-  EXPECT_EQ("odom_frame_test", latestMsg->header.frame_id);
+  EXPECT_EQ("test/odom_frame_test", latestMsg->header.frame_id);
   EXPECT_LT(0.0, latestMsg->pose.pose.position.x);
   EXPECT_LT(0.0, latestMsg->pose.pose.orientation.z);
 

--- a/gazebo_plugins/test/test_gazebo_ros_ray_sensor.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_ray_sensor.cpp
@@ -127,7 +127,7 @@ TEST_F(GazeboRosRaySensorTest, CorrectOutput)
   ASSERT_NE(range, nullptr);
 
   // Range message verification
-  EXPECT_EQ(range->header.frame_id, "ray_link");
+  EXPECT_EQ(range->header.frame_id, "ray/ray_link");
   EXPECT_EQ(range->radiation_type, sensor_msgs::msg::Range::INFRARED);
   EXPECT_NEAR(range->field_of_view, 1.0472, ROUNDING_ERROR_TOL);
   EXPECT_NEAR(range->min_range, 0.05, ROUNDING_ERROR_TOL);
@@ -135,7 +135,7 @@ TEST_F(GazeboRosRaySensorTest, CorrectOutput)
   EXPECT_NEAR(range->range, min_range, ROUNDING_ERROR_TOL);
 
   // PointCloud verification
-  EXPECT_EQ(pc->header.frame_id, "ray_link");
+  EXPECT_EQ(pc->header.frame_id, "ray/ray_link");
   ASSERT_EQ(pc->channels.size(), 1u);
   ASSERT_EQ(pc->points.size(), pc->channels[0].values.size());
   auto point = pc->points.begin();
@@ -148,7 +148,7 @@ TEST_F(GazeboRosRaySensorTest, CorrectOutput)
   }
 
   // PointCloud2 verification
-  EXPECT_EQ(pc2->header.frame_id, "ray_link");
+  EXPECT_EQ(pc2->header.frame_id, "ray/ray_link");
   auto pc2_iter_x = sensor_msgs::PointCloud2Iterator<float>(*pc2, "x");
   auto pc2_iter_y = sensor_msgs::PointCloud2Iterator<float>(*pc2, "y");
   auto pc2_iter_z = sensor_msgs::PointCloud2Iterator<float>(*pc2, "z");
@@ -163,7 +163,7 @@ TEST_F(GazeboRosRaySensorTest, CorrectOutput)
   }
 
   // LaserScan verification
-  EXPECT_EQ(ls->header.frame_id, "ray_link");
+  EXPECT_EQ(ls->header.frame_id, "ray/ray_link");
   EXPECT_NEAR(ls->angle_min, -0.5236, ROUNDING_ERROR_TOL);
   EXPECT_NEAR(ls->angle_max, 0.5236, ROUNDING_ERROR_TOL);
   EXPECT_NEAR(ls->range_min, 0.05, ROUNDING_ERROR_TOL);


### PR DESCRIPTION
Currently, the robot_state_publisher comes with an argument called as the `frame_prefix` for adding a prefix to the frames. Also, even if there is a `frame_prefix` added to the robot_state_publisher, the plugins from this package does not broadcast the frames with the prefix. This missing feature, does not allow an ease of developing a multi-robot simulation. 

Assuming that the namespaces and the `frame_prefix` will be defined the same by the users, I added the namespaces to the frames. For example: `odom` will be broadcasted as `my_ns/odom` . 

Do let me know your thoughts ? Maybe there is also someother way to achieve this! 