### PR TITLE
[gazebo_plugins] fix: inverted diff angle calc to obtain the correct angle

### DIFF
--- a/gazebo_plugins/CMakeLists.txt
+++ b/gazebo_plugins/CMakeLists.txt
@@ -186,6 +186,7 @@ target_include_directories(gazebo_ros_gps_sensor PUBLIC include)
 ament_target_dependencies(gazebo_ros_gps_sensor
   "gazebo_ros"
   "sensor_msgs"
+  "geometry_msgs"
   "gazebo_dev"
 )
 ament_export_libraries(gazebo_ros_gps_sensor)

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_gps_sensor.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_gps_sensor.hpp
@@ -40,6 +40,7 @@ class GazeboRosGpsSensorPrivate;
           <!-- publish to /gps/data -->
           <namespace>/gps</namespace>
           <remapping>~/out:=data</remapping>
+          <remapping>~/vel:=velocity</remapping>
         </ros>
       </plugin>
     </sensor>

--- a/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
@@ -566,7 +566,7 @@ void GazeboRosTricycleDrivePrivate::MotorController(
     if (fabs(diff_angle) < max_steering_angle_tol_) {
       // we're withing angle tolerance
       applied_steering_speed = 0;
-    } else if (diff_angle < target_speed) {
+    } else if (diff_angle >= max_steering_angle_tol_) {
       // steer toward target angle
       applied_steering_speed = max_steering_speed_;
     } else {

--- a/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
+++ b/gazebo_plugins/src/gazebo_ros_tricycle_drive.cpp
@@ -559,7 +559,7 @@ void GazeboRosTricycleDrivePrivate::MotorController(
 
   // if max_steering_speed_ is > 0, use speed control, otherwise use position control
   // With position control, one cannot expect dynamics to work correctly.
-  double diff_angle = current_angle - target_angle;
+  double diff_angle = target_angle - current_angle;
   double applied_steering_speed = 0;
   if (max_steering_speed_ > 0) {
     // this means we will steer using steering speed

--- a/gazebo_plugins/test/test_gazebo_ros_gps_sensor.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_gps_sensor.cpp
@@ -17,10 +17,12 @@
 #include <gazebo_ros/testing_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
+#include <geometry_msgs/msg/vector3_stamped.hpp>
 
 #include <memory>
 
 #define tol 10e-4
+#define tol_vel 10e-3
 
 /// Tests the gazebo_ros_gps_sensor plugin
 class GazeboRosGpsSensorTest : public gazebo::ServerFixture
@@ -54,16 +56,25 @@ TEST_F(GazeboRosGpsSensorTest, GpsMessageCorrect)
     [&msg](sensor_msgs::msg::NavSatFix::SharedPtr _msg) {
       msg = _msg;
     });
+  geometry_msgs::msg::Vector3Stamped::SharedPtr msg_vel = nullptr;
+  auto sub_vel = node->create_subscription<geometry_msgs::msg::Vector3Stamped>(
+    "/gps/velocity", rclcpp::SensorDataQoS(),
+    [&msg_vel](geometry_msgs::msg::Vector3Stamped::SharedPtr _msg) {
+      msg_vel = _msg;
+    });
 
   world->Step(1);
   EXPECT_NEAR(0.0, box->WorldPose().Pos().X(), tol);
   EXPECT_NEAR(0.0, box->WorldPose().Pos().Y(), tol);
   EXPECT_NEAR(0.5, box->WorldPose().Pos().Z(), tol);
+  EXPECT_NEAR(0.0, box->WorldLinearVel().X(), tol_vel);
+  EXPECT_NEAR(0.0, box->WorldLinearVel().Y(), tol_vel);
+  EXPECT_NEAR(0.0, box->WorldLinearVel().Z(), tol_vel);
 
   // Step until a gps message will have been published
   int sleep{0};
   int max_sleep{1000};
-  while (sleep < max_sleep && nullptr == msg) {
+  while (sleep < max_sleep && (nullptr == msg || nullptr == msg_vel)) {
     world->Step(100);
     rclcpp::spin_some(node);
     gazebo::common::Time::MSleep(100);
@@ -72,22 +83,30 @@ TEST_F(GazeboRosGpsSensorTest, GpsMessageCorrect)
   EXPECT_LT(0u, sub->get_publisher_count());
   EXPECT_LT(sleep, max_sleep);
   ASSERT_NE(nullptr, msg);
+  ASSERT_NE(nullptr, msg_vel);
 
   // Get the initial gps output when the box is at rest
   auto pre_movement_msg = std::make_shared<sensor_msgs::msg::NavSatFix>(*msg);
+  auto pre_movement_msg_vel = std::make_shared<geometry_msgs::msg::Vector3Stamped>(*msg_vel);
   ASSERT_NE(nullptr, pre_movement_msg);
   EXPECT_NEAR(0.0, pre_movement_msg->latitude, tol);
   EXPECT_NEAR(0.0, pre_movement_msg->longitude, tol);
   EXPECT_NEAR(0.5, pre_movement_msg->altitude, tol);
+  EXPECT_NEAR(0.0, pre_movement_msg_vel->vector.x, tol_vel);
+  EXPECT_NEAR(0.0, pre_movement_msg_vel->vector.y, tol_vel);
+  EXPECT_NEAR(0.0, pre_movement_msg_vel->vector.z, tol_vel);
 
-  // Change the position of the link and step a few times to wait the ros message to be received
+  // Change the position and velocity of the link
+  // and step a few times to wait the ros message to be received
   msg = nullptr;
+  msg_vel = nullptr;
   ignition::math::Pose3d box_pose;
   box_pose.Pos() = {100.0, 200.0, 300.0};
   link->SetWorldPose(box_pose);
+  link->SetLinearVel({15.0, 10.0, 0.0});
 
   sleep = 0;
-  while (sleep < max_sleep && (nullptr == msg || msg->altitude < 150)) {
+  while (sleep < max_sleep && (nullptr == msg || msg->altitude < 150 || nullptr == msg_vel)) {
     world->Step(50);
     rclcpp::spin_some(node);
     gazebo::common::Time::MSleep(100);
@@ -96,10 +115,15 @@ TEST_F(GazeboRosGpsSensorTest, GpsMessageCorrect)
 
   // Check that GPS output reflects the position change
   auto post_movement_msg = std::make_shared<sensor_msgs::msg::NavSatFix>(*msg);
+  auto post_movement_msg_vel = std::make_shared<geometry_msgs::msg::Vector3Stamped>(*msg_vel);
   ASSERT_NE(nullptr, post_movement_msg);
+  ASSERT_NE(nullptr, post_movement_msg_vel);
   EXPECT_GT(post_movement_msg->latitude, 0.0);
   EXPECT_GT(post_movement_msg->longitude, 0.0);
   EXPECT_NEAR(300, post_movement_msg->altitude, 1);
+  EXPECT_NEAR(15.0, post_movement_msg_vel->vector.x, tol_vel);
+  EXPECT_NEAR(10.0, post_movement_msg_vel->vector.y, tol_vel);
+  EXPECT_NEAR(0.0, post_movement_msg_vel->vector.z, 0.1);
 }
 
 int main(int argc, char ** argv)

--- a/gazebo_plugins/test/worlds/gazebo_ros_gps_sensor.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_gps_sensor.world
@@ -48,11 +48,26 @@
                 </noise>
               </vertical>
             </position_sensing>
+            <velocity_sensing>
+              <horizontal>
+                <noise type="gaussian">
+                  <mean>0.0</mean>
+                  <stddev>2e-4</stddev>
+                </noise>
+              </horizontal>
+              <vertical>
+                <noise type="gaussian">
+                  <mean>0.0</mean>
+                  <stddev>2e-4</stddev>
+                </noise>
+              </vertical>
+            </velocity_sensing>
           </gps>
           <plugin name="my_gps_plugin" filename="libgazebo_ros_gps_sensor.so">
             <ros>
               <namespace>/gps</namespace>
               <remapping>~/out:=data</remapping>
+              <remapping>~/vel:=velocity</remapping>
             </ros>
           </plugin>
         </sensor>

--- a/gazebo_ros/include/gazebo_ros/conversions/builtin_interfaces.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/builtin_interfaces.hpp
@@ -28,6 +28,7 @@ namespace gazebo_ros
 /// \param[in] in Gazebo Time to convert.
 /// \return A ROS Time message with the same value as in
 template<>
+inline
 builtin_interfaces::msg::Time Convert(const gazebo::common::Time & in)
 {
   builtin_interfaces::msg::Time time;
@@ -40,6 +41,7 @@ builtin_interfaces::msg::Time Convert(const gazebo::common::Time & in)
 /// \param[in] in Gazebo Time message to convert.
 /// \return A ROS Time message with the same value as in
 template<>
+inline
 builtin_interfaces::msg::Time Convert(const gazebo::msgs::Time & in)
 {
   builtin_interfaces::msg::Time time;
@@ -53,6 +55,7 @@ builtin_interfaces::msg::Time Convert(const gazebo::msgs::Time & in)
 /// \return Conversion result
 /// \tparam T Output type
 template<class T>
+inline
 T Convert(const builtin_interfaces::msg::Time &)
 {
   T::ConversionNotImplemented;
@@ -62,6 +65,7 @@ T Convert(const builtin_interfaces::msg::Time &)
 /// \param[in] in ROS Time message to convert.
 /// \return A Gazebo Time with the same value as in
 template<>
+inline
 gazebo::common::Time Convert(const builtin_interfaces::msg::Time & in)
 {
   gazebo::common::Time time;
@@ -75,6 +79,7 @@ gazebo::common::Time Convert(const builtin_interfaces::msg::Time & in)
 /// \return Conversion result
 /// \tparam T Output type
 template<class T>
+inline
 T Convert(const builtin_interfaces::msg::Duration &)
 {
   T::ConversionNotImplemented;
@@ -84,6 +89,7 @@ T Convert(const builtin_interfaces::msg::Duration &)
 /// \param[in] in ROS Time message to convert.
 /// \return A Gazebo Time with the same value as in
 template<>
+inline
 gazebo::common::Time Convert(const builtin_interfaces::msg::Duration & in)
 {
   gazebo::common::Time time;

--- a/gazebo_ros/include/gazebo_ros/conversions/gazebo_msgs.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/gazebo_msgs.hpp
@@ -32,6 +32,7 @@ namespace gazebo_ros
 /// \return Conversion result
 /// \tparam T Output type
 template<class T>
+inline
 T Convert(const gazebo::msgs::Contacts &)
 {
   T::ConversionNotImplemented;
@@ -41,6 +42,7 @@ T Convert(const gazebo::msgs::Contacts &)
 /// \param[in] in Input message;
 /// \return A ROS Contacts state message with the same data as the input message
 template<>
+inline
 gazebo_msgs::msg::ContactsState Convert(const gazebo::msgs::Contacts & in)
 {
   gazebo_msgs::msg::ContactsState contact_state_msg;

--- a/gazebo_ros/include/gazebo_ros/conversions/generic.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/generic.hpp
@@ -35,6 +35,7 @@ static rclcpp::Logger conversions_logger = rclcpp::get_logger("gazebo_ros_conver
 /// \return Conversion result
 /// \tparam T Output type
 template<class T>
+inline
 T Convert(const ignition::math::Vector3d &)
 {
   T::ConversionNotImplemented;
@@ -45,6 +46,7 @@ T Convert(const ignition::math::Vector3d &)
 /// \return Conversion result
 /// \tparam T Output type
 template<class T>
+inline
 T Convert(const ignition::math::Quaterniond &)
 {
   T::ConversionNotImplemented;
@@ -55,6 +57,7 @@ T Convert(const ignition::math::Quaterniond &)
 /// \return Conversion result
 /// \tparam T Output type
 template<class T>
+inline
 T Convert(const ignition::math::Pose3d &)
 {
   T::ConversionNotImplemented;
@@ -65,6 +68,7 @@ T Convert(const ignition::math::Pose3d &)
 /// \return Conversion result
 /// \tparam T Output type
 template<class T>
+inline
 T Convert(const gazebo::common::Time &)
 {
   T::ConversionNotImplemented;
@@ -74,6 +78,7 @@ T Convert(const gazebo::common::Time &)
 /// \param[in] in Gazebo Time to convert.
 /// \return A rclcpp::Time object with the same value as in
 template<>
+inline
 rclcpp::Time Convert(const gazebo::common::Time & in)
 {
   return rclcpp::Time(in.sec, in.nsec, rcl_clock_type_t::RCL_ROS_TIME);
@@ -84,6 +89,7 @@ rclcpp::Time Convert(const gazebo::common::Time & in)
 /// \return Conversion result
 /// \tparam T Output type
 template<class T>
+inline
 T Convert(const gazebo::msgs::Time &)
 {
   T::ConversionNotImplemented;

--- a/gazebo_ros/include/gazebo_ros/conversions/geometry_msgs.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/geometry_msgs.hpp
@@ -35,6 +35,7 @@ namespace gazebo_ros
 /// \return Conversion result
 /// \tparam T Output type
 template<class T>
+inline
 T Convert(const geometry_msgs::msg::Vector3 &)
 {
   T::ConversionNotImplemented;
@@ -44,6 +45,7 @@ T Convert(const geometry_msgs::msg::Vector3 &)
 /// \param[in] msg ROS message to convert.
 /// \return An Ignition Math vector.
 template<>
+inline
 ignition::math::Vector3d Convert(const geometry_msgs::msg::Vector3 & msg)
 {
   ignition::math::Vector3d vec;
@@ -58,6 +60,7 @@ ignition::math::Vector3d Convert(const geometry_msgs::msg::Vector3 & msg)
 /// \return Conversion result
 /// \tparam T Output type
 template<class T>
+inline
 T Convert(const geometry_msgs::msg::Point32 &)
 {
   T::ConversionNotImplemented;
@@ -67,6 +70,7 @@ T Convert(const geometry_msgs::msg::Point32 &)
 /// \param[in] in ROS message to convert.
 /// \return An Ignition Math vector.
 template<>
+inline
 ignition::math::Vector3d Convert(const geometry_msgs::msg::Point32 & in)
 {
   ignition::math::Vector3d vec;
@@ -81,6 +85,7 @@ ignition::math::Vector3d Convert(const geometry_msgs::msg::Point32 & in)
 /// \return Conversion result
 /// \tparam T Output type
 template<class T>
+inline
 T Convert(const geometry_msgs::msg::Point &)
 {
   T::ConversionNotImplemented;
@@ -91,6 +96,7 @@ T Convert(const geometry_msgs::msg::Point &)
 /// \param[in] in ROS message to convert.
 /// \return A ROS vector message.
 template<>
+inline
 geometry_msgs::msg::Vector3 Convert(const geometry_msgs::msg::Point & in)
 {
   geometry_msgs::msg::Vector3 msg;
@@ -104,6 +110,7 @@ geometry_msgs::msg::Vector3 Convert(const geometry_msgs::msg::Point & in)
 /// \param[in] in ROS message to convert.
 /// \return A ROS vector message.
 template<>
+inline
 ignition::math::Vector3d Convert(const geometry_msgs::msg::Point & in)
 {
   ignition::math::Vector3d out;
@@ -117,6 +124,7 @@ ignition::math::Vector3d Convert(const geometry_msgs::msg::Point & in)
 /// \param[in] vec Ignition vector to convert.
 /// \return ROS geometry vector message
 template<>
+inline
 geometry_msgs::msg::Vector3 Convert(const ignition::math::Vector3d & vec)
 {
   geometry_msgs::msg::Vector3 msg;
@@ -130,6 +138,7 @@ geometry_msgs::msg::Vector3 Convert(const ignition::math::Vector3d & vec)
 /// \param[in] vec Ignition vector to convert.
 /// \return ROS geometry point message
 template<>
+inline
 geometry_msgs::msg::Point Convert(const ignition::math::Vector3d & vec)
 {
   geometry_msgs::msg::Point msg;
@@ -143,6 +152,7 @@ geometry_msgs::msg::Point Convert(const ignition::math::Vector3d & vec)
 /// \param[in] in Ignition Quaternion to convert.
 /// \return ROS geometry quaternion message
 template<>
+inline
 geometry_msgs::msg::Quaternion Convert(const ignition::math::Quaterniond & in)
 {
   geometry_msgs::msg::Quaternion msg;
@@ -157,6 +167,7 @@ geometry_msgs::msg::Quaternion Convert(const ignition::math::Quaterniond & in)
 /// \param[in] in Ignition Pose3d to convert.
 /// \return ROS geometry transform message
 template<>
+inline
 geometry_msgs::msg::Transform Convert(const ignition::math::Pose3d & in)
 {
   geometry_msgs::msg::Transform msg;
@@ -169,6 +180,7 @@ geometry_msgs::msg::Transform Convert(const ignition::math::Pose3d & in)
 /// \param[in] in Ignition Pose3d to convert.
 /// \return ROS geometry pose message
 template<>
+inline
 geometry_msgs::msg::Pose Convert(const ignition::math::Pose3d & in)
 {
   geometry_msgs::msg::Pose msg;
@@ -182,6 +194,7 @@ geometry_msgs::msg::Pose Convert(const ignition::math::Pose3d & in)
 /// \return Conversion result
 /// \tparam T Output type
 template<class T>
+inline
 T Convert(const geometry_msgs::msg::Quaternion &)
 {
   T::ConversionNotImplemented;
@@ -191,6 +204,7 @@ T Convert(const geometry_msgs::msg::Quaternion &)
 /// \param[in] in Input quaternion message
 /// \return Ignition math quaternion with same values as the input message
 template<>
+inline
 ignition::math::Quaterniond Convert(const geometry_msgs::msg::Quaternion & in)
 {
   return ignition::math::Quaterniond(in.w, in.x, in.y, in.z);
@@ -201,6 +215,7 @@ ignition::math::Quaterniond Convert(const geometry_msgs::msg::Quaternion & in)
 /// \return Conversion result
 /// \tparam T Output type
 template<class T>
+inline
 T Convert(const geometry_msgs::msg::Transform &)
 {
   T::ConversionNotImplemented;
@@ -210,6 +225,7 @@ T Convert(const geometry_msgs::msg::Transform &)
 /// \param[in] in ROS message to convert.
 /// \return A Ignition Math pose3d.
 template<>
+inline
 ignition::math::Pose3d Convert(const geometry_msgs::msg::Transform & in)
 {
   ignition::math::Pose3d msg;
@@ -223,6 +239,7 @@ ignition::math::Pose3d Convert(const geometry_msgs::msg::Transform & in)
 /// \return Conversion result
 /// \tparam T Output type
 template<class T>
+inline
 T Convert(const geometry_msgs::msg::Pose &)
 {
   T::ConversionNotImplemented;
@@ -232,6 +249,7 @@ T Convert(const geometry_msgs::msg::Pose &)
 /// \param[in] in ROS pose message to convert.
 /// \return A ROS geometry transform message.
 template<>
+inline
 geometry_msgs::msg::Transform Convert(const geometry_msgs::msg::Pose & in)
 {
   geometry_msgs::msg::Transform msg;
@@ -244,6 +262,7 @@ geometry_msgs::msg::Transform Convert(const geometry_msgs::msg::Pose & in)
 /// \param[in] in ROS pose message to convert.
 /// \return Ignition Math pose.
 template<>
+inline
 ignition::math::Pose3d Convert(const geometry_msgs::msg::Pose & in)
 {
   return {Convert<ignition::math::Vector3d>(in.position),

--- a/gazebo_ros/include/gazebo_ros/conversions/sensor_msgs.hpp
+++ b/gazebo_ros/include/gazebo_ros/conversions/sensor_msgs.hpp
@@ -40,6 +40,7 @@ namespace gazebo_ros
 /// \return Conversion result
 /// \tparam T Output type
 template<class T>
+inline
 T Convert(const gazebo::msgs::LaserScanStamped &, double min_intensity = 0.0)
 {
   (void)min_intensity;
@@ -53,6 +54,7 @@ T Convert(const gazebo::msgs::LaserScanStamped &, double min_intensity = 0.0)
 /// \note If multiple vertical rays are present, the LaserScan will be the
 ///       horizontal scan in the center of the vertical range
 template<>
+inline
 sensor_msgs::msg::LaserScan Convert(const gazebo::msgs::LaserScanStamped & in, double min_intensity)
 {
   sensor_msgs::msg::LaserScan ls;
@@ -95,6 +97,7 @@ sensor_msgs::msg::LaserScan Convert(const gazebo::msgs::LaserScanStamped & in, d
 /// \param[in] min_intensity The minimum intensity value to clip the output intensities
 /// \return A ROS PointCloud message with the same data as the input message
 template<>
+inline
 sensor_msgs::msg::PointCloud Convert(
   const gazebo::msgs::LaserScanStamped & in,
   double min_intensity)
@@ -178,6 +181,7 @@ sensor_msgs::msg::PointCloud Convert(
 /// \param[in] min_intensity The minimum intensity value to clip the output intensities
 /// \return A ROS PointCloud2 message with the same data as the input message
 template<>
+inline
 sensor_msgs::msg::PointCloud2 Convert(
   const gazebo::msgs::LaserScanStamped & in,
   double min_intensity)
@@ -283,6 +287,7 @@ sensor_msgs::msg::PointCloud2 Convert(
 /// \param[in] min_intensity Ignored.
 /// \return A ROS Range message with minimum range of the rays in the laser scan
 template<>
+inline
 sensor_msgs::msg::Range Convert(const gazebo::msgs::LaserScanStamped & in, double min_intensity)
 {
   (void) min_intensity;

--- a/gazebo_ros/launch/gzclient.launch.py
+++ b/gazebo_ros/launch/gzclient.launch.py
@@ -29,13 +29,13 @@ from scripts import GazeboRosPaths
 
 
 def generate_launch_description():
-    cmd = [[
+    cmd = [
         'gzclient',
         _boolean_command('version'), ' ',
         _boolean_command('verbose'), ' ',
         _boolean_command('help'), ' ',
         LaunchConfiguration('extra_gazebo_args'),
-    ]]
+    ]
 
     model, plugin, media = GazeboRosPaths.get_paths()
 
@@ -99,7 +99,7 @@ def generate_launch_description():
             cmd=cmd,
             output='screen',
             additional_env=env,
-            shell=True,
+            shell=False,
             prefix=prefix,
             on_exit=Shutdown(),
             condition=IfCondition(LaunchConfiguration('gui_required')),
@@ -110,7 +110,7 @@ def generate_launch_description():
             cmd=cmd,
             output='screen',
             additional_env=env,
-            shell=True,
+            shell=False,
             prefix=prefix,
             condition=UnlessCondition(LaunchConfiguration('gui_required')),
         ),

--- a/gazebo_ros/launch/gzserver.launch.py
+++ b/gazebo_ros/launch/gzserver.launch.py
@@ -185,7 +185,7 @@ def generate_launch_description():
             cmd=cmd,
             output='screen',
             additional_env=env,
-            shell=True,
+            shell=False,
             prefix=prefix,
             on_exit=Shutdown(),
             condition=IfCondition(LaunchConfiguration('server_required')),
@@ -196,7 +196,7 @@ def generate_launch_description():
             cmd=cmd,
             output='screen',
             additional_env=env,
-            shell=True,
+            shell=False,
             prefix=prefix,
             condition=UnlessCondition(LaunchConfiguration('server_required')),
         ),
@@ -219,6 +219,7 @@ def _arg_command(arg):
 
 # Add gazebo_ros plugins if true
 def _plugin_command(arg):
-    cmd = ['"-s libgazebo_ros_', arg, '.so" if "true" == "', LaunchConfiguration(arg), '" else ""']
+    cmd = ['"-s', 'libgazebo_ros_', arg, '.so" if "true" == "',
+           LaunchConfiguration(arg), '" else ""']
     py_cmd = PythonExpression(cmd)
     return py_cmd


### PR DESCRIPTION
Hi, 

I'm using the gazebo ros tricycle for a while now. When I started, to use it, I realized that the math to obtain the difference between the current angle and the target angle was inverted. So when asking for the wheel to turn right it would turn left and also make it drive in the wrong way.

I fixed it in my branch but sometimes I need to compile the entire package to use this updated feature in new pcs. 

Therefore, I'm creating a PR with this fix to contribute and kindly ask you to add it to the next binary release. 

Thanks