### PR TITLE
Add drawbar pull demo world and script

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -538,6 +538,12 @@ install(TARGETS
   RUNTIME DESTINATION bin)
 endif()
 
+install(
+  PROGRAMS
+    scripts/wheel_slip_drawbar_pull_publisher.py
+    DESTINATION lib/${PROJECT_NAME}/
+)
+
 install(DIRECTORY
   worlds
   DESTINATION share/${PROJECT_NAME}/

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_p3d.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_p3d.hpp
@@ -29,7 +29,7 @@ class GazeboRosP3DPrivate;
 /**
   Example Usage:
   \code{.xml}
-    <plugin name="gazebo_ros_force" filename="libgazebo_ros_force.so">
+    <plugin name="gazebo_ros_p3d" filename="libgazebo_ros_p3d.so">
 
       <ros>
 

--- a/gazebo_plugins/scripts/wheel_slip_drawbar_pull_publisher.py
+++ b/gazebo_plugins/scripts/wheel_slip_drawbar_pull_publisher.py
@@ -28,11 +28,13 @@ DEFAULT_FORCE_INCREMENT = 10
 DEFAULT_MAX_FORCE = 70
 DEFAULT_PUBLISH_INTERVAL = 2.0
 
+
 class WheelSlipDrawbarPullPublisher(Node):
+
     def __init__(self, args):
         super().__init__('wheel_slip_drawbar_pull_publisher')
         parser = argparse.ArgumentParser(
-            description='Publish drag forces as a wrench representing drawbar pull on the back of a vehicle.')
+            description='Publish a wrench representing drawbar pull on the back of a vehicle.')
         parser.add_argument('-f', '--force-increment', type=float, default=DEFAULT_FORCE_INCREMENT,
                             help='The drawbar pull force increment (Newtons)')
         parser.add_argument('-i', '--interval', type=float, default=DEFAULT_PUBLISH_INTERVAL,
@@ -59,18 +61,19 @@ class WheelSlipDrawbarPullPublisher(Node):
         self.publisher.publish(msg)
         self.get_logger().info(f'Publishing drawbar pull force of {msg.force.x} N')
 
+
 def main(args=sys.argv):
     rclpy.init(args=args)
     args_without_ros = rclpy.utilities.remove_ros_args(args)
-    wheel_slip_drawbar_pull_publisher = WheelSlipDrawbarPullPublisher(args_without_ros)
-    wheel_slip_drawbar_pull_publisher.get_logger().info('Wheel Slip Drawbar Pull Publisher started')
+    node = WheelSlipDrawbarPullPublisher(args_without_ros)
+    node.get_logger().info('Wheel Slip Drawbar Pull Publisher started')
 
     try:
-        rclpy.spin(wheel_slip_drawbar_pull_publisher)
+        rclpy.spin(node)
     except KeyboardInterrupt:
         pass
 
-    wheel_slip_drawbar_pull_publisher.destroy_node()
+    node.destroy_node()
     rclpy.shutdown()
 
 

--- a/gazebo_plugins/scripts/wheel_slip_drawbar_pull_publisher.py
+++ b/gazebo_plugins/scripts/wheel_slip_drawbar_pull_publisher.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Desc: helper script for publishing drawbar pull wrenches
+# Author: Steve Peters
+#
+import argparse
+import math
+import rclpy
+import sys
+from geometry_msgs.msg import Wrench
+from rclpy.node import Node
+
+kDefaultTopic = '/drawbar_pull'
+kDefaultForceIncrement = 10
+kDefaultMaxForce = 70
+kDefaultPublishInterval = 2.0
+
+class WheelSlipDrawbarPullPublisher(Node):
+    def __init__(self, args):
+        super().__init__('wheel_slip_drawbar_pull_publisher')
+        parser = argparse.ArgumentParser(
+            description='Publish drag forces as a wrench representing drawbar pull on the back of a vehicle.')
+        parser.add_argument('-t', '--topic', type=str, default=kDefaultTopic,
+                            help='The topic name for publishing a drawbar pull wrench')
+        parser.add_argument('-f', '--force-increment', type=float, default=kDefaultForceIncrement,
+                            help='The drawbar pull force increment (Newtons)')
+        parser.add_argument('-i', '--interval', type=float, default=kDefaultPublishInterval,
+                            help='The drawar pull publication interval (seconds)')
+        parser.add_argument('-m', '--max-force', type=float, default=kDefaultMaxForce,
+                            help='The maximum drawbar pull force')
+        self.args = parser.parse_args(args[1:])
+
+        self.publisher = self.create_publisher(Wrench, self.args.topic, 1)
+        self.publish_counter = 1
+        self.publish_timer = self.create_timer(self.args.interval, self.updateWrench)
+
+    def updateWrench(self):
+        i = self.publish_counter
+        self.publish_counter += 1
+        amplitude = self.args.force_increment * math.floor(i / 2)
+        sign = (-1) ** (i % 2)
+        if amplitude > self.args.max_force:
+            amplitude = 0
+
+        msg = Wrench()
+        msg.force.x = sign * float(amplitude)
+
+        self.publisher.publish(msg)
+        self.get_logger().info(f"Publishing drawbar pull force of {msg.force.x} N")
+
+def main(args=sys.argv):
+    rclpy.init(args=args)
+    args_without_ros = rclpy.utilities.remove_ros_args(args)
+    wheel_slip_drawbar_pull_publisher = WheelSlipDrawbarPullPublisher(args_without_ros)
+    wheel_slip_drawbar_pull_publisher.get_logger().info('Wheel Slip Drawbar Pull Publisher started')
+
+    try:
+        rclpy.spin(wheel_slip_drawbar_pull_publisher)
+    except KeyboardInterrupt:
+        pass
+
+    wheel_slip_drawbar_pull_publisher.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/gazebo_plugins/scripts/wheel_slip_drawbar_pull_publisher.py
+++ b/gazebo_plugins/scripts/wheel_slip_drawbar_pull_publisher.py
@@ -24,31 +24,28 @@ import sys
 from geometry_msgs.msg import Wrench
 from rclpy.node import Node
 
-kDefaultTopic = '/drawbar_pull'
-kDefaultForceIncrement = 10
-kDefaultMaxForce = 70
-kDefaultPublishInterval = 2.0
+DEFAULT_FORCE_INCREMENT = 10
+DEFAULT_MAX_FORCE = 70
+DEFAULT_PUBLISH_INTERVAL = 2.0
 
 class WheelSlipDrawbarPullPublisher(Node):
     def __init__(self, args):
         super().__init__('wheel_slip_drawbar_pull_publisher')
         parser = argparse.ArgumentParser(
             description='Publish drag forces as a wrench representing drawbar pull on the back of a vehicle.')
-        parser.add_argument('-t', '--topic', type=str, default=kDefaultTopic,
-                            help='The topic name for publishing a drawbar pull wrench')
-        parser.add_argument('-f', '--force-increment', type=float, default=kDefaultForceIncrement,
+        parser.add_argument('-f', '--force-increment', type=float, default=DEFAULT_FORCE_INCREMENT,
                             help='The drawbar pull force increment (Newtons)')
-        parser.add_argument('-i', '--interval', type=float, default=kDefaultPublishInterval,
+        parser.add_argument('-i', '--interval', type=float, default=DEFAULT_PUBLISH_INTERVAL,
                             help='The drawar pull publication interval (seconds)')
-        parser.add_argument('-m', '--max-force', type=float, default=kDefaultMaxForce,
+        parser.add_argument('-m', '--max-force', type=float, default=DEFAULT_MAX_FORCE,
                             help='The maximum drawbar pull force')
         self.args = parser.parse_args(args[1:])
 
-        self.publisher = self.create_publisher(Wrench, self.args.topic, 1)
+        self.publisher = self.create_publisher(Wrench, "drawbar_pull", 1)
         self.publish_counter = 1
-        self.publish_timer = self.create_timer(self.args.interval, self.updateWrench)
+        self.publish_timer = self.create_timer(self.args.interval, self.update_wrench)
 
-    def updateWrench(self):
+    def update_wrench(self):
         i = self.publish_counter
         self.publish_counter += 1
         amplitude = self.args.force_increment * math.floor(i / 2)
@@ -60,7 +57,7 @@ class WheelSlipDrawbarPullPublisher(Node):
         msg.force.x = sign * float(amplitude)
 
         self.publisher.publish(msg)
-        self.get_logger().info(f"Publishing drawbar pull force of {msg.force.x} N")
+        self.get_logger().info(f'Publishing drawbar pull force of {msg.force.x} N')
 
 def main(args=sys.argv):
     rclpy.init(args=args)

--- a/gazebo_plugins/worlds/gazebo_ros_wheel_slip_drawbar_pull_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_wheel_slip_drawbar_pull_demo.world
@@ -1,0 +1,150 @@
+<?xml version="1.0" ?>
+<!--
+  Gazebo ROS wheel slip plugin and drawbar pull demo
+
+  Try for example:
+
+  To publish time-varying drawbar pull force:
+
+    ros2 run gazebo_plugins wheel_slip_drawbar_pull_publisher.py
+
+  To change slip compliance of a group of wheels:
+
+    ros2 param set /trisphere_cycle_slip0/wheel_slip_rear slip_compliance_unitless_longitudinal 1.0
+    ros2 param set /trisphere_cycle_slip1/wheel_slip_rear slip_compliance_unitless_longitudinal 0.0
+
+  To get the current slip compliance of a group of wheels:
+
+    ros2 param get /trisphere_cycle_slip1/wheel_slip_rear slip_compliance_unitless_longitudinal
+-->
+<sdf version="1.6">
+  <world name="default">
+    <gravity>0 0 -9.8</gravity>
+
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <include>
+      <uri>model://trisphere_cycle</uri>
+      <name>trisphere_cycle_slip0</name>
+      <pose>0 0 0  0 0 0</pose>
+      <plugin name="force_drawbar_pull_trisphere_cycle_slip0" filename="libgazebo_ros_force.so">
+        <ros>
+          <remapping>gazebo_ros_force:=drawbar_pull</remapping>
+        </ros>
+        <link_name>frame</link_name>
+        <force_frame>link</force_frame>
+      </plugin>
+      <plugin name="wheel_slip_front" filename="libgazebo_ros_wheel_slip.so">
+        <ros>
+          <namespace>trisphere_cycle_slip0</namespace>
+        </ros>
+        <wheel link_name="wheel_front">
+          <slip_compliance_lateral>0</slip_compliance_lateral>
+          <slip_compliance_longitudinal>0</slip_compliance_longitudinal>
+          <wheel_normal_force>77</wheel_normal_force>
+        </wheel>
+      </plugin>
+      <plugin name="wheel_slip_rear" filename="libgazebo_ros_wheel_slip.so">
+        <ros>
+          <namespace>trisphere_cycle_slip0</namespace>
+        </ros>
+        <wheel link_name="wheel_rear_left">
+          <slip_compliance_lateral>0</slip_compliance_lateral>
+          <slip_compliance_longitudinal>0</slip_compliance_longitudinal>
+          <wheel_normal_force>32</wheel_normal_force>
+        </wheel>
+        <wheel link_name="wheel_rear_right">
+          <slip_compliance_lateral>0</slip_compliance_lateral>
+          <slip_compliance_longitudinal>0</slip_compliance_longitudinal>
+          <wheel_normal_force>32</wheel_normal_force>
+        </wheel>
+      </plugin>
+      <plugin name="joint_control" filename="libJointControlPlugin.so">
+        <controller type="position">
+          <joint>wheel_front_steer</joint>
+          <target>0</target>
+          <pid_gains>9 0 0.1</pid_gains>
+        </controller>
+        <controller type="velocity">
+          <joint>wheel_rear_left_spin</joint>
+          <joint>wheel_rear_right_spin</joint>
+          <target>6.0</target>
+          <pid_gains>9 0 0</pid_gains>
+        </controller>
+        <controller type="force">
+          <joint>wheel_rear_left_spin</joint>
+          <joint>wheel_rear_right_spin</joint>
+          <target>2.15</target>
+        </controller>
+      </plugin>
+    </include>
+
+    <include>
+      <uri>model://trisphere_cycle</uri>
+      <name>trisphere_cycle_slip1</name>
+      <pose>0 2 0  0 0 0</pose>
+      <plugin name="force_drawbar_pull_trisphere_cycle_slip1" filename="libgazebo_ros_force.so">
+        <ros>
+          <remapping>gazebo_ros_force:=drawbar_pull</remapping>
+        </ros>
+        <link_name>frame</link_name>
+        <force_frame>link</force_frame>
+      </plugin>
+      <plugin name="wheel_slip_front" filename="libgazebo_ros_wheel_slip.so">
+        <ros>
+          <namespace>trisphere_cycle_slip1</namespace>
+        </ros>
+        <wheel link_name="wheel_front">
+          <slip_compliance_lateral>1</slip_compliance_lateral>
+          <slip_compliance_longitudinal>1</slip_compliance_longitudinal>
+          <wheel_normal_force>77</wheel_normal_force>
+        </wheel>
+      </plugin>
+      <plugin name="wheel_slip_rear" filename="libgazebo_ros_wheel_slip.so">
+        <ros>
+          <namespace>trisphere_cycle_slip1</namespace>
+        </ros>
+        <wheel link_name="wheel_rear_left">
+          <slip_compliance_lateral>1</slip_compliance_lateral>
+          <slip_compliance_longitudinal>1</slip_compliance_longitudinal>
+          <wheel_normal_force>32</wheel_normal_force>
+        </wheel>
+        <wheel link_name="wheel_rear_right">
+          <slip_compliance_lateral>1</slip_compliance_lateral>
+          <slip_compliance_longitudinal>1</slip_compliance_longitudinal>
+          <wheel_normal_force>32</wheel_normal_force>
+        </wheel>
+      </plugin>
+      <plugin name="joint_control" filename="libJointControlPlugin.so">
+        <controller type="position">
+          <joint>wheel_front_steer</joint>
+          <target>0</target>
+          <pid_gains>9 0 0.1</pid_gains>
+        </controller>
+        <controller type="velocity">
+          <joint>wheel_rear_left_spin</joint>
+          <joint>wheel_rear_right_spin</joint>
+          <target>6.0</target>
+          <pid_gains>9 0 0</pid_gains>
+        </controller>
+        <controller type="force">
+          <joint>wheel_rear_left_spin</joint>
+          <joint>wheel_rear_right_spin</joint>
+          <target>2.15</target>
+        </controller>
+      </plugin>
+    </include>
+
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose>1.5 -4 2.5  0 0.5 1.6</pose>
+        <view_controller>orbit</view_controller>
+      </camera>
+    </gui>
+  </world>
+</sdf>


### PR DESCRIPTION
This adds a variant of the wheel-slip plugin demo world that replaces the inclined gravity vector with `gazebo_ros_force` plugins that act on the body-fixed frame of the trisphere_cycle frame. When applying forces in the longitudinal direction, these forces correspond to "[drawbar pull](https://en.wikipedia.org/wiki/Drawbar_pull)", which is similar to driving on different slopes. Note that this plugin can also apply "drawbar push", which isn't normally tested experimentally, but can be used to approximate driving downhill.

A script is provided that publishes a steadily increasing square wave of drawbar pull force values to quickly test wheel slip on a range of conditions equivalent to driving on different slopes.