### PR TITLE
[ROS 2] Allow Setting Publish Rate for /clock

### DIFF
--- a/gazebo_ros/launch/gazebo.launch.py
+++ b/gazebo_ros/launch/gazebo.launch.py
@@ -17,10 +17,33 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import IncludeLaunchDescription
+from launch.actions import OpaqueFunction
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import ThisLaunchFileDir
+
+from ament_index_python.packages import get_package_share_directory
+
+import em
+import os
+
+
+def gzserver_with_params(context, *args, **kwargs):
+    rate = LaunchConfiguration('publish_rate').perform(context)
+    params_yaml_in = os.path.join(get_package_share_directory('gazebo_ros'), 'launch', 'params.yaml.in')
+    interpreter = em.Interpreter(output=open('/tmp/gazebo_params.yaml', 'w'))
+    interpreter.string("@{publish_rate = %f}" % float(rate))
+    interpreter.file(open(params_yaml_in))
+    interpreter.shutdown()
+    return [
+        IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([ThisLaunchFileDir(), '/gzserver.launch.py']),
+        condition=IfCondition(LaunchConfiguration('server')),
+        launch_arguments={
+            'extra_gazebo_args': '--ros-args --params-file /tmp/gazebo_params.yaml'
+        }.items()
+    )]
 
 
 def generate_launch_description():
@@ -32,10 +55,10 @@ def generate_launch_description():
         DeclareLaunchArgument('server', default_value='true',
                               description='Set to "false" not to run gzserver.'),
 
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([ThisLaunchFileDir(), '/gzserver.launch.py']),
-            condition=IfCondition(LaunchConfiguration('server'))
-        ),
+        DeclareLaunchArgument('publish_rate', default_value='10',
+                              description='Rate (in Hz) at which the clock publishes.'),
+
+        OpaqueFunction(function=gzserver_with_params),
 
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource([ThisLaunchFileDir(), '/gzclient.launch.py']),

--- a/gazebo_ros/launch/params.yaml.in
+++ b/gazebo_ros/launch/params.yaml.in
@@ -1,0 +1,3 @@
+/gazebo:
+  ros__parameters:
+    publish_rate: @publish_rate


### PR DESCRIPTION
This generates a params file with the desired clock rate, then passes the file to `gzserver` as the contents of `extra_gazebo_args`.

Signed-off-by: Hunter L. Allen <hunter.allen@ghostrobotics.io>

---

This adds `empy` as a dependency (which I need to add to the `package.xml`).

Other than that, this allows one to pass a publish rate from an external launch file, as requested in #1211, #1247, and #1305.