### PR TITLE
wheel_slip: set lateral slip to zero at low speed

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_wheel_slip.cpp
+++ b/gazebo_plugins/src/gazebo_ros_wheel_slip.cpp
@@ -341,12 +341,14 @@ void GazeboRosWheelSlip::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr 
         auto long_vel = slip.X() + slip.Z();
         auto lat_vel = slip.Y();
         double long_slip;
+        double lat_slip;
         if (fabs(spin_speed) < wheel_spin_tolerance) {
           long_slip = 0;
+          lat_slip = 0;
         } else {
           long_slip = (spin_speed - long_vel) / spin_speed;
+          lat_slip = atan2(lat_vel, long_vel);
         }
-        auto lat_slip = atan2(lat_vel, long_vel);
         slip_msg.name.push_back(name);
         slip_msg.lateral_slip.push_back(lat_slip);
         slip_msg.longitudinal_slip.push_back(long_slip);

--- a/gazebo_plugins/test/test_gazebo_ros_wheelslip.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_wheelslip.cpp
@@ -263,53 +263,76 @@ TEST_F(GazeboRosWheelSlipTest, TestSetParameters)
 
 class GazeboRosWheelSlipPublisherTest : public gazebo::ServerFixture
 {
+public:
+  void test_publishing(
+    std::string world_file,
+    bool at_rest)
+  {
+    // Load test world and start paused
+    this->Load(world_file, true);
+
+    // World
+    auto world = gazebo::physics::get_world();
+    ASSERT_NE(nullptr, world);
+
+    // Create node and executor
+    auto node = std::make_shared<rclcpp::Node>("gazebo_ros_joint_state_publisher_test");
+    ASSERT_NE(nullptr, node);
+
+    rclcpp::executors::SingleThreadedExecutor executor;
+    executor.add_node(node);
+
+    // Create subscriber
+    gazebo_msgs::msg::WheelSlip::SharedPtr latestMsg;
+    auto sub = node->create_subscription<gazebo_msgs::msg::WheelSlip>(
+      "trisphere_cycle_slip/wheel_slip", rclcpp::QoS(1),
+      [&latestMsg](const gazebo_msgs::msg::WheelSlip::SharedPtr msg) {
+        latestMsg = msg;
+      });
+
+    // Spin until we get a message or timeout
+    auto startTime = std::chrono::steady_clock::now();
+    while (latestMsg == nullptr &&
+      (std::chrono::steady_clock::now() - startTime) < std::chrono::seconds(2))
+    {
+      world->Step(1000);
+      executor.spin_once(100ms);
+      gazebo::common::Time::MSleep(100);
+    }
+
+    // Check that we receive the latest joint state
+    ASSERT_NE(nullptr, latestMsg);
+
+    EXPECT_EQ(3u, latestMsg->name.size());
+    EXPECT_EQ(latestMsg->name.size(), latestMsg->lateral_slip.size());
+    EXPECT_EQ(latestMsg->name.size(), latestMsg->longitudinal_slip.size());
+
+    for (unsigned int i = 0; i < latestMsg->name.size(); ++i) {
+      if (at_rest) {
+        EXPECT_DOUBLE_EQ(0.0, latestMsg->lateral_slip[i]);
+        EXPECT_DOUBLE_EQ(0.0, latestMsg->longitudinal_slip[i]);
+      } else {
+        EXPECT_NEAR(0.0, latestMsg->lateral_slip[i], 1e-4);
+        EXPECT_NEAR(0.3, latestMsg->longitudinal_slip[i], 0.05);
+      }
+    }
+  }
 };
 
 TEST_F(GazeboRosWheelSlipPublisherTest, Publishing)
 {
-  // Load test world and start paused
-  this->Load("worlds/gazebo_ros_wheel_slip.world", true);
+  this->test_publishing(
+    "worlds/gazebo_ros_wheel_slip.world",
+    false
+  );
+}
 
