### PR TITLE
gazebo_ros: fix check_test_ran syntax

### DIFF
--- a/gazebo_ros/test/CMakeLists.txt
+++ b/gazebo_ros/test/CMakeLists.txt
@@ -12,7 +12,7 @@ if(CATKIN_ENABLE_TESTING)
       # Check for test result file and create one if needed.  rostest can fail to
       # generate a file if it throws an exception.
       add_test(check_${rostest} rosrun rosunit check_test_ran.py 
-               --rostest ${ROS_PACKAGE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${rostest})
+               --rostest ${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${rostest})
   endforeach()
 endif()
 


### PR DESCRIPTION
The ros_network tests have a `check_test_ran.py` invocation but the `ROS_PACKAGE_NAME` variable is unset. Replacing it
with `PROJECT_NAME` fixes it.

## Without this branch:

from https://build.osrfoundation.org/job/ros_gazebo_pkgs-ci-pr_any_noetic-focal-amd64/57/consoleText

~~~
2: Test command: /opt/ros/noetic/bin/rosrun "rosunit" "check_test_ran.py" "--rostest" "/var/lib/jenkins/workspace/ros_gazebo_pkgs-ci-default_noetic-focal-amd64/ws/src/gazebo_ros_pkgs/gazebo_ros/test/ros_network/ros_network_default.test"
2: Test timeout computed to be: 10000000
2: Usage:
2: 	check_test_ran.py test-file.xml
2: or
2: 	check_test_ran.py --rostest pkg-name test-file.xml
2: 
2: ['/opt/ros/noetic/share/rosunit/scripts/check_test_ran.py', '--rostest', '/var/lib/jenkins/workspace/ros_gazebo_pkgs-ci-default_noetic-focal-amd64/ws/src/gazebo_ros_pkgs/gazebo_ros/test/ros_network/ros_network_default.test']
2/4 Test #2: check_ros_network/ros_network_default.test .............................***Failed    0.36 sec
~~~

