### PR TITLE
feat: make cmd topic configurable

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_planar_move.cpp
+++ b/gazebo_plugins/src/gazebo_ros_planar_move.cpp
@@ -150,17 +150,19 @@ void GazeboRosPlanarMove::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr
   }
   impl_->last_update_time_ = impl_->world_->SimTime();
 
-  // Update rate
+  // Publish rate
   auto publish_rate = _sdf->Get<double>("publish_rate", 20.0).first;
-  if (update_rate > 0.0) {
+  if (publish_rate > 0.0) {
     impl_->publish_period_ = 1.0 / publish_rate;
   } else {
     impl_->publish_period_ = 0.0;
   }
   impl_->last_publish_time_ = impl_->world_->SimTime();
 
+  auto cmd_topic = _sdf->Get<std::string>("command_topic", "cmd_vel").first;
+
   impl_->cmd_vel_sub_ = impl_->ros_node_->create_subscription<geometry_msgs::msg::Twist>(
-    "cmd_vel", qos.get_subscription_qos("cmd_vel", rclcpp::QoS(1)),
+    cmd_topic, qos.get_subscription_qos(cmd_topic, rclcpp::QoS(1)),
     std::bind(&GazeboRosPlanarMovePrivate::OnCmdVel, impl_.get(), std::placeholders::_1));
 
   RCLCPP_INFO(


### PR DESCRIPTION
This MR add the feature to set the `command_topic` for the `gazebo_ros_planar_move` plugin

It can now be used like the other paramters:
```xml
    <gazebo>
        <plugin name="object_controller" filename="libgazebo_ros_planar_move.so">
            <command_topic>/cmd_vel</command_topic>
            <odometry_frame>odom</odometry_frame>
            <publish_rate>20.0</publish_rate>
            <update_rate>20.0</update_rate>
            <publish_odom>True</publish_odom>
            <publish_odom_tf>False</publish_odom_tf>
            <robot_base_frame>base_link</robot_base_frame>
            <covariance_x>0.00001</covariance_x>
            <covariance_y>0.00001</covariance_y>
            <covariance_yaw>0.00001</covariance_yaw>
        </plugin>
    </gazebo>
```