### PR TITLE
gazebo_ros: fix cpplint and flake8 errors

### DIFF
--- a/gazebo_ros/include/gazebo_ros/conversions/builtin_interfaces.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/builtin_interfaces.hpp
@@ -16,9 +16,9 @@
 #define GAZEBO_ROS__CONVERSIONS__BUILTIN_INTERFACES_HPP_
 
 #include <gazebo/msgs/time.pb.h>
+#include <gazebo/common/Time.hh>
 
 #include <builtin_interfaces/msg/time.hpp>
-#include <gazebo/common/Time.hh>
 
 #include "gazebo_ros/conversions/generic.hpp"
 

--- a/gazebo_ros/include/gazebo_ros/conversions/gazebo_msgs.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/gazebo_msgs.hpp
@@ -16,10 +16,11 @@
 #define GAZEBO_ROS__CONVERSIONS__GAZEBO_MSGS_HPP_
 
 #include <gazebo/msgs/contacts.pb.h>
-#include <gazebo_msgs/msg/contact_state.hpp>
-#include <gazebo_msgs/msg/contacts_state.hpp>
 
 #include <sstream>
+
+#include <gazebo_msgs/msg/contact_state.hpp>
+#include <gazebo_msgs/msg/contacts_state.hpp>
 
 #include "gazebo_ros/conversions/builtin_interfaces.hpp"
 #include "gazebo_ros/conversions/generic.hpp"

--- a/gazebo_ros/include/gazebo_ros/conversions/geometry_msgs.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/geometry_msgs.hpp
@@ -15,15 +15,16 @@
 #ifndef GAZEBO_ROS__CONVERSIONS__GEOMETRY_MSGS_HPP_
 #define GAZEBO_ROS__CONVERSIONS__GEOMETRY_MSGS_HPP_
 
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Quaternion.hh>
+#include <ignition/math/Vector3.hh>
+
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/point32.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/quaternion.hpp>
 #include <geometry_msgs/msg/transform.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
-#include <ignition/math/Pose3.hh>
-#include <ignition/math/Quaternion.hh>
-#include <ignition/math/Vector3.hh>
 
 #include "gazebo_ros/conversions/generic.hpp"
 

--- a/gazebo_ros/include/gazebo_ros/conversions/sensor_msgs.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/sensor_msgs.hpp
@@ -18,6 +18,10 @@
 #include <math.h>
 
 #include <gazebo/msgs/laserscan_stamped.pb.h>
+
+#include <algorithm>
+#include <limits>
+
 #include <geometry_msgs/msg/point32.hpp>
 #include <rclcpp/logging.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -25,9 +29,6 @@
 #include <sensor_msgs/msg/laser_scan.hpp>
 #include <sensor_msgs/msg/range.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
-
-#include <algorithm>
-#include <limits>
 
 #include "gazebo_ros/conversions/builtin_interfaces.hpp"
 #include "gazebo_ros/conversions/generic.hpp"

--- a/gazebo_ros/include/gazebo_ros/executor.hpp
+++ b/gazebo_ros/include/gazebo_ros/executor.hpp
@@ -15,8 +15,8 @@
 #ifndef GAZEBO_ROS__EXECUTOR_HPP_
 #define GAZEBO_ROS__EXECUTOR_HPP_
 
-#include <rclcpp/rclcpp.hpp>
 #include <gazebo/common/Events.hh>
