### PR TITLE
remove image_common from gazebo_ros_pkgs.repos

### DIFF
--- a/gazebo_ros_pkgs.repos
+++ b/gazebo_ros_pkgs.repos
@@ -3,10 +3,6 @@ repositories:
     type: git
     url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
     version: ros2
-  image_common:
-    type: git
-    url: https://github.com/ros-perception/image_common.git
-    version: ros2
   vision_opencv:
     type: git
     url: https://github.com/ros-perception/vision_opencv.git


### PR DESCRIPTION
`image_common` is already provided in [`ros2.repos`](https://github.com/ros2/ros2/blob/077c53b9a27100bcb4e3ec94549d5a9e6690fea5/ros2.repos#L66-L69)
