### PR TITLE
gazebo_ros_ft_sensor_demo.world: use world solver

### DIFF
--- a/gazebo_plugins/worlds/gazebo_ros_ft_sensor_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_ft_sensor_demo.world
@@ -12,6 +12,7 @@
 
     <physics type="ode">
       <ode>
+        <ode_quiet>1</ode_quiet>
         <solver>
           <type>world</type>
         </solver>

--- a/gazebo_plugins/worlds/gazebo_ros_ft_sensor_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_ft_sensor_demo.world
@@ -10,6 +10,14 @@
 <sdf version="1.6">
   <world name="default">
 
+    <physics type="ode">
+      <ode>
+        <solver>
+          <type>world</type>
+        </solver>
+      </ode>
+    </physics>
+
     <include>
       <uri>model://ground_plane</uri>
     </include>


### PR DESCRIPTION
The default solver settings with the quick-step solver have poor convergence behavior. The world-step solver has less noise.

## Default parameters: plot of joint angle on far left, measured force in the middle

https://user-images.githubusercontent.com/3650755/152436314-b782dea5-53c0-41b3-966c-c38a23dcf1b1.mp4

## World-step solver: plot of joint angle on far left, measured force in the middle

https://user-images.githubusercontent.com/3650755/152436304-1568250a-8983-47ec-b16e-c087e4540a7f.mp4



