### PR TITLE
gazebo_ros: Add inline keyword to template definitions

### DIFF
--- a/gazebo_ros/include/gazebo_ros/conversions/builtin_interfaces.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/builtin_interfaces.hpp
@@ -27,7 +27,8 @@ namespace gazebo_ros
 /// \brief Specialized conversion from an Gazebo Time to a ROS Time message.
 /// \param[in] in Gazebo Time to convert.
 /// \return A ROS Time message with the same value as in
-template<> inline
+template<>
+inline
 builtin_interfaces::msg::Time Convert(const gazebo::common::Time & in)
 {
   builtin_interfaces::msg::Time time;
@@ -39,7 +40,8 @@ builtin_interfaces::msg::Time Convert(const gazebo::common::Time & in)
 /// \brief Specialized conversion from an Gazebo Time message to a ROS Time message.
 /// \param[in] in Gazebo Time message to convert.
 /// \return A ROS Time message with the same value as in
-template<> inline
+template<>
+inline
 builtin_interfaces::msg::Time Convert(const gazebo::msgs::Time & in)
 {
   builtin_interfaces::msg::Time time;
@@ -52,7 +54,8 @@ builtin_interfaces::msg::Time Convert(const gazebo::msgs::Time & in)
 /// \param[in] in Input message.
 /// \return Conversion result
 /// \tparam T Output type
-template<class T> inline
+template<class T>
+inline
 T Convert(const builtin_interfaces::msg::Time &)
 {
   T::ConversionNotImplemented;
@@ -61,7 +64,8 @@ T Convert(const builtin_interfaces::msg::Time &)
 /// \brief Specialized conversion from a ROS Time message to a Gazebo Time.
 /// \param[in] in ROS Time message to convert.
 /// \return A Gazebo Time with the same value as in
-template<> inline
+template<>
+inline
 gazebo::common::Time Convert(const builtin_interfaces::msg::Time & in)
 {
   gazebo::common::Time time;
@@ -74,7 +78,8 @@ gazebo::common::Time Convert(const builtin_interfaces::msg::Time & in)
 /// \param[in] in Input message.
 /// \return Conversion result
 /// \tparam T Output type
-template<class T> inline
+template<class T>
+inline
 T Convert(const builtin_interfaces::msg::Duration &)
 {
   T::ConversionNotImplemented;
@@ -83,7 +88,8 @@ T Convert(const builtin_interfaces::msg::Duration &)
 /// \brief Specialized conversion from a ROS duration message to a Gazebo Time.
 /// \param[in] in ROS Time message to convert.
 /// \return A Gazebo Time with the same value as in
-template<> inline
+template<>
+inline
 gazebo::common::Time Convert(const builtin_interfaces::msg::Duration & in)
 {
   gazebo::common::Time time;

--- a/gazebo_ros/include/gazebo_ros/conversions/builtin_interfaces.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/builtin_interfaces.hpp
@@ -27,7 +27,7 @@ namespace gazebo_ros
 /// \brief Specialized conversion from an Gazebo Time to a ROS Time message.
 /// \param[in] in Gazebo Time to convert.
 /// \return A ROS Time message with the same value as in
-template<>
+template<> inline
 builtin_interfaces::msg::Time Convert(const gazebo::common::Time & in)
 {
   builtin_interfaces::msg::Time time;
@@ -39,7 +39,7 @@ builtin_interfaces::msg::Time Convert(const gazebo::common::Time & in)
 /// \brief Specialized conversion from an Gazebo Time message to a ROS Time message.
 /// \param[in] in Gazebo Time message to convert.
 /// \return A ROS Time message with the same value as in
-template<>
+template<> inline
 builtin_interfaces::msg::Time Convert(const gazebo::msgs::Time & in)
 {
   builtin_interfaces::msg::Time time;
@@ -52,7 +52,7 @@ builtin_interfaces::msg::Time Convert(const gazebo::msgs::Time & in)
 /// \param[in] in Input message.
 /// \return Conversion result
 /// \tparam T Output type
-template<class T>
+template<class T> inline
 T Convert(const builtin_interfaces::msg::Time &)
 {
   T::ConversionNotImplemented;
@@ -61,7 +61,7 @@ T Convert(const builtin_interfaces::msg::Time &)
 /// \brief Specialized conversion from a ROS Time message to a Gazebo Time.
 /// \param[in] in ROS Time message to convert.
 /// \return A Gazebo Time with the same value as in
-template<>
+template<> inline
 gazebo::common::Time Convert(const builtin_interfaces::msg::Time & in)
 {
   gazebo::common::Time time;
@@ -74,7 +74,7 @@ gazebo::common::Time Convert(const builtin_interfaces::msg::Time & in)
 /// \param[in] in Input message.
 /// \return Conversion result
 /// \tparam T Output type
-template<class T>
+template<class T> inline
 T Convert(const builtin_interfaces::msg::Duration &)
 {
   T::ConversionNotImplemented;
@@ -83,7 +83,7 @@ T Convert(const builtin_interfaces::msg::Duration &)
 /// \brief Specialized conversion from a ROS duration message to a Gazebo Time.
 /// \param[in] in ROS Time message to convert.
 /// \return A Gazebo Time with the same value as in
-template<>
+template<> inline
 gazebo::common::Time Convert(const builtin_interfaces::msg::Duration & in)
 {
   gazebo::common::Time time;

--- a/gazebo_ros/include/gazebo_ros/conversions/gazebo_msgs.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/gazebo_msgs.hpp
@@ -31,7 +31,7 @@ namespace gazebo_ros
 /// \param[in] in Input message;
 /// \return Conversion result
 /// \tparam T Output type
-template<class T>
+template<class T> inline
 T Convert(const gazebo::msgs::Contacts &)
 {
   T::ConversionNotImplemented;
@@ -40,7 +40,7 @@ T Convert(const gazebo::msgs::Contacts &)
 /// \brief Specialized conversion from an Gazebo message to a ROS Contacts State.
 /// \param[in] in Input message;
 /// \return A ROS Contacts state message with the same data as the input message
-template<>
+template<> inline
 gazebo_msgs::msg::ContactsState Convert(const gazebo::msgs::Contacts & in)
 {
   gazebo_msgs::msg::ContactsState contact_state_msg;

--- a/gazebo_ros/include/gazebo_ros/conversions/gazebo_msgs.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/gazebo_msgs.hpp
@@ -31,7 +31,8 @@ namespace gazebo_ros
 /// \param[in] in Input message;
 /// \return Conversion result
 /// \tparam T Output type
-template<class T> inline
+template<class T>
+inline
 T Convert(const gazebo::msgs::Contacts &)
 {
   T::ConversionNotImplemented;
@@ -40,7 +41,8 @@ T Convert(const gazebo::msgs::Contacts &)
 /// \brief Specialized conversion from an Gazebo message to a ROS Contacts State.
 /// \param[in] in Input message;
 /// \return A ROS Contacts state message with the same data as the input message
-template<> inline
+template<>
+inline
 gazebo_msgs::msg::ContactsState Convert(const gazebo::msgs::Contacts & in)
 {
   gazebo_msgs::msg::ContactsState contact_state_msg;

--- a/gazebo_ros/include/gazebo_ros/conversions/generic.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/generic.hpp
@@ -34,7 +34,8 @@ static rclcpp::Logger conversions_logger = rclcpp::get_logger("gazebo_ros_conver
 /// \param[in] in Input vector.
 /// \return Conversion result
 /// \tparam T Output type
-template<class T> inline
+template<class T>
+inline
 T Convert(const ignition::math::Vector3d &)
 {
   T::ConversionNotImplemented;
@@ -44,7 +45,8 @@ T Convert(const ignition::math::Vector3d &)
 /// \param[in] in Input quaternion
 /// \return Conversion result
 /// \tparam T Output type
-template<class T> inline
+template<class T>
+inline
 T Convert(const ignition::math::Quaterniond &)
 {
   T::ConversionNotImplemented;
@@ -54,7 +56,8 @@ T Convert(const ignition::math::Quaterniond &)
 /// \param[in] in Input pose3d
 /// \return Conversion result
 /// \tparam T Output type
-template<class T> inline
+template<class T>
+inline
 T Convert(const ignition::math::Pose3d &)
 {
   T::ConversionNotImplemented;
@@ -64,7 +67,8 @@ T Convert(const ignition::math::Pose3d &)
 /// \param[in] in Input time;
 /// \return Conversion result
 /// \tparam T Output type
-template<class T> inline
+template<class T>
+inline
 T Convert(const gazebo::common::Time &)
 {
   T::ConversionNotImplemented;
@@ -73,7 +77,8 @@ T Convert(const gazebo::common::Time &)
 /// \brief Specialized conversion from an Gazebo Time to a RCLCPP Time.
 /// \param[in] in Gazebo Time to convert.
 /// \return A rclcpp::Time object with the same value as in
-template<> inline
+template<>
+inline
 rclcpp::Time Convert(const gazebo::common::Time & in)
 {
   return rclcpp::Time(in.sec, in.nsec, rcl_clock_type_t::RCL_ROS_TIME);
@@ -83,7 +88,8 @@ rclcpp::Time Convert(const gazebo::common::Time & in)
 /// \param[in] in Input time
 /// \return Conversion result
 /// \tparam T Output type
-template<class T> inline
+template<class T>
+inline
 T Convert(const gazebo::msgs::Time &)
 {
   T::ConversionNotImplemented;

--- a/gazebo_ros/include/gazebo_ros/conversions/generic.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/generic.hpp
@@ -34,7 +34,7 @@ static rclcpp::Logger conversions_logger = rclcpp::get_logger("gazebo_ros_conver
 /// \param[in] in Input vector.
 /// \return Conversion result
 /// \tparam T Output type
-template<class T>
+template<class T> inline
 T Convert(const ignition::math::Vector3d &)
 {
   T::ConversionNotImplemented;
@@ -44,7 +44,7 @@ T Convert(const ignition::math::Vector3d &)
 /// \param[in] in Input quaternion
 /// \return Conversion result
 /// \tparam T Output type
-template<class T>
+template<class T> inline
 T Convert(const ignition::math::Quaterniond &)
 {
   T::ConversionNotImplemented;
@@ -54,7 +54,7 @@ T Convert(const ignition::math::Quaterniond &)
 /// \param[in] in Input pose3d
 /// \return Conversion result
 /// \tparam T Output type
-template<class T>
+template<class T> inline
 T Convert(const ignition::math::Pose3d &)
 {
   T::ConversionNotImplemented;
@@ -64,7 +64,7 @@ T Convert(const ignition::math::Pose3d &)
 /// \param[in] in Input time;
 /// \return Conversion result
 /// \tparam T Output type
-template<class T>
+template<class T> inline
 T Convert(const gazebo::common::Time &)
 {
   T::ConversionNotImplemented;
@@ -73,7 +73,7 @@ T Convert(const gazebo::common::Time &)
 /// \brief Specialized conversion from an Gazebo Time to a RCLCPP Time.
 /// \param[in] in Gazebo Time to convert.
 /// \return A rclcpp::Time object with the same value as in
-template<>
+template<> inline
 rclcpp::Time Convert(const gazebo::common::Time & in)
 {
   return rclcpp::Time(in.sec, in.nsec, rcl_clock_type_t::RCL_ROS_TIME);
@@ -83,7 +83,7 @@ rclcpp::Time Convert(const gazebo::common::Time & in)
 /// \param[in] in Input time
 /// \return Conversion result
 /// \tparam T Output type
-template<class T>
+template<class T> inline
 T Convert(const gazebo::msgs::Time &)
 {
   T::ConversionNotImplemented;

--- a/gazebo_ros/include/gazebo_ros/conversions/geometry_msgs.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/geometry_msgs.hpp
@@ -34,7 +34,8 @@ namespace gazebo_ros
 /// \param[in] in Input message.
 /// \return Conversion result
 /// \tparam T Output type
-template<class T> inline
+template<class T>
+inline
 T Convert(const geometry_msgs::msg::Vector3 &)
 {
   T::ConversionNotImplemented;
@@ -43,7 +44,8 @@ T Convert(const geometry_msgs::msg::Vector3 &)
 /// \brief Specialized conversion from a ROS vector message to an Ignition Math vector.
 /// \param[in] msg ROS message to convert.
 /// \return An Ignition Math vector.
-template<> inline
+template<>
+inline
 ignition::math::Vector3d Convert(const geometry_msgs::msg::Vector3 & msg)
 {
   ignition::math::Vector3d vec;
@@ -57,7 +59,8 @@ ignition::math::Vector3d Convert(const geometry_msgs::msg::Vector3 & msg)
 /// \param[in] in Input message.
 /// \return Conversion result
 /// \tparam T Output type
-template<class T> inline
+template<class T>
+inline
 T Convert(const geometry_msgs::msg::Point32 &)
 {
   T::ConversionNotImplemented;
@@ -66,7 +69,8 @@ T Convert(const geometry_msgs::msg::Point32 &)
 /// \brief Specialized conversion from a ROS point32 message to an Ignition Math vector.
 /// \param[in] in ROS message to convert.
 /// \return An Ignition Math vector.
-template<> inline
+template<>
+inline
 ignition::math::Vector3d Convert(const geometry_msgs::msg::Point32 & in)
 {
   ignition::math::Vector3d vec;
@@ -80,7 +84,8 @@ ignition::math::Vector3d Convert(const geometry_msgs::msg::Point32 & in)
 /// \param[in] in Input message.
 /// \return Conversion result
 /// \tparam T Output type
-template<class T> inline
+template<class T>
+inline
 T Convert(const geometry_msgs::msg::Point &)
 {
   T::ConversionNotImplemented;
@@ -90,7 +95,8 @@ T Convert(const geometry_msgs::msg::Point &)
 /// \brief Specialized conversion from a ROS point message to a ROS vector message.
 /// \param[in] in ROS message to convert.
 /// \return A ROS vector message.
-template<> inline
+template<>
+inline
 geometry_msgs::msg::Vector3 Convert(const geometry_msgs::msg::Point & in)
 {
   geometry_msgs::msg::Vector3 msg;
@@ -103,7 +109,8 @@ geometry_msgs::msg::Vector3 Convert(const geometry_msgs::msg::Point & in)
 /// \brief Specialized conversion from a ROS point message to an Ignition math vector.
 /// \param[in] in ROS message to convert.
 /// \return A ROS vector message.
-template<> inline
+template<>
+inline
 ignition::math::Vector3d Convert(const geometry_msgs::msg::Point & in)
 {
   ignition::math::Vector3d out;
@@ -116,7 +123,8 @@ ignition::math::Vector3d Convert(const geometry_msgs::msg::Point & in)
 /// \brief Specialized conversion from an Ignition Math vector to a ROS message.
 /// \param[in] vec Ignition vector to convert.
 /// \return ROS geometry vector message
-template<> inline
+template<>
+inline
 geometry_msgs::msg::Vector3 Convert(const ignition::math::Vector3d & vec)
 {
   geometry_msgs::msg::Vector3 msg;
@@ -129,7 +137,8 @@ geometry_msgs::msg::Vector3 Convert(const ignition::math::Vector3d & vec)
 /// \brief Specialized conversion from an Ignition Math vector to a ROS message.
 /// \param[in] vec Ignition vector to convert.
 /// \return ROS geometry point message
-template<> inline
+template<>
+inline
 geometry_msgs::msg::Point Convert(const ignition::math::Vector3d & vec)
 {
   geometry_msgs::msg::Point msg;
@@ -142,7 +151,8 @@ geometry_msgs::msg::Point Convert(const ignition::math::Vector3d & vec)
 /// \brief Specialized conversion from an Ignition Math Quaternion to a ROS message.
 /// \param[in] in Ignition Quaternion to convert.
 /// \return ROS geometry quaternion message
-template<> inline
+template<>
+inline
 geometry_msgs::msg::Quaternion Convert(const ignition::math::Quaterniond & in)
 {
   geometry_msgs::msg::Quaternion msg;
@@ -156,7 +166,8 @@ geometry_msgs::msg::Quaternion Convert(const ignition::math::Quaterniond & in)
 /// \brief Specialized conversion from an Ignition Math Pose3d to a ROS geometry transform message.
 /// \param[in] in Ignition Pose3d to convert.
 /// \return ROS geometry transform message
-template<> inline
+template<>
+inline
 geometry_msgs::msg::Transform Convert(const ignition::math::Pose3d & in)
 {
   geometry_msgs::msg::Transform msg;
@@ -168,7 +179,8 @@ geometry_msgs::msg::Transform Convert(const ignition::math::Pose3d & in)
 /// \brief Specialized conversion from an Ignition Math Pose3d to a ROS geometry pose message.
 /// \param[in] in Ignition Pose3d to convert.
 /// \return ROS geometry pose message
-template<> inline
+template<>
+inline
 geometry_msgs::msg::Pose Convert(const ignition::math::Pose3d & in)
 {
   geometry_msgs::msg::Pose msg;
@@ -181,7 +193,8 @@ geometry_msgs::msg::Pose Convert(const ignition::math::Pose3d & in)
 /// \param[in] in Input quaternion
 /// \return Conversion result
 /// \tparam T Output type
-template<class T> inline
+template<class T>
+inline
 T Convert(const geometry_msgs::msg::Quaternion &)
 {
   T::ConversionNotImplemented;
@@ -190,7 +203,8 @@ T Convert(const geometry_msgs::msg::Quaternion &)
 /// \brief Specialized conversion from a ROS quaternion message to ignition quaternion
 /// \param[in] in Input quaternion message
 /// \return Ignition math quaternion with same values as the input message
-template<> inline
+template<>
+inline
 ignition::math::Quaterniond Convert(const geometry_msgs::msg::Quaternion & in)
 {
   return ignition::math::Quaterniond(in.w, in.x, in.y, in.z);
@@ -200,7 +214,8 @@ ignition::math::Quaterniond Convert(const geometry_msgs::msg::Quaternion & in)
 /// \param[in] in Input message.
 /// \return Conversion result
 /// \tparam T Output type
-template<class T> inline
+template<class T>
+inline
 T Convert(const geometry_msgs::msg::Transform &)
 {
   T::ConversionNotImplemented;
@@ -209,7 +224,8 @@ T Convert(const geometry_msgs::msg::Transform &)
 /// \brief Specialized conversion from a ROS geometry transform message to an Ignition math pose3d.
 /// \param[in] in ROS message to convert.
 /// \return A Ignition Math pose3d.
-template<> inline
+template<>
+inline
 ignition::math::Pose3d Convert(const geometry_msgs::msg::Transform & in)
 {
   ignition::math::Pose3d msg;
@@ -222,7 +238,8 @@ ignition::math::Pose3d Convert(const geometry_msgs::msg::Transform & in)
 /// \param[in] in Input message.
 /// \return Conversion result
 /// \tparam T Output type
-template<class T> inline
+template<class T>
+inline
 T Convert(const geometry_msgs::msg::Pose &)
 {
   T::ConversionNotImplemented;
@@ -231,7 +248,8 @@ T Convert(const geometry_msgs::msg::Pose &)
 /// \brief Specialized conversion from a ROS pose message to a ROS geometry transform message.
 /// \param[in] in ROS pose message to convert.
 /// \return A ROS geometry transform message.
-template<> inline
+template<>
+inline
 geometry_msgs::msg::Transform Convert(const geometry_msgs::msg::Pose & in)
 {
   geometry_msgs::msg::Transform msg;
@@ -243,7 +261,8 @@ geometry_msgs::msg::Transform Convert(const geometry_msgs::msg::Pose & in)
 /// \brief Specialized conversion from a ROS pose message to an Ignition Math pose.
 /// \param[in] in ROS pose message to convert.
 /// \return Ignition Math pose.
-template<> inline
+template<>
+inline
 ignition::math::Pose3d Convert(const geometry_msgs::msg::Pose & in)
 {
   return {Convert<ignition::math::Vector3d>(in.position),

--- a/gazebo_ros/include/gazebo_ros/conversions/geometry_msgs.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/geometry_msgs.hpp
@@ -34,7 +34,7 @@ namespace gazebo_ros
 /// \param[in] in Input message.
 /// \return Conversion result
 /// \tparam T Output type
-template<class T>
+template<class T> inline
 T Convert(const geometry_msgs::msg::Vector3 &)
 {
   T::ConversionNotImplemented;
@@ -43,7 +43,7 @@ T Convert(const geometry_msgs::msg::Vector3 &)
 /// \brief Specialized conversion from a ROS vector message to an Ignition Math vector.
 /// \param[in] msg ROS message to convert.
 /// \return An Ignition Math vector.
-template<>
+template<> inline
 ignition::math::Vector3d Convert(const geometry_msgs::msg::Vector3 & msg)
 {
   ignition::math::Vector3d vec;
@@ -57,7 +57,7 @@ ignition::math::Vector3d Convert(const geometry_msgs::msg::Vector3 & msg)
 /// \param[in] in Input message.
 /// \return Conversion result
 /// \tparam T Output type
-template<class T>
+template<class T> inline
 T Convert(const geometry_msgs::msg::Point32 &)
 {
   T::ConversionNotImplemented;
@@ -66,7 +66,7 @@ T Convert(const geometry_msgs::msg::Point32 &)
 /// \brief Specialized conversion from a ROS point32 message to an Ignition Math vector.
 /// \param[in] in ROS message to convert.
 /// \return An Ignition Math vector.
-template<>
+template<> inline
 ignition::math::Vector3d Convert(const geometry_msgs::msg::Point32 & in)
 {
   ignition::math::Vector3d vec;
@@ -80,7 +80,7 @@ ignition::math::Vector3d Convert(const geometry_msgs::msg::Point32 & in)
 /// \param[in] in Input message.
 /// \return Conversion result
 /// \tparam T Output type
-template<class T>
+template<class T> inline
 T Convert(const geometry_msgs::msg::Point &)
 {
   T::ConversionNotImplemented;
@@ -90,7 +90,7 @@ T Convert(const geometry_msgs::msg::Point &)
 /// \brief Specialized conversion from a ROS point message to a ROS vector message.
 /// \param[in] in ROS message to convert.
 /// \return A ROS vector message.
-template<>
+template<> inline
 geometry_msgs::msg::Vector3 Convert(const geometry_msgs::msg::Point & in)
 {
   geometry_msgs::msg::Vector3 msg;
@@ -103,7 +103,7 @@ geometry_msgs::msg::Vector3 Convert(const geometry_msgs::msg::Point & in)
 /// \brief Specialized conversion from a ROS point message to an Ignition math vector.
 /// \param[in] in ROS message to convert.
 /// \return A ROS vector message.
-template<>
+template<> inline
 ignition::math::Vector3d Convert(const geometry_msgs::msg::Point & in)
 {
   ignition::math::Vector3d out;
@@ -116,7 +116,7 @@ ignition::math::Vector3d Convert(const geometry_msgs::msg::Point & in)
 /// \brief Specialized conversion from an Ignition Math vector to a ROS message.
 /// \param[in] vec Ignition vector to convert.
 /// \return ROS geometry vector message
-template<>
+template<> inline
 geometry_msgs::msg::Vector3 Convert(const ignition::math::Vector3d & vec)
 {
   geometry_msgs::msg::Vector3 msg;
@@ -129,7 +129,7 @@ geometry_msgs::msg::Vector3 Convert(const ignition::math::Vector3d & vec)
 /// \brief Specialized conversion from an Ignition Math vector to a ROS message.
 /// \param[in] vec Ignition vector to convert.
 /// \return ROS geometry point message
-template<>
+template<> inline
 geometry_msgs::msg::Point Convert(const ignition::math::Vector3d & vec)
 {
   geometry_msgs::msg::Point msg;
@@ -142,7 +142,7 @@ geometry_msgs::msg::Point Convert(const ignition::math::Vector3d & vec)
 /// \brief Specialized conversion from an Ignition Math Quaternion to a ROS message.
 /// \param[in] in Ignition Quaternion to convert.
 /// \return ROS geometry quaternion message
-template<>
+template<> inline
 geometry_msgs::msg::Quaternion Convert(const ignition::math::Quaterniond & in)
 {
   geometry_msgs::msg::Quaternion msg;
@@ -156,7 +156,7 @@ geometry_msgs::msg::Quaternion Convert(const ignition::math::Quaterniond & in)
 /// \brief Specialized conversion from an Ignition Math Pose3d to a ROS geometry transform message.
 /// \param[in] in Ignition Pose3d to convert.
 /// \return ROS geometry transform message
-template<>
+template<> inline
 geometry_msgs::msg::Transform Convert(const ignition::math::Pose3d & in)
 {
   geometry_msgs::msg::Transform msg;
@@ -168,7 +168,7 @@ geometry_msgs::msg::Transform Convert(const ignition::math::Pose3d & in)
 /// \brief Specialized conversion from an Ignition Math Pose3d to a ROS geometry pose message.
 /// \param[in] in Ignition Pose3d to convert.
 /// \return ROS geometry pose message
-template<>
+template<> inline
 geometry_msgs::msg::Pose Convert(const ignition::math::Pose3d & in)
 {
   geometry_msgs::msg::Pose msg;
@@ -181,7 +181,7 @@ geometry_msgs::msg::Pose Convert(const ignition::math::Pose3d & in)
 /// \param[in] in Input quaternion
 /// \return Conversion result
 /// \tparam T Output type
-template<class T>
+template<class T> inline
 T Convert(const geometry_msgs::msg::Quaternion &)
 {
   T::ConversionNotImplemented;
@@ -190,7 +190,7 @@ T Convert(const geometry_msgs::msg::Quaternion &)
 /// \brief Specialized conversion from a ROS quaternion message to ignition quaternion
 /// \param[in] in Input quaternion message
 /// \return Ignition math quaternion with same values as the input message
-template<>
+template<> inline
 ignition::math::Quaterniond Convert(const geometry_msgs::msg::Quaternion & in)
 {
   return ignition::math::Quaterniond(in.w, in.x, in.y, in.z);
@@ -200,7 +200,7 @@ ignition::math::Quaterniond Convert(const geometry_msgs::msg::Quaternion & in)
 /// \param[in] in Input message.
 /// \return Conversion result
 /// \tparam T Output type
-template<class T>
+template<class T> inline
 T Convert(const geometry_msgs::msg::Transform &)
 {
   T::ConversionNotImplemented;
@@ -209,7 +209,7 @@ T Convert(const geometry_msgs::msg::Transform &)
 /// \brief Specialized conversion from a ROS geometry transform message to an Ignition math pose3d.
 /// \param[in] in ROS message to convert.
 /// \return A Ignition Math pose3d.
-template<>
+template<> inline
 ignition::math::Pose3d Convert(const geometry_msgs::msg::Transform & in)
 {
   ignition::math::Pose3d msg;
@@ -222,7 +222,7 @@ ignition::math::Pose3d Convert(const geometry_msgs::msg::Transform & in)
 /// \param[in] in Input message.
 /// \return Conversion result
 /// \tparam T Output type
-template<class T>
+template<class T> inline
 T Convert(const geometry_msgs::msg::Pose &)
 {
   T::ConversionNotImplemented;
@@ -231,7 +231,7 @@ T Convert(const geometry_msgs::msg::Pose &)
 /// \brief Specialized conversion from a ROS pose message to a ROS geometry transform message.
 /// \param[in] in ROS pose message to convert.
 /// \return A ROS geometry transform message.
-template<>
+template<> inline
 geometry_msgs::msg::Transform Convert(const geometry_msgs::msg::Pose & in)
 {
   geometry_msgs::msg::Transform msg;
@@ -243,7 +243,7 @@ geometry_msgs::msg::Transform Convert(const geometry_msgs::msg::Pose & in)
 /// \brief Specialized conversion from a ROS pose message to an Ignition Math pose.
 /// \param[in] in ROS pose message to convert.
 /// \return Ignition Math pose.
-template<>
+template<> inline
 ignition::math::Pose3d Convert(const geometry_msgs::msg::Pose & in)
 {
   return {Convert<ignition::math::Vector3d>(in.position),

--- a/gazebo_ros/include/gazebo_ros/conversions/sensor_msgs.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/sensor_msgs.hpp
@@ -39,7 +39,8 @@ namespace gazebo_ros
 /// \param[in] min_intensity The minimum intensity value to clip the output intensities
 /// \return Conversion result
 /// \tparam T Output type
-template<class T> inline
+template<class T>
+inline
 T Convert(const gazebo::msgs::LaserScanStamped &, double min_intensity = 0.0)
 {
   (void)min_intensity;
@@ -52,7 +53,8 @@ T Convert(const gazebo::msgs::LaserScanStamped &, double min_intensity = 0.0)
 /// \return A ROS Laser Scan message with the same data as the input message
 /// \note If multiple vertical rays are present, the LaserScan will be the
 ///       horizontal scan in the center of the vertical range
-template<> inline
+template<>
+inline
 sensor_msgs::msg::LaserScan Convert(const gazebo::msgs::LaserScanStamped & in, double min_intensity)
 {
   sensor_msgs::msg::LaserScan ls;
@@ -94,7 +96,8 @@ sensor_msgs::msg::LaserScan Convert(const gazebo::msgs::LaserScanStamped & in, d
 /// \param[in] in Input message;
 /// \param[in] min_intensity The minimum intensity value to clip the output intensities
 /// \return A ROS PointCloud message with the same data as the input message
-template<> inline
+template<>
+inline
 sensor_msgs::msg::PointCloud Convert(
   const gazebo::msgs::LaserScanStamped & in,
   double min_intensity)
@@ -177,7 +180,8 @@ sensor_msgs::msg::PointCloud Convert(
 /// \param[in] in Input message;
 /// \param[in] min_intensity The minimum intensity value to clip the output intensities
 /// \return A ROS PointCloud2 message with the same data as the input message
-template<> inline
+template<>
+inline
 sensor_msgs::msg::PointCloud2 Convert(
   const gazebo::msgs::LaserScanStamped & in,
   double min_intensity)
@@ -282,7 +286,8 @@ sensor_msgs::msg::PointCloud2 Convert(
 /// \param[in] in Input message;
 /// \param[in] min_intensity Ignored.
 /// \return A ROS Range message with minimum range of the rays in the laser scan
-template<> inline
+template<>
+inline
 sensor_msgs::msg::Range Convert(const gazebo::msgs::LaserScanStamped & in, double min_intensity)
 {
   (void) min_intensity;

--- a/gazebo_ros/include/gazebo_ros/conversions/sensor_msgs.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/sensor_msgs.hpp
@@ -39,7 +39,7 @@ namespace gazebo_ros
 /// \param[in] min_intensity The minimum intensity value to clip the output intensities
 /// \return Conversion result
 /// \tparam T Output type
-template<class T>
+template<class T> inline
 T Convert(const gazebo::msgs::LaserScanStamped &, double min_intensity = 0.0)
 {
   (void)min_intensity;
@@ -52,7 +52,7 @@ T Convert(const gazebo::msgs::LaserScanStamped &, double min_intensity = 0.0)
 /// \return A ROS Laser Scan message with the same data as the input message
 /// \note If multiple vertical rays are present, the LaserScan will be the
 ///       horizontal scan in the center of the vertical range
-template<>
+template<> inline
 sensor_msgs::msg::LaserScan Convert(const gazebo::msgs::LaserScanStamped & in, double min_intensity)
 {
   sensor_msgs::msg::LaserScan ls;
@@ -94,7 +94,7 @@ sensor_msgs::msg::LaserScan Convert(const gazebo::msgs::LaserScanStamped & in, d
 /// \param[in] in Input message;
 /// \param[in] min_intensity The minimum intensity value to clip the output intensities
 /// \return A ROS PointCloud message with the same data as the input message
-template<>
+template<> inline
 sensor_msgs::msg::PointCloud Convert(
   const gazebo::msgs::LaserScanStamped & in,
   double min_intensity)
@@ -177,7 +177,7 @@ sensor_msgs::msg::PointCloud Convert(
 /// \param[in] in Input message;
 /// \param[in] min_intensity The minimum intensity value to clip the output intensities
 /// \return A ROS PointCloud2 message with the same data as the input message
-template<>
+template<> inline
 sensor_msgs::msg::PointCloud2 Convert(
   const gazebo::msgs::LaserScanStamped & in,
   double min_intensity)
@@ -282,7 +282,7 @@ sensor_msgs::msg::PointCloud2 Convert(
 /// \param[in] in Input message;
 /// \param[in] min_intensity Ignored.
 /// \return A ROS Range message with minimum range of the rays in the laser scan
-template<>
+template<> inline
 sensor_msgs::msg::Range Convert(const gazebo::msgs::LaserScanStamped & in, double min_intensity)
 {
   (void) min_intensity;


### PR DESCRIPTION
Hello maintainers, 

I recently ran into the issue that I was referencing some of these template definitions in multiple translation units. This would result in linker errors. Marking these inline should prevent others to run into the same issue as me.