### PR TITLE
Initialize wheel slip parameters directly from SDF

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_wheel_slip.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_wheel_slip.hpp
@@ -77,7 +77,16 @@ class GazeboRosWheelSlipPrivate;
 ///      If not specified, these will default to 0.0.
 ///      Any negative values will ignored and set to 0.0.
 ///
-///  2. ROS parameters for each wheel, e.g :
+///  2. ROS parameters for all wheels, e.g :
+///      <ros>
+///         <parameter name="slip_compliance_unitless_lateral" type="double">0.1</parameter>
+///         <parameter name="slip_compliance_unitless_longitudinal" type="double">0.2</parameter>
+///      </ros>
+///
+///     If not specified, these will default to the last values set in SDF tags.
+///     If these are specified, they override SDF parameters for each wheel.
+///
+///  3. ROS parameters for each wheel, e.g :
 ///       <ros>
 ///         <parameter name="slip_compliance_unitless_lateral/wheel_front" type="double">0.1
 ///           </parameter>
@@ -85,20 +94,12 @@ class GazeboRosWheelSlipPrivate;
 ///           </parameter>
 ///       </ros>
 ///
-///      If not specified, these default to SDF parameters set for each wheel.
-///      If specified, they will override the values set as SDF parameters.
-///
-///  3. ROS parameters for all wheels, e.g :
-///      <ros>
-///         <parameter name="slip_compliance_unitless_lateral" type="double">0.1</parameter>
-///         <parameter name="slip_compliance_unitless_longitudinal" type="double">0.2</parameter>
-///      </ros>
-///
-///     If not specified, these will default to the last values set in SDF tags.
-///     If these are specified, they override both SDF and the ROS parameters for each wheel.
+///      If not specified, these default to the value of the ROS parameter for all wheels.
+///      If specified, they will override values set as SDF parameters or ROS parameters for all
+///      wheels.
 ///
 ///   Precedence order :
-///   ROS Params for all wheels > ROS params for individual wheels > SDF parameters
+///   ROS Params for individual wheels > ROS params for all wheels > SDF parameters
 ///   Check out the test cases for more information and expected behaviour.
 ///
 /// See the WheelSlipPlugin documentation at the following location for more details:

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_wheel_slip.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_wheel_slip.hpp
@@ -64,8 +64,8 @@ class GazeboRosWheelSlipPrivate;
 ///           value is zero or negative, the publisher will publish at the maximum rate.
 ///           This value is applied to all wheels declared in the WheelSlipPlugin.
 ///
-/// Precedence order and default values:
-/// ------------------------------------
+/// Default values:
+/// ---------------
 /// Slip compliance values can be declared in 3 ways:
 ///  1. SDF parameters, e.g. :
 ///       <wheel link_name="wheel_front">
@@ -84,9 +84,9 @@ class GazeboRosWheelSlipPrivate;
 ///      </ros>
 ///
 ///     If not specified, these will default to the last values set in SDF tags.
-///     If these are specified, they override SDF parameters for each wheel.
+///     If these are specified, they override SDF parameters.
 ///
-///  3. ROS parameters for each wheel, e.g :
+///  3. ROS parameters for specific wheels, e.g :
 ///       <ros>
 ///         <parameter name="slip_compliance_unitless_lateral/wheel_front" type="double">0.1
 ///           </parameter>
@@ -95,11 +95,12 @@ class GazeboRosWheelSlipPrivate;
 ///       </ros>
 ///
 ///      If not specified, these default to the value of the ROS parameter for all wheels.
-///      If specified, they will override values set as SDF parameters or ROS parameters for all
-///      wheels.
+///      If specified, they override SDF parameters and ROS parameters
+///      "slip_compliance_unitless_lateral" and "slip_compliance_unitless_longitudinal".
 ///
-///   Precedence order :
-///   ROS Params for individual wheels > ROS params for all wheels > SDF parameters
+///   Precedence order
+///   ----------------
+///   ROS parameters for individual wheels > ROS parameters for all wheels > SDF parameters
 ///   Check out the test cases for more information and expected behaviour.
 ///
 /// See the WheelSlipPlugin documentation at the following location for more details:

