### PR TITLE
Use shell=False in when launching gazebo

### DIFF
--- a/gazebo_ros/launch/gzclient.launch.py
+++ b/gazebo_ros/launch/gzclient.launch.py
@@ -29,13 +29,13 @@ from scripts import GazeboRosPaths
 
 
 def generate_launch_description():
-    cmd = [[
+    cmd = [
         'gzclient',
         _boolean_command('version'), ' ',
         _boolean_command('verbose'), ' ',
         _boolean_command('help'), ' ',
         LaunchConfiguration('extra_gazebo_args'),
-    ]]
+    ]
 
     model, plugin, media = GazeboRosPaths.get_paths()
 
@@ -99,7 +99,7 @@ def generate_launch_description():
             cmd=cmd,
             output='screen',
             additional_env=env,
-            shell=True,
+            shell=False,
             prefix=prefix,
             on_exit=Shutdown(),
             condition=IfCondition(LaunchConfiguration('gui_required')),
@@ -110,7 +110,7 @@ def generate_launch_description():
             cmd=cmd,
             output='screen',
             additional_env=env,
-            shell=True,
+            shell=False,
             prefix=prefix,
             condition=UnlessCondition(LaunchConfiguration('gui_required')),
         ),

--- a/gazebo_ros/launch/gzserver.launch.py
+++ b/gazebo_ros/launch/gzserver.launch.py
@@ -185,7 +185,7 @@ def generate_launch_description():
             cmd=cmd,
             output='screen',
             additional_env=env,
-            shell=True,
+            shell=False,
             prefix=prefix,
             on_exit=Shutdown(),
             condition=IfCondition(LaunchConfiguration('server_required')),
@@ -196,7 +196,7 @@ def generate_launch_description():
             cmd=cmd,
             output='screen',
             additional_env=env,
-            shell=True,
+            shell=False,
             prefix=prefix,
             condition=UnlessCondition(LaunchConfiguration('server_required')),
         ),
@@ -219,6 +219,7 @@ def _arg_command(arg):
 
 # Add gazebo_ros plugins if true
 def _plugin_command(arg):
-    cmd = ['"-s libgazebo_ros_', arg, '.so" if "true" == "', LaunchConfiguration(arg), '" else ""']
+    cmd = ['"-s', 'libgazebo_ros_', arg, '.so" if "true" == "',
+           LaunchConfiguration(arg), '" else ""']
     py_cmd = PythonExpression(cmd)
     return py_cmd


### PR DESCRIPTION
Backport of https://github.com/ros-simulation/gazebo_ros_pkgs/pull/1376

Fixes gazebo shutdown errors when using nested launch files.

Signed-off-by: Aditya <aditya050995@gmail.com>