### PR TITLE
Fix spawn_entity_demo: use executable

### DIFF
--- a/gazebo_ros/launch/spawn_entity_demo.launch.py
+++ b/gazebo_ros/launch/spawn_entity_demo.launch.py
@@ -31,7 +31,7 @@ def generate_launch_description():
              )
 
     # GAZEBO_MODEL_PATH has to be correctly set for Gazebo to be able to find the model
-    spawn_entity = Node(package='gazebo_ros', node_executable='spawn_entity.py',
+    spawn_entity = Node(package='gazebo_ros', executable='spawn_entity.py',
                         arguments=['-entity', 'demo', '-database', 'double_pendulum_with_base'],
                         output='screen')
 


### PR DESCRIPTION
No big deal, but when I tried using the `spawn_entity_demo.launch.py` on my galactic system, it failed on me.

Since Foxy `node_executable` was marked [deprecated](https://github.com/ros2/launch_ros/blob/d2c726b5e8ce1aa99a9ae6c4881d2fa691ce0a64/launch_ros/launch_ros/actions/node.py#L140) and in Galactic it got removed. I assume the `ros2` branch should reflect that. This should also be applied to the `galactic` branch.