-  // World
-  auto world = gazebo::physics::get_world();
-  ASSERT_NE(nullptr, world);
-
-  // Create node and executor
-  auto node = std::make_shared<rclcpp::Node>("gazebo_ros_joint_state_publisher_test");
-  ASSERT_NE(nullptr, node);
-
-  rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(node);
-
-  // Create subscriber
-  gazebo_msgs::msg::WheelSlip::SharedPtr latestMsg;
-  auto sub = node->create_subscription<gazebo_msgs::msg::WheelSlip>(
-    "trisphere_cycle_slip/wheel_slip", rclcpp::QoS(1),
-    [&latestMsg](const gazebo_msgs::msg::WheelSlip::SharedPtr msg) {
-      latestMsg = msg;
-    });
-
-  // Spin until we get a message or timeout
-  auto startTime = std::chrono::steady_clock::now();
-  while (latestMsg == nullptr &&
-    (std::chrono::steady_clock::now() - startTime) < std::chrono::seconds(2))
-  {
-    world->Step(1000);
-    executor.spin_once(100ms);
-    gazebo::common::Time::MSleep(100);
-  }
-
-  // Check that we receive the latest joint state
-  ASSERT_NE(nullptr, latestMsg);
-
-  EXPECT_EQ(3u, latestMsg->name.size());
-  EXPECT_EQ(latestMsg->name.size(), latestMsg->lateral_slip.size());
-  EXPECT_EQ(latestMsg->name.size(), latestMsg->longitudinal_slip.size());
-
-  for (unsigned int i = 0; i < latestMsg->name.size(); ++i) {
-    EXPECT_NEAR(0.0, latestMsg->lateral_slip[i], 1e-4);
-    EXPECT_NEAR(0.3, latestMsg->longitudinal_slip[i], 0.05);
-  }
+TEST_F(GazeboRosWheelSlipPublisherTest, PublishingAtRest)
+{
+  this->test_publishing(
+    "worlds/gazebo_ros_wheel_slip_at_rest.world",
+    true
+  );
 }
 
 int main(int argc, char ** argv)

--- a/gazebo_plugins/test/worlds/gazebo_ros_wheel_slip_at_rest.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_wheel_slip_at_rest.world
@@ -1,0 +1,46 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="default">
+    <gravity>0 0 -9.8</gravity>
+
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <include>
+      <uri>model://trisphere_cycle</uri>
+      <name>trisphere_cycle_slip</name>
+      <pose>0 2 0  0 0 0</pose>
+      <plugin name="wheel_slip" filename="libgazebo_ros_wheel_slip.so">
+        <ros>
+          <namespace>trisphere_cycle_slip</namespace>
+        </ros>
+        <wheel link_name="wheel_front">
+          <slip_compliance_lateral>1</slip_compliance_lateral>
+          <slip_compliance_longitudinal>1</slip_compliance_longitudinal>
+          <wheel_normal_force>32</wheel_normal_force>
+        </wheel>
+        <wheel link_name="wheel_rear_left">
+          <slip_compliance_lateral>1</slip_compliance_lateral>
+          <slip_compliance_longitudinal>1</slip_compliance_longitudinal>
+          <wheel_normal_force>32</wheel_normal_force>
+        </wheel>
+        <wheel link_name="wheel_rear_right">
+          <slip_compliance_lateral>1</slip_compliance_lateral>
+          <slip_compliance_longitudinal>1</slip_compliance_longitudinal>
+          <wheel_normal_force>32</wheel_normal_force>
+        </wheel>
+      </plugin>
+    </include>
+
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose>1.5 -4 2.5  0 0.5 1.6</pose>
+        <view_controller>orbit</view_controller>
+      </camera>
+    </gui>
+  </world>
+</sdf>


### PR DESCRIPTION
The `gazebo_ros_wheel_slip` plugin publishes instantaneous wheel slip as of #1331. It currently truncates the longitudinal slip to `0` when the `spin_speed` is sufficiently small to avoid division by `0`. Lateral slip does not have a problem with dividing by `0` because it uses the `atan2` function, but it still generates significant slip values even when the vehicle is at rest. This updates the logic for the slip publisher to also truncate the lateral slip to `0` when the `spin_speed` is small. A test is added using a world file with a model at rest.