### PR TITLE
Multiple nodes with same name issue

### DIFF
--- a/gazebo_ros/include/gazebo_ros/node.hpp
+++ b/gazebo_ros/include/gazebo_ros/node.hpp
@@ -27,6 +27,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <unordered_set>
 
 namespace gazebo_ros
 {

--- a/gazebo_ros/include/gazebo_ros/node.hpp
+++ b/gazebo_ros/include/gazebo_ros/node.hpp
@@ -87,9 +87,11 @@ public:
    * </plugin>
    * \endcode
    * \param[in] _sdf An SDF element in the style above or containing a <ros> tag in the style above
-   * \return A shared pointer to a new #gazebo_ros::Node
+   * \param[in] _node_name: An optional node_name to overwrite plugin name being used as node name.
+   * \return A shared pointer to a new #gazebo_ros::Node. A nullptr is returned in case multiple
+   * nodes have the same name resulting in a ROS error and gazebo crash.
    */
-  static SharedPtr Get(sdf::ElementPtr _sdf);
+  static SharedPtr Get(sdf::ElementPtr _sdf, std::string _node_name="");
 
   /// Create a #gazebo_ros::Node and add it to the global #gazebo_ros::Executor.
   /**

--- a/gazebo_ros/include/gazebo_ros/node.hpp
+++ b/gazebo_ros/include/gazebo_ros/node.hpp
@@ -88,8 +88,8 @@ public:
    * \endcode
    * \param[in] _sdf An SDF element in the style above or containing a <ros> tag in the style above
    * \param[in] _node_name: An optional node_name to overwrite plugin name being used as node name.
-   * \return A shared pointer to a new #gazebo_ros::Node. A nullptr is returned in case multiple
-   * nodes have the same name resulting in a ROS error and gazebo crash.
+   * \return A shared pointer to a new #gazebo_ros::Node. A nullptr is returned and an error message
+   * is logged in case multiple nodes have the same name.
    */
   static SharedPtr Get(sdf::ElementPtr _sdf, std::string _node_name = "");
 

--- a/gazebo_ros/include/gazebo_ros/node.hpp
+++ b/gazebo_ros/include/gazebo_ros/node.hpp
@@ -30,6 +30,9 @@
 
 namespace gazebo_ros
 {
+
+class NodeLookUp;
+
 /// ROS Node for gazebo plugins
 /**
  * \class Node node.hpp <gazebo_ros/node.hpp>
@@ -140,6 +143,9 @@ private:
   /// QoS for node entities
   gazebo_ros::QoS qos_;
 
+  /// ros node lookup
+  static NodeLookUp static_node_lookup_;
+
   /// Locks #initialized_ and #executor_
   static std::mutex lock_;
 
@@ -217,5 +223,20 @@ Node::SharedPtr Node::CreateWithArgs(Args && ... args)
 
   return node;
 }
+
+// Class to hold the global map of gazebo_ros::Node::SharedPtr objects
+class NodeLookUp{
+   public:
+    // Methods need to be protected by internal mutex
+    void add_node(const std::string& node_name, Node::SharedPtr ros_node);
+    Node::SharedPtr get_node(const std::string& node_name);
+    void remove_node(const std::string& node_name);
+
+ private:
+    /// map of node names vs objects
+    std::unordered_map<std::string, Node::SharedPtr> map_;
+    std::mutex internal_mutex_;
+};
+
 }  // namespace gazebo_ros
 #endif  // GAZEBO_ROS__NODE_HPP_

--- a/gazebo_ros/include/gazebo_ros/node.hpp
+++ b/gazebo_ros/include/gazebo_ros/node.hpp
@@ -31,8 +31,8 @@
 
 namespace gazebo_ros
 {
-// forward declare NodeLookUp
-class NodeLookUp;
+// forward declare ExistingNodes
+class ExistingNodes;
 
 /// ROS Node for gazebo plugins
 /**
@@ -145,7 +145,7 @@ private:
   gazebo_ros::QoS qos_;
 
   /// ros node lookup
-  static NodeLookUp static_node_lookup_;
+  static ExistingNodes static_node_lookup_;
 
   /// Locks #initialized_ and #executor_
   static std::mutex lock_;
@@ -226,12 +226,12 @@ Node::SharedPtr Node::CreateWithArgs(Args && ... args)
 }
 
 // Class to hold the global set of tracked node names.
-class NodeLookUp
+class ExistingNodes
 {
 public:
   // Methods need to be protected by internal mutex
   void add_node(const std::string & node_name);
-  bool is_node_name_in_set(const std::string & node_name);
+  bool check_node(const std::string & node_name);
   void remove_node(const std::string & node_name);
 
 private:

--- a/gazebo_ros/include/gazebo_ros/node.hpp
+++ b/gazebo_ros/include/gazebo_ros/node.hpp
@@ -225,17 +225,19 @@ Node::SharedPtr Node::CreateWithArgs(Args && ... args)
 }
 
 // Class to hold the global set of tracked node names.
-class NodeLookUp{
-   public:
-    // Methods need to be protected by internal mutex
-    void add_node(const std::string& node_name);
-    bool is_node_name_in_set(const std::string& node_name);
-    void remove_node(const std::string& node_name);
+class NodeLookUp
+{
+public:
+  // Methods need to be protected by internal mutex
+  void add_node(const std::string & node_name);
+  bool is_node_name_in_set(const std::string & node_name);
+  void remove_node(const std::string & node_name);
 
- private:
-    /// set of tracked node names
-    std::unordered_set<std::string> set_;
-    std::mutex internal_mutex_;
+private:
+  /// set of tracked node names
+  std::unordered_set<std::string> set_;
+  std::mutex internal_mutex_;
+
 };
 
 }  // namespace gazebo_ros

--- a/gazebo_ros/include/gazebo_ros/node.hpp
+++ b/gazebo_ros/include/gazebo_ros/node.hpp
@@ -239,6 +239,5 @@ private:
   std::unordered_set<std::string> set_;
   std::mutex internal_mutex_;
 };
-
 }  // namespace gazebo_ros
 #endif  // GAZEBO_ROS__NODE_HPP_

--- a/gazebo_ros/include/gazebo_ros/node.hpp
+++ b/gazebo_ros/include/gazebo_ros/node.hpp
@@ -238,7 +238,6 @@ private:
   /// set of tracked node names
   std::unordered_set<std::string> set_;
   std::mutex internal_mutex_;
-
 };
 
 }  // namespace gazebo_ros

--- a/gazebo_ros/include/gazebo_ros/node.hpp
+++ b/gazebo_ros/include/gazebo_ros/node.hpp
@@ -30,7 +30,7 @@
 
 namespace gazebo_ros
 {
-
+// forward declare NodeLookUp
 class NodeLookUp;
 
 /// ROS Node for gazebo plugins
@@ -230,6 +230,7 @@ class NodeLookUp{
     // Methods need to be protected by internal mutex
     void add_node(const std::string& node_name, Node::SharedPtr ros_node);
     Node::SharedPtr get_node(const std::string& node_name);
+    bool is_node_name_in_map(const std::string& node_name);
     void remove_node(const std::string& node_name);
 
  private:

--- a/gazebo_ros/include/gazebo_ros/node.hpp
+++ b/gazebo_ros/include/gazebo_ros/node.hpp
@@ -144,8 +144,8 @@ private:
   /// QoS for node entities
   gazebo_ros::QoS qos_;
 
-  /// ros node lookup
-  static ExistingNodes static_node_lookup_;
+  /// track of nodes already instantiated
+  static ExistingNodes static_existing_nodes_;
 
   /// Locks #initialized_ and #executor_
   static std::mutex lock_;

--- a/gazebo_ros/include/gazebo_ros/node.hpp
+++ b/gazebo_ros/include/gazebo_ros/node.hpp
@@ -224,18 +224,17 @@ Node::SharedPtr Node::CreateWithArgs(Args && ... args)
   return node;
 }
 
-// Class to hold the global map of gazebo_ros::Node::SharedPtr objects
+// Class to hold the global set of tracked node names.
 class NodeLookUp{
    public:
     // Methods need to be protected by internal mutex
-    void add_node(const std::string& node_name, Node::SharedPtr ros_node);
-    Node::SharedPtr get_node(const std::string& node_name);
-    bool is_node_name_in_map(const std::string& node_name);
+    void add_node(const std::string& node_name);
+    bool is_node_name_in_set(const std::string& node_name);
     void remove_node(const std::string& node_name);
 
  private:
-    /// map of node names vs objects
-    std::unordered_map<std::string, Node::SharedPtr> map_;
+    /// set of tracked node names
+    std::unordered_set<std::string> set_;
     std::mutex internal_mutex_;
 };
 

--- a/gazebo_ros/include/gazebo_ros/node.hpp
+++ b/gazebo_ros/include/gazebo_ros/node.hpp
@@ -91,7 +91,7 @@ public:
    * \return A shared pointer to a new #gazebo_ros::Node. A nullptr is returned in case multiple
    * nodes have the same name resulting in a ROS error and gazebo crash.
    */
-  static SharedPtr Get(sdf::ElementPtr _sdf, std::string _node_name="");
+  static SharedPtr Get(sdf::ElementPtr _sdf, std::string _node_name = "");
 
   /// Create a #gazebo_ros::Node and add it to the global #gazebo_ros::Executor.
   /**

--- a/gazebo_ros/src/node.cpp
+++ b/gazebo_ros/src/node.cpp
@@ -102,8 +102,13 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf)
       parameter_sdf = parameter_sdf->GetNextElement("parameter");
     }
   }
+
   // set full node name
-  full_name = ns + "/" + name;
+  if (ns[0] == '/' && ns.size() == 1) {
+    full_name = ns + name;
+  } else {
+    full_name = ns + "/" + name;
+  }
 
   // check if node with the same name exists already
   if (static_node_lookup_.is_node_name_in_set(full_name)) {
@@ -111,7 +116,7 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf)
       internal_logger(),
       "Found multiple nodes with same name: %s. This is due to different plugins with same name, "
       "either change the plugin name or use a unique namespace", full_name.c_str());
-    return nullptr;
+    return nullptr; // this makes the gazebo shutdown safely
   }
 
   rclcpp::NodeOptions node_options;

--- a/gazebo_ros/src/node.cpp
+++ b/gazebo_ros/src/node.cpp
@@ -111,7 +111,7 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf)
       internal_logger(),
       "Found multiple nodes with same name: %s. This is due to different plugins with same name, "
       "either change the plugin name or use a unique namespace", full_name.c_str());
-    // TODO(deepanshu): maybe throw here check with Aditya and Jacob
+    return nullptr;
   }
 
   rclcpp::NodeOptions node_options;

--- a/gazebo_ros/src/node.cpp
+++ b/gazebo_ros/src/node.cpp
@@ -38,7 +38,7 @@ Node::~Node()
   static_existing_nodes_.remove_node(this->get_fully_qualified_name());
 }
 
-Node::SharedPtr Node::Get(sdf::ElementPtr sdf)
+Node::SharedPtr Node::Get(sdf::ElementPtr sdf, std::string node_name)
 {
   // Initialize arguments
   std::string name = "";
@@ -51,7 +51,12 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf)
   if (!sdf->HasAttribute("name")) {
     RCLCPP_WARN(internal_logger(), "Name of plugin not found.");
   }
-  name = sdf->Get<std::string>("name");
+
+  if(!node_name.empty()){
+    name = node_name;
+  }else{
+    name = sdf->Get<std::string>("name");
+  }
 
   // Get inner <ros> element if full plugin sdf was passed in
   if (sdf->HasElement("ros")) {
@@ -115,10 +120,11 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf)
     RCLCPP_ERROR(
       internal_logger(),
       "Found multiple nodes with same name: %s. This might be due to multiple plugins using same "
-      "name to solve this either change one of the the plugin names or use a different namespace. "
-      "The error might also result from a custom plugin inheriting from one of the GazeboRosPlugin "
-      "this can be solved by accessing node object of the parent class itself instead of creating "
-      "a new node object for custom plugin.", full_name.c_str());
+      "name. Try changing one of the the plugin names or use a different ROS namespace. "
+      "This error might also result from a custom plugin inheriting from another gazebo_ros plugin "
+      "and the custom plugin trying to access the ROS node object, resulting in multiple nodes "
+      "with same name. To solve this try providing the optional node_name argument in "
+      "gazebo_ros::Node::Get() function. ", full_name.c_str());
     return nullptr;  // this makes the gazebo shutdown safely
   }
 

--- a/gazebo_ros/src/node.cpp
+++ b/gazebo_ros/src/node.cpp
@@ -119,7 +119,7 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf)
       "The error might also result from a custom plugin inheriting from one of the GazeboRosPlugin "
       "this can be solved by accessing node object of the parent class itself instead of creating "
       "a new node object for custom plugin.", full_name.c_str());
-    return nullptr; // this makes the gazebo shutdown safely
+    return nullptr;  // this makes the gazebo shutdown safely
   }
 
   rclcpp::NodeOptions node_options;

--- a/gazebo_ros/src/node.cpp
+++ b/gazebo_ros/src/node.cpp
@@ -110,7 +110,7 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf)
     RCLCPP_ERROR(
       internal_logger(),
       "Found multiple nodes with same name: %s. This is due to different plugins with same name, either change the plugin name"
-      "or use a unique namespace", full_name.c_str());
+      " or use a unique namespace", full_name.c_str());
     // TODO: maybe throw here check with Aditya and Jacob
   }
 

--- a/gazebo_ros/src/node.cpp
+++ b/gazebo_ros/src/node.cpp
@@ -106,12 +106,12 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf)
   full_name = ns + "/" + name;
 
   // check if node with the same name exists already
-  if(static_node_lookup_.is_node_name_in_set(full_name)){
+  if (static_node_lookup_.is_node_name_in_set(full_name)) {
     RCLCPP_ERROR(
-        internal_logger(),
-        "Found multiple nodes with same name: %s. This is due to different plugins with same name, either change the plugin name"
-        "or use a unique namespace", full_name.c_str());
-    // TODO: throw?
+      internal_logger(),
+      "Found multiple nodes with same name: %s. This is due to different plugins with same name, either change the plugin name"
+      "or use a unique namespace", full_name.c_str());
+    // TODO: maybe throw here check with Aditya and Jacob
   }
 
   rclcpp::NodeOptions node_options;
@@ -183,17 +183,20 @@ rclcpp::Logger Node::internal_logger()
   return rclcpp::get_logger("gazebo_ros_node");
 }
 
-void NodeLookUp::add_node(const std::string& node_name) {
+void NodeLookUp::add_node(const std::string & node_name)
+{
   std::lock_guard<std::mutex> guard(this->internal_mutex_);
   this->set_.insert(node_name);
 }
 
-void NodeLookUp::remove_node(const std::string& node_name) {
+void NodeLookUp::remove_node(const std::string & node_name)
+{
   std::lock_guard<std::mutex> guard(this->internal_mutex_);
   this->set_.erase(node_name);
 }
 
-bool NodeLookUp::is_node_name_in_set(const std::string &node_name) {
+bool NodeLookUp::is_node_name_in_set(const std::string & node_name)
+{
   std::lock_guard<std::mutex> guard(this->internal_mutex_);
   return this->set_.find(node_name) != this->set_.end();
 }

--- a/gazebo_ros/src/node.cpp
+++ b/gazebo_ros/src/node.cpp
@@ -52,9 +52,9 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf, std::string node_name)
     RCLCPP_WARN(internal_logger(), "Name of plugin not found.");
   }
 
-  if(!node_name.empty()){
+  if (!node_name.empty()) {
     name = node_name;
-  }else{
+  } else {
     name = sdf->Get<std::string>("name");
   }
 

--- a/gazebo_ros/src/node.cpp
+++ b/gazebo_ros/src/node.cpp
@@ -28,14 +28,14 @@ namespace gazebo_ros
 std::weak_ptr<Executor> Node::static_executor_;
 std::weak_ptr<Node> Node::static_node_;
 std::mutex Node::lock_;
-ExistingNodes Node::static_node_lookup_;
+ExistingNodes Node::static_existing_nodes_;
 
 Node::~Node()
 {
   executor_->remove_node(get_node_base_interface());
 
   // remove node object from global map
-  static_node_lookup_.remove_node(this->get_fully_qualified_name());
+  static_existing_nodes_.remove_node(this->get_fully_qualified_name());
 }
 
 Node::SharedPtr Node::Get(sdf::ElementPtr sdf)
@@ -111,7 +111,7 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf)
   }
 
   // check if node with the same name exists already
-  if (static_node_lookup_.check_node(full_name)) {
+  if (static_existing_nodes_.check_node(full_name)) {
     RCLCPP_ERROR(
       internal_logger(),
       "Found multiple nodes with same name: %s. This might be due to multiple plugins using same "
@@ -130,7 +130,7 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf)
   std::shared_ptr<gazebo_ros::Node> node = CreateWithArgs(name, ns, node_options);
 
   // Add node to global map
-  static_node_lookup_.add_node(full_name);
+  static_existing_nodes_.add_node(full_name);
 
   // Parse the qos tag
   node->qos_ = gazebo_ros::QoS(sdf, name, ns, node_options);

--- a/gazebo_ros/src/node.cpp
+++ b/gazebo_ros/src/node.cpp
@@ -119,13 +119,13 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf, std::string node_name)
   if (static_existing_nodes_.check_node(full_name)) {
     RCLCPP_ERROR(
       internal_logger(),
-      "Found multiple nodes with same name: %s. This might be due to multiple plugins using same "
-      "name. Try changing one of the the plugin names or use a different ROS namespace. "
+      "Found multiple nodes with same name: %s. This might be due to multiple plugins using the "
+      "same name. Try changing one of the the plugin names or use a different ROS namespace. "
       "This error might also result from a custom plugin inheriting from another gazebo_ros plugin "
       "and the custom plugin trying to access the ROS node object hence creating multiple nodes "
       "with same name. To solve this try providing the optional node_name argument in "
       "gazebo_ros::Node::Get() function. ", full_name.c_str());
-    return nullptr;  // this makes the gazebo shutdown safely
+    return nullptr;
   }
 
   rclcpp::NodeOptions node_options;

--- a/gazebo_ros/src/node.cpp
+++ b/gazebo_ros/src/node.cpp
@@ -109,9 +109,9 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf)
   if (static_node_lookup_.is_node_name_in_set(full_name)) {
     RCLCPP_ERROR(
       internal_logger(),
-      "Found multiple nodes with same name: %s. This is due to different plugins with same name, either change the plugin name"
-      " or use a unique namespace", full_name.c_str());
-    // TODO: maybe throw here check with Aditya and Jacob
+      "Found multiple nodes with same name: %s. This is due to different plugins with same name, "
+      "either change the plugin name or use a unique namespace", full_name.c_str());
+    // TODO(deepanshu): maybe throw here check with Aditya and Jacob
   }
 
   rclcpp::NodeOptions node_options;

--- a/gazebo_ros/src/node.cpp
+++ b/gazebo_ros/src/node.cpp
@@ -122,7 +122,7 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf, std::string node_name)
       "Found multiple nodes with same name: %s. This might be due to multiple plugins using same "
       "name. Try changing one of the the plugin names or use a different ROS namespace. "
       "This error might also result from a custom plugin inheriting from another gazebo_ros plugin "
-      "and the custom plugin trying to access the ROS node object, resulting in multiple nodes "
+      "and the custom plugin trying to access the ROS node object hence creating multiple nodes "
       "with same name. To solve this try providing the optional node_name argument in "
       "gazebo_ros::Node::Get() function. ", full_name.c_str());
     return nullptr;  // this makes the gazebo shutdown safely

--- a/gazebo_ros/test/CMakeLists.txt
+++ b/gazebo_ros/test/CMakeLists.txt
@@ -39,6 +39,7 @@ set(tests
   test_gazebo_ros_properties
   test_gazebo_ros_state
   test_node
+  test_node_lookup
   test_plugins
   test_qos
   test_sim_time

--- a/gazebo_ros/test/CMakeLists.txt
+++ b/gazebo_ros/test/CMakeLists.txt
@@ -39,7 +39,7 @@ set(tests
   test_gazebo_ros_properties
   test_gazebo_ros_state
   test_node
-  test_node_lookup
+  test_reject_duplicate_nodes
   test_plugins
   test_qos
   test_sim_time

--- a/gazebo_ros/test/test_node.cpp
+++ b/gazebo_ros/test/test_node.cpp
@@ -110,14 +110,14 @@ TEST(TestNode, GetSdf)
   // EXPECT_STREQ("node_3", node_3->get_name());
 }
 
-TEST(TestNode, OptionalNodeName){
+TEST(TestNode, OptionalNodeName) {
   auto sdf_str_1 =
-      "<?xml version='1.0' ?>"
-      "<sdf version='1.6'>"
-      "<world name='default'>"
-      "<plugin name='node_1' filename='libnode_name.so'/>"
-      "</world>"
-      "</sdf>";
+    "<?xml version='1.0' ?>"
+    "<sdf version='1.6'>"
+    "<world name='default'>"
+    "<plugin name='node_1' filename='libnode_name.so'/>"
+    "</world>"
+    "</sdf>";
   sdf::SDF sdf_1;
   sdf_1.SetFromString(sdf_str_1);
   auto plugin_sdf_1 = sdf_1.Root()->GetElement("world")->GetElement("plugin");

--- a/gazebo_ros/test/test_node.cpp
+++ b/gazebo_ros/test/test_node.cpp
@@ -110,6 +110,24 @@ TEST(TestNode, GetSdf)
   // EXPECT_STREQ("node_3", node_3->get_name());
 }
 
+TEST(TestNode, OptionalNodeName){
+  auto sdf_str_1 =
+      "<?xml version='1.0' ?>"
+      "<sdf version='1.6'>"
+      "<world name='default'>"
+      "<plugin name='node_1' filename='libnode_name.so'/>"
+      "</world>"
+      "</sdf>";
+  sdf::SDF sdf_1;
+  sdf_1.SetFromString(sdf_str_1);
+  auto plugin_sdf_1 = sdf_1.Root()->GetElement("world")->GetElement("plugin");
+
+  // use optional node name instead of plugin name as node name
+  auto node_1 = gazebo_ros::Node::Get(plugin_sdf_1, "node_name_optional");
+  ASSERT_NE(nullptr, node_1);
+  EXPECT_STREQ("node_name_optional", node_1->get_name());
+}
+
 TEST(TestNode, RemapAndQoSOverride)
 {
   // Remap topic 'foo' to 'bar', 'bar' to 'baz', and '~/zoo' to 'foo/bar'

--- a/gazebo_ros/test/test_node_lookup.cpp
+++ b/gazebo_ros/test/test_node_lookup.cpp
@@ -1,6 +1,16 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
 //
-// Created by deepanshu on 5/20/22.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <gtest/gtest.h>
 #include <gazebo_ros/node.hpp>
@@ -8,34 +18,30 @@
 
 TEST(TestNodeLookUp, NodesSameName)
 {
-  // create first node
-  auto sdf_str_1 =
-      "<?xml version='1.0' ?>"
-      "<sdf version='1.6'>"
-      "<world name='default'>"
-      "<plugin name='node_1' filename='libnode_name.so'/>"
-      "</world>"
-      "</sdf>";
-  sdf::SDF sdf_1;
-  sdf_1.SetFromString(sdf_str_1);
-  auto plugin_sdf_1 = sdf_1.Root()->GetElement("world")->GetElement("plugin");
+  // sdf model with same plugin name
+  auto sdf_str =
+    "<?xml version='1.0' ?>"
+    "<sdf version='1.6'>"
+    "<world name='default'>"
+    "<model name='model_1'>"
+    "<plugin name='node_1' filename='libnode_name.so'/>"
+    "</model>"
+    "<model name='model_2'>"
+    "<plugin name='node_1' filename='libnode_name.so'/>"
+    "</model>"
+    "</world>"
+    "</sdf>";
 
+  sdf::SDF sdf;
+  sdf.SetFromString(sdf_str);
+  auto plugin_sdf_1 = sdf.Root()->GetElement("world")->GetFirstElement()->GetElement("plugin");
   gazebo_ros::Node::SharedPtr node_1 = gazebo_ros::Node::Get(plugin_sdf_1);
   ASSERT_NE(nullptr, node_1);
 
-  // create second node with same name as first
-  auto sdf_str_2 =
-      "<?xml version='1.0' ?>"
-      "<sdf version='1.6'>"
-      "<world name='default'>"
-      "<plugin name='node_1' filename='libnode_name.so'/>"
-      "</world>"
-      "</sdf>";
-  sdf::SDF sdf_2;
-  sdf_2.SetFromString(sdf_str_2);
-  auto plugin_sdf_2 = sdf_1.Root()->GetElement("world")->GetElement("plugin");
-
-  gazebo_ros::Node::SharedPtr node_2 = gazebo_ros::Node::Get(plugin_sdf_1);
+  // check if a node with the same name exists
+  auto plugin_sdf_2 =
+    sdf.Root()->GetElement("world")->GetElement("model")->GetNextElement()->GetElement("plugin");
+  gazebo_ros::Node::SharedPtr node_2 = gazebo_ros::Node::Get(plugin_sdf_2);
   ASSERT_TRUE(node_2 == nullptr);
 }
 

--- a/gazebo_ros/test/test_node_lookup.cpp
+++ b/gazebo_ros/test/test_node_lookup.cpp
@@ -1,0 +1,47 @@
+//
+// Created by deepanshu on 5/20/22.
+//
+
+#include <gtest/gtest.h>
+#include <gazebo_ros/node.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+TEST(TestNodeLookUp, NodesSameName)
+{
+  // create first node
+  auto sdf_str_1 =
+      "<?xml version='1.0' ?>"
+      "<sdf version='1.6'>"
+      "<world name='default'>"
+      "<plugin name='node_1' filename='libnode_name.so'/>"
+      "</world>"
+      "</sdf>";
+  sdf::SDF sdf_1;
+  sdf_1.SetFromString(sdf_str_1);
+  auto plugin_sdf_1 = sdf_1.Root()->GetElement("world")->GetElement("plugin");
+
+  gazebo_ros::Node::SharedPtr node_1 = gazebo_ros::Node::Get(plugin_sdf_1);
+  ASSERT_NE(nullptr, node_1);
+
+  // create second node with same name as first
+  auto sdf_str_2 =
+      "<?xml version='1.0' ?>"
+      "<sdf version='1.6'>"
+      "<world name='default'>"
+      "<plugin name='node_1' filename='libnode_name.so'/>"
+      "</world>"
+      "</sdf>";
+  sdf::SDF sdf_2;
+  sdf_2.SetFromString(sdf_str_2);
+  auto plugin_sdf_2 = sdf_1.Root()->GetElement("world")->GetElement("plugin");
+
+  gazebo_ros::Node::SharedPtr node_2 = gazebo_ros::Node::Get(plugin_sdf_1);
+  ASSERT_TRUE(node_2 == nullptr);
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/gazebo_ros/test/test_reject_duplicate_nodes.cpp
+++ b/gazebo_ros/test/test_reject_duplicate_nodes.cpp
@@ -16,7 +16,7 @@
 #include <gazebo_ros/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-TEST(TestNodeLookUp, NodesSameName)
+TEST(TestRejectDuplicateNodes, PluginsSameName)
 {
   // sdf model with same plugin name
   auto sdf_str =


### PR DESCRIPTION
The `gazebo_ros_plugins` while instantiating the rclcpp::Node object uses the node name as  the plugin name specified in sdf/world file. However, this can create problems in cases we have multiple plugins with same name. 

This PR forbids creating nodes with same name by keeping track of global node names. In case a given name exists already, a rclcpp error is shown and the gazebo is shutdown safely.  

The full description of the original issue can be found here #1303 