+#include <rclcpp/rclcpp.hpp>
 
 namespace gazebo_ros
 {

--- a/gazebo_ros/include/gazebo_ros/node.hpp
+++ b/gazebo_ros/include/gazebo_ros/node.hpp
@@ -15,11 +15,7 @@
 #ifndef GAZEBO_ROS__NODE_HPP_
 #define GAZEBO_ROS__NODE_HPP_
 
-#include <rclcpp/rclcpp.hpp>
-
-#include <gazebo_ros/executor.hpp>
 #include <gazebo_ros/node_visibility_control.h>
-#include <gazebo_ros/qos.hpp>
 
 #include <atomic>
 #include <memory>
@@ -27,6 +23,11 @@
 #include <string>
 #include <utility>
 #include <vector>
+
+#include <gazebo_ros/executor.hpp>
+#include <gazebo_ros/qos.hpp>
+
+#include <rclcpp/rclcpp.hpp>
 
 namespace gazebo_ros
 {

--- a/gazebo_ros/include/gazebo_ros/qos.hpp
+++ b/gazebo_ros/include/gazebo_ros/qos.hpp
@@ -15,17 +15,16 @@
 #ifndef GAZEBO_ROS__QOS_HPP_
 #define GAZEBO_ROS__QOS_HPP_
 
-#include <sdf/sdf.hh>
-
-#include <rclcpp/node_options.hpp>
-#include <rclcpp/qos.hpp>
-
 #include <gazebo_ros/node_visibility_control.h>
+#include <sdf/sdf.hh>
 
 #include <map>
 #include <memory>
 #include <stdexcept>
 #include <string>
+
+#include <rclcpp/node_options.hpp>
+#include <rclcpp/qos.hpp>
 
 namespace gazebo_ros
 {

--- a/gazebo_ros/include/gazebo_ros/testing_utils.hpp
+++ b/gazebo_ros/include/gazebo_ros/testing_utils.hpp
@@ -19,11 +19,12 @@
 #include <stdlib.h>
 
 #include <gtest/gtest.h>
-#include <rclcpp/rclcpp.hpp>
 
 #include <utility>
 #include <vector>
 #include <string>
+
+#include <rclcpp/rclcpp.hpp>
 
 namespace gazebo_ros
 {

--- a/gazebo_ros/scripts/spawn_entity.py
+++ b/gazebo_ros/scripts/spawn_entity.py
@@ -22,13 +22,13 @@ import math
 import os
 import sys
 from urllib.parse import SplitResult, urlsplit
-from lxml import etree as ElementTree
 
 from gazebo_msgs.msg import ModelStates
 from gazebo_msgs.srv import DeleteEntity
 # from gazebo_msgs.srv import SetModelConfiguration
 from gazebo_msgs.srv import SpawnEntity
 from geometry_msgs.msg import Pose
+from lxml import etree as ElementTree
 import rclpy
 from rclpy.node import Node
 from rclpy.qos import QoSDurabilityPolicy

--- a/gazebo_ros/src/gazebo_ros_factory.cpp
+++ b/gazebo_ros/src/gazebo_ros_factory.cpp
@@ -14,6 +14,8 @@
 
 #include "gazebo_ros/gazebo_ros_factory.hpp"
 
+#include <tinyxml.h>
+
 #include <gazebo/common/Events.hh>
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/physics/Entity.hh>
@@ -21,6 +23,13 @@
 #include <gazebo/physics/PhysicsIface.hh>
 #include <gazebo/physics/World.hh>
 #include <gazebo/transport/Node.hh>
+
+#include <algorithm>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
 #include <gazebo_msgs/srv/get_model_list.hpp>
 #include <gazebo_msgs/srv/delete_entity.hpp>
 #include <gazebo_msgs/srv/spawn_entity.hpp>
@@ -29,13 +38,6 @@
 #include <gazebo_ros/node.hpp>
 #include <gazebo_ros/utils.hpp>
 #include <rosgraph_msgs/msg/clock.hpp>
-
-#include <tinyxml.h>
-#include <algorithm>
-#include <memory>
-#include <sstream>
-#include <string>
-#include <vector>
 
 namespace gazebo_ros
 {

--- a/gazebo_ros/src/gazebo_ros_force_system.cpp
+++ b/gazebo_ros/src/gazebo_ros_force_system.cpp
@@ -16,16 +16,17 @@
 #include <gazebo/physics/Model.hh>
 #include <gazebo/physics/PhysicsIface.hh>
 #include <gazebo/physics/World.hh>
-#include <gazebo_msgs/srv/apply_link_wrench.hpp>
-#include <gazebo_msgs/srv/apply_joint_effort.hpp>
-#include <gazebo_msgs/srv/joint_request.hpp>
-#include <gazebo_msgs/srv/link_request.hpp>
-#include <gazebo_ros/node.hpp>
 
 #include <algorithm>
 #include <memory>
 #include <string>
 #include <vector>
+
+#include <gazebo_msgs/srv/apply_link_wrench.hpp>
+#include <gazebo_msgs/srv/apply_joint_effort.hpp>
+#include <gazebo_msgs/srv/joint_request.hpp>
+#include <gazebo_msgs/srv/link_request.hpp>
+#include <gazebo_ros/node.hpp>
 
 #include "gazebo_ros/conversions/builtin_interfaces.hpp"
 #include "gazebo_ros/gazebo_ros_force_system.hpp"

--- a/gazebo_ros/src/gazebo_ros_init.cpp
+++ b/gazebo_ros/src/gazebo_ros_init.cpp
@@ -20,6 +20,9 @@
 #include <gazebo/physics/World.hh>
 #include <gazebo/transport/Node.hh>
 
+#include <memory>
+#include <string>
+
 #include <gazebo_msgs/msg/performance_metrics.hpp>
 #include <gazebo_msgs/msg/sensor_performance_metric.hpp>
 
@@ -29,9 +32,6 @@
 
 #include <rosgraph_msgs/msg/clock.hpp>
 #include <std_srvs/srv/empty.hpp>
-
-#include <memory>
-#include <string>
 
 #ifndef GAZEBO_ROS_HAS_PERFORMANCE_METRICS
 #if \

--- a/gazebo_ros/src/gazebo_ros_properties.cpp
+++ b/gazebo_ros/src/gazebo_ros_properties.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "gazebo_ros/gazebo_ros_properties.hpp"
+
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/physics/Entity.hh>
 #include <gazebo/physics/Joint.hh>
@@ -21,6 +23,9 @@
 #include <gazebo/physics/World.hh>
 #include <gazebo/physics/Collision.hh>
 #include <gazebo/transport/Node.hh>
+
+#include <memory>
+
 #include <gazebo_msgs/srv/get_joint_properties.hpp>
 #include <gazebo_msgs/srv/get_light_properties.hpp>
 #include <gazebo_msgs/srv/get_link_properties.hpp>
@@ -32,10 +37,6 @@
 #include <gazebo_msgs/srv/set_physics_properties.hpp>
 #include <gazebo_ros/conversions/geometry_msgs.hpp>
 #include <gazebo_ros/node.hpp>
-
-#include <memory>
-
-#include "gazebo_ros/gazebo_ros_properties.hpp"
 
 namespace gazebo_ros
 {

--- a/gazebo_ros/src/gazebo_ros_state.cpp
+++ b/gazebo_ros/src/gazebo_ros_state.cpp
@@ -12,23 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "gazebo_ros/gazebo_ros_state.hpp"
+
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/physics/Entity.hh>
 #include <gazebo/physics/Light.hh>
 #include <gazebo/physics/Link.hh>
 #include <gazebo/physics/Model.hh>
 #include <gazebo/physics/World.hh>
+
+#include <memory>
+
 #include <gazebo_msgs/msg/link_states.hpp>
 #include <gazebo_msgs/msg/model_states.hpp>
 #include <gazebo_msgs/srv/get_entity_state.hpp>
 #include <gazebo_msgs/srv/set_entity_state.hpp>
 #include <gazebo_ros/node.hpp>
 
-#include <memory>
-
 #include "gazebo_ros/conversions/builtin_interfaces.hpp"
 #include "gazebo_ros/conversions/geometry_msgs.hpp"
-#include "gazebo_ros/gazebo_ros_state.hpp"
 
 namespace gazebo_ros
 {

--- a/gazebo_ros/src/qos.cpp
+++ b/gazebo_ros/src/qos.cpp
@@ -13,10 +13,6 @@
 // limitations under the License.
 
 #include <gazebo_ros/qos.hpp>
-
-#include <rclcpp/expand_topic_or_service_name.hpp>
-#include <rclcpp/node_options.hpp>
-#include <rclcpp/qos.hpp>
 #include <rcl/rcl.h>
 #include <rcl/remap.h>
 #include <rmw/types.h>
@@ -28,6 +24,10 @@
 #include <sstream>
 #include <string>
 #include <utility>
+
+#include <rclcpp/expand_topic_or_service_name.hpp>
+#include <rclcpp/node_options.hpp>
+#include <rclcpp/qos.hpp>
 
 namespace gazebo_ros
 {

--- a/gazebo_ros/test/plugins/args_init.cpp
+++ b/gazebo_ros/test/plugins/args_init.cpp
@@ -14,10 +14,10 @@
 
 #include <gazebo/common/Plugin.hh>
 
-#include <std_msgs/msg/string.hpp>
-#include <gazebo_ros/node.hpp>
-
 #include <memory>
+
+#include <gazebo_ros/node.hpp>
+#include <std_msgs/msg/string.hpp>
 
 /// Simple example of a gazebo system plugin which uses a ROS2 node with gazebo_ros::Node.
 class ProperInit : public gazebo::SystemPlugin

--- a/gazebo_ros/test/plugins/create_node_without_init.cpp
+++ b/gazebo_ros/test/plugins/create_node_without_init.cpp
@@ -14,10 +14,10 @@
 
 #include <gazebo/common/Plugin.hh>
 
-#include <std_msgs/msg/string.hpp>
-#include <gazebo_ros/node.hpp>
-
 #include <memory>
+
+#include <gazebo_ros/node.hpp>
+#include <std_msgs/msg/string.hpp>
 
 /// Simple example of a gazebo system plugin which uses a ROS2 node with gazebo_ros::Node.
 class CreateBeforeInit : public gazebo::SystemPlugin

--- a/gazebo_ros/test/plugins/multiple_nodes.cpp
+++ b/gazebo_ros/test/plugins/multiple_nodes.cpp
@@ -14,10 +14,10 @@
 
 #include <gazebo/common/Plugin.hh>
 
-#include <std_msgs/msg/string.hpp>
-#include <gazebo_ros/node.hpp>
-
 #include <memory>
+
+#include <gazebo_ros/node.hpp>
+#include <std_msgs/msg/string.hpp>
 
 /// Simple example of a gazebo system plugin which uses a ROS2 node with gazebo_ros::Node.
 class MultipleNodes : public gazebo::SystemPlugin

--- a/gazebo_ros/test/plugins/ros_world_plugin.cpp
+++ b/gazebo_ros/test/plugins/ros_world_plugin.cpp
@@ -14,10 +14,10 @@
 
 #include <gazebo/common/Plugin.hh>
 
-#include <std_msgs/msg/string.hpp>
-#include <gazebo_ros/node.hpp>
-
 #include <memory>
+
+#include <gazebo_ros/node.hpp>
+#include <std_msgs/msg/string.hpp>
 
 /// Simple example of a gazebo world plugin which uses a ROS2 node with gazebo_ros::Node.
 class RosWorldPlugin : public gazebo::WorldPlugin

--- a/gazebo_ros/test/plugins/sdf_node.cpp
+++ b/gazebo_ros/test/plugins/sdf_node.cpp
@@ -14,12 +14,12 @@
 
 #include <gazebo/common/Plugin.hh>
 
-#include <std_msgs/msg/string.hpp>
-#include <gazebo_ros/node.hpp>
-#include <rclcpp/exceptions.hpp>
-
 #include <memory>
 #include <string>
+
+#include <gazebo_ros/node.hpp>
+#include <rclcpp/exceptions.hpp>
+#include <std_msgs/msg/string.hpp>
 
 /// Simple example of a gazebo world plugin which uses a ROS2 node with gazebo_ros::Node.
 class SDFNode : public gazebo::WorldPlugin

--- a/gazebo_ros/test/test_disable_performance_metrics.test.py
+++ b/gazebo_ros/test/test_disable_performance_metrics.test.py
@@ -12,22 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from threading import Event, Thread
+import time
 import unittest
+
+from gazebo_msgs.msg import PerformanceMetrics
 
 import launch
 import launch.actions
 
 import launch_testing
 import launch_testing.asserts
+
 import pytest
 
-import rclpy
-from gazebo_msgs.msg import PerformanceMetrics
-from rclpy.node import Node
 from rcl_interfaces.msg import Parameter, ParameterType
 from rcl_interfaces.srv import SetParameters
-import time
-from threading import Thread, Event
+import rclpy
+from rclpy.node import Node
 
 
 @pytest.mark.launch_test
@@ -95,6 +97,7 @@ class TestPerformanceMetricsParam(unittest.TestCase):
 
 
 class MakeTestNode(Node):
+
     def __init__(self, name):
         """Initialize node and counters."""
         super().__init__(name)

--- a/gazebo_ros/test/test_gazebo_ros_factory.cpp
+++ b/gazebo_ros/test/test_gazebo_ros_factory.cpp
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 #include <gazebo/test/ServerFixture.hh>
+#include <memory>
 #include <gazebo_msgs/srv/get_model_list.hpp>
 #include <gazebo_msgs/srv/delete_entity.hpp>
 #include <gazebo_msgs/srv/spawn_entity.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <memory>
 
 class GazeboRosFactoryTest : public gazebo::ServerFixture
 {

--- a/gazebo_ros/test/test_gazebo_ros_init.cpp
+++ b/gazebo_ros/test/test_gazebo_ros_init.cpp
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include <gazebo/test/ServerFixture.hh>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <std_srvs/srv/empty.hpp>
-#include <memory>
 
 class GazeboRosInitTest : public gazebo::ServerFixture
 {

--- a/gazebo_ros/test/test_gazebo_ros_joint_effort.cpp
+++ b/gazebo_ros/test/test_gazebo_ros_joint_effort.cpp
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include <gazebo/test/ServerFixture.hh>
+#include <memory>
 #include <gazebo_msgs/srv/apply_joint_effort.hpp>
 #include <gazebo_msgs/srv/joint_request.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <memory>
 
 #define tol 10e-2
 

--- a/gazebo_ros/test/test_gazebo_ros_link_wrench.cpp
+++ b/gazebo_ros/test/test_gazebo_ros_link_wrench.cpp
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include <gazebo/test/ServerFixture.hh>
+#include <memory>
 #include <gazebo_msgs/srv/apply_link_wrench.hpp>
 #include <gazebo_msgs/srv/link_request.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <memory>
 
 #define tol 10e-2
 

--- a/gazebo_ros/test/test_gazebo_ros_properties.cpp
+++ b/gazebo_ros/test/test_gazebo_ros_properties.cpp
@@ -14,6 +14,10 @@
 
 #include <gazebo/test/ServerFixture.hh>
 
+#include <memory>
+#include <string>
+#include <vector>
+
 #include <gazebo_msgs/srv/get_model_properties.hpp>
 #include <gazebo_msgs/srv/get_joint_properties.hpp>
 #include <gazebo_msgs/srv/get_link_properties.hpp>
@@ -23,15 +27,11 @@
 #include <gazebo_msgs/srv/set_link_properties.hpp>
 #include <gazebo_msgs/srv/set_light_properties.hpp>
 #include <gazebo_msgs/srv/set_physics_properties.hpp>
-
-#include <geometry_msgs/msg/pose.hpp>
 #include <gazebo_msgs/srv/spawn_entity.hpp>
-#include <gazebo_ros/conversions/geometry_msgs.hpp>
-#include <rclcpp/rclcpp.hpp>
 
-#include <memory>
-#include <string>
-#include <vector>
+#include <gazebo_ros/conversions/geometry_msgs.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 #define tol 0.01
 

--- a/gazebo_ros/test/test_gazebo_ros_state.cpp
+++ b/gazebo_ros/test/test_gazebo_ros_state.cpp
@@ -16,15 +16,15 @@
 #include <ignition/math/Pose3.hh>
 #include <ignition/math/Vector3.hh>
 
+#include <memory>
+#include <string>
+
 #include <gazebo_msgs/msg/link_states.hpp>
 #include <gazebo_msgs/msg/model_states.hpp>
 #include <gazebo_msgs/srv/get_entity_state.hpp>
 #include <gazebo_msgs/srv/set_entity_state.hpp>
 #include <gazebo_ros/conversions/geometry_msgs.hpp>
 #include <rclcpp/rclcpp.hpp>
-
-#include <memory>
-#include <string>
 
 #define tol 10e-2
 

--- a/gazebo_ros/test/test_plugins.cpp
+++ b/gazebo_ros/test/test_plugins.cpp
@@ -14,15 +14,15 @@
 
 #include <gtest/gtest.h>
 
-#include <gazebo_ros/testing_utils.hpp>
-
-#include <rclcpp/rclcpp.hpp>
-#include <std_msgs/msg/string.hpp>
-
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
+
+#include <gazebo_ros/testing_utils.hpp>
+
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/string.hpp>
 
 struct TestParams
 {

--- a/gazebo_ros/test/test_sim_time.cpp
+++ b/gazebo_ros/test/test_sim_time.cpp
@@ -13,13 +13,14 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
-#include <gazebo_ros/testing_utils.hpp>
-#include <rclcpp/rclcpp.hpp>
-#include <rosgraph_msgs/msg/clock.hpp>
 
 #include <memory>
 #include <string>
 #include <vector>
+
+#include <gazebo_ros/testing_utils.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rosgraph_msgs/msg/clock.hpp>
 
 using namespace std::literals::chrono_literals;
 

--- a/gazebo_ros/test/test_utils.cpp
+++ b/gazebo_ros/test/test_utils.cpp
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gazebo_ros/utils.hpp>
 #include <gazebo/sensors/GaussianNoiseModel.hh>
 #include <gazebo/sensors/sensors.hh>
 #include <gtest/gtest.h>
 
 #include <memory>
 #include <string>
+
+#include <gazebo_ros/utils.hpp>
 
 TEST(TestUtils, NoiseVariance)
 {


### PR DESCRIPTION
There are lots of cpplint errors since a recent change in rolling. This fixes the new `build_order` errors in the `gazebo_ros` package. `gazebo_plugins` will be addressed in a separate pull request.