--- a/gazebo_plugins/test/test_gazebo_ros_wheelslip.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_wheelslip.cpp
@@ -159,9 +159,7 @@ TEST_F(GazeboRosWheelSlipTest, RosLocalParamsOverrideSdf)
   // ----------------------------------------------------------------------------------------------
   // Expected result: ROS parameters (for each wheel) should override the SDF ones
   std::map<std::string, double> parameter_pairs = {
-    {"slip_compliance_unitless_lateral", 0.1},
     {"slip_compliance_unitless_lateral/wheel_front", 0.3},
-    {"slip_compliance_unitless_longitudinal", 0.2},
     {"slip_compliance_unitless_longitudinal/wheel_front", 0.4}};
 
   this->test_parameters(

--- a/gazebo_plugins/test/test_gazebo_ros_wheelslip.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_wheelslip.cpp
@@ -58,17 +58,24 @@ public:
     /* Query for the parameters and check if they match with the expected ones.
        Plugin takes a while to set the parameters, so we make multiple attempts to
        check the parameters */
-    int max_attempts = 5;
+    int max_attempts = 30;
     bool flag_do_parameters_match;
+    std::vector<rclcpp::Parameter> parameters_received;
     for (int i = 0; i < max_attempts; i++) {
       // Assume all expected and received parameters match
       flag_do_parameters_match = true;
 
       // Query for parameters
-      auto parameters_received = parameters_client->get_parameters(parameter_names);
+      parameters_received = parameters_client->get_parameters(parameter_names);
       for (auto & parameter : parameters_received) {
-        if (parameter_pairs[parameter.get_name()] != parameter.as_double()) {
-          // Parameters don't match
+        try {
+          if (fabs(parameter_pairs[parameter.get_name()] - parameter.as_double()) < 1e-3) {
+            // Parameters don't match
+            flag_do_parameters_match = false;
+            break;
+          }
+        } catch (std::runtime_error &) {
+          // Parameter may not be set yet
           flag_do_parameters_match = false;
           break;
         }
@@ -78,7 +85,12 @@ public:
       if (flag_do_parameters_match) {break;}
       std::this_thread::sleep_for(0.2s);
     }
-    ASSERT_TRUE(flag_do_parameters_match);
+    if (!flag_do_parameters_match) {
+      for (auto & parameter : parameters_received) {
+        EXPECT_NEAR(parameter_pairs[parameter.get_name()], parameter.as_double(), 1e-3)
+          << "unexpected value for param '" << parameter.get_name() << "'";
+      }
+    }
   }
 };
 
@@ -168,14 +180,14 @@ TEST_F(GazeboRosWheelSlipTest, TestRosGlobalParamsOverrideAll)
   // - ROS parameters (for all wheels) - ('slip_compliance_unitless_lateral',
   //                  'slip_compliance_unitless_longitudinal')
   // ----------------------------------------------------------------------------------------------
-  // Expected result: ROS parameters (for all wheels) should override all SDF
-  // and ROS parameters (for each wheel)
+  // Expected result: ROS parameters for all wheels should override SDF values
+  // and ROS parameters for each wheel should override parameters for all wheels.
   std::map<std::string, double> parameter_pairs = {
     {"slip_compliance_unitless_lateral", 0.1},
-    {"slip_compliance_unitless_lateral/wheel_rear_left", 0.1},
+    {"slip_compliance_unitless_lateral/wheel_rear_left", 0.6},
     {"slip_compliance_unitless_lateral/wheel_rear_right", 0.1},
     {"slip_compliance_unitless_longitudinal", 0.2},
-    {"slip_compliance_unitless_longitudinal/wheel_rear_left", 0.2},
+    {"slip_compliance_unitless_longitudinal/wheel_rear_left", 0.7},
     {"slip_compliance_unitless_longitudinal/wheel_rear_right", 0.2}};
 
   this->test_parameters(
@@ -208,10 +220,8 @@ TEST_F(GazeboRosWheelSlipTest, TestSetParameters)
     "trisphere_cycle_slip0/wheel_slip_rear");
 
   std::map<std::string, double> parameter_pairs = {
-    {"slip_compliance_unitless_lateral", 0.5},
     {"slip_compliance_unitless_lateral/wheel_rear_left", 0.0},
     {"slip_compliance_unitless_lateral/wheel_rear_right", 0.5},
-    {"slip_compliance_unitless_longitudinal", 0.6},
     {"slip_compliance_unitless_longitudinal/wheel_rear_left", 0.4},
     {"slip_compliance_unitless_longitudinal/wheel_rear_right", 0.6}};
 


### PR DESCRIPTION
Do not rely on the parameter_events topic for initialization.
Otherwise, it's easy to race with other nodes that want to query or update the wheel slip parameters.

This commit changes the behavior of the parameters affecting all wheels.
These parameters are no longer initialized if a user does not provide a value, i.e. they are
'unset' until a value is set. Previously, they defaulted to the value set on an individual wheel.

For purposes of initializing values, parameters setting individual wheels now have higher precendence
than the parameters for all wheels.

I also bumped the number of retries (timeout) in the tests, since I noticed a larger delay with certain
RMWs (ie. rmw_connextdds).
