### PR TITLE
use DurabilityPolicy.TRANSIENT_LOCAL rather than deprecated name

### DIFF
--- a/gazebo_ros/scripts/spawn_entity.py
+++ b/gazebo_ros/scripts/spawn_entity.py
@@ -31,7 +31,7 @@ from gazebo_msgs.srv import SpawnEntity
 from geometry_msgs.msg import Pose
 import rclpy
 from rclpy.node import Node
-from rclpy.qos import QoSDurabilityPolicy
+from rclpy.qos import DurabilityPolicy
 from rclpy.qos import QoSProfile
 from std_msgs.msg import String
 from std_srvs.srv import Empty
@@ -167,7 +167,7 @@ class SpawnEntityNode(Node):
 
             latched_qos = QoSProfile(
                 depth=1,
-                durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL)
+                durability=DurabilityPolicy.TRANSIENT_LOCAL)
             self.subscription = self.create_subscription(
                 String, self.args.topic, entity_xml_cb, latched_qos)
 


### PR DESCRIPTION
Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>


Fixes a deprecation warning 
```
[spawn_entity.py-5] /opt/ros/galactic/lib/python3.8/site-packages/rclpy/qos.py:307: UserWarning: DurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL is deprecated. Use DurabilityPolicy.TRANSIENT_LOCAL instead.
```

See https://github.com/ros2/rclpy/pull/634

This PR should also be backported to the Galactic branch.