### PR TITLE
Set camera optical centre from gazebo directly instead of SDF tag

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera.cpp
@@ -405,7 +405,7 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
       impl_->camera_[i]->LensDistortion()->SetCrop(border_crop);
 
       cx = impl_->camera_[i]->LensDistortion()->Center().X();
-      cy =  impl_->camera_[i]->LensDistortion()->Center().Y();
+      cy = impl_->camera_[i]->LensDistortion()->Center().Y();
 
       distortion_k1 = impl_->camera_[i]->LensDistortion()->K1();
       distortion_k2 = impl_->camera_[i]->LensDistortion()->K2();

--- a/gazebo_plugins/src/gazebo_ros_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera.cpp
@@ -392,8 +392,8 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
     auto hack_baseline = _sdf->Get<double>("hack_baseline", 0.0).first;
 
     // Get Optical center from camera
-    double cx = (static_cast<double>(width[i]) + 1.0) / 2.0;
-    double cy = (static_cast<double>(height[i]) + 1.0) / 2.0;
+    double default_cx = (static_cast<double>(width[i]) + 1.0) / 2.0;
+    double default_cy = (static_cast<double>(height[i]) + 1.0) / 2.0;
 
     // Get distortion from camera
     double distortion_k1{0.0};
@@ -404,8 +404,8 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
     if (impl_->camera_[i]->LensDistortion()) {
       impl_->camera_[i]->LensDistortion()->SetCrop(border_crop);
 
-      cx = impl_->camera_[i]->LensDistortion()->Center().X();
-      cy = impl_->camera_[i]->LensDistortion()->Center().Y();
+      default_cx = impl_->camera_[i]->LensDistortion()->Center().X();
+      default_cy = impl_->camera_[i]->LensDistortion()->Center().Y();
 
       distortion_k1 = impl_->camera_[i]->LensDistortion()->K1();
       distortion_k2 = impl_->camera_[i]->LensDistortion()->K2();
@@ -413,6 +413,9 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
       distortion_t1 = impl_->camera_[i]->LensDistortion()->P1();
       distortion_t2 = impl_->camera_[i]->LensDistortion()->P2();
     }
+
+    double cx = _sdf->Get<double>("cx", default_cx).first;
+    double cy = _sdf->Get<double>("cy", default_cy).first;
 
     // D = {k1, k2, t1, t2, k3}, as specified in:
     // - sensor_msgs/CameraInfo: http://docs.ros.org/api/sensor_msgs/html/msg/CameraInfo.html

--- a/gazebo_plugins/src/gazebo_ros_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera.cpp
@@ -356,13 +356,6 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
   }
 
   for (uint64_t i = 0; i < impl_->num_cameras_; ++i) {
-    // C parameters
-    auto default_cx = (static_cast<double>(width[i]) + 1.0) / 2.0;
-    auto cx = _sdf->Get<double>("cx", default_cx).first;
-
-    auto default_cy = (static_cast<double>(height[i]) + 1.0) / 2.0;
-    auto cy = _sdf->Get<double>("cy", default_cy).first;
-
     impl_->hfov_.push_back(impl_->camera_[i]->HFOV().Radian());
 
     double computed_focal_length =
@@ -398,6 +391,10 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
     auto border_crop = _sdf->Get<bool>("border_crop", true).first;
     auto hack_baseline = _sdf->Get<double>("hack_baseline", 0.0).first;
 
+    // Get Optical center from camera
+    double cx = (static_cast<double>(width[i]) + 1.0) / 2.0;
+    double cy = (static_cast<double>(height[i]) + 1.0) / 2.0;
+
     // Get distortion from camera
     double distortion_k1{0.0};
     double distortion_k2{0.0};
@@ -406,6 +403,9 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
     double distortion_t2{0.0};
     if (impl_->camera_[i]->LensDistortion()) {
       impl_->camera_[i]->LensDistortion()->SetCrop(border_crop);
+
+      cx = impl_->camera_[i]->LensDistortion()->Center().X();
+      cy =  impl_->camera_[i]->LensDistortion()->Center().Y();
 
       distortion_k1 = impl_->camera_[i]->LensDistortion()->K1();
       distortion_k2 = impl_->camera_[i]->LensDistortion()->K2();

--- a/gazebo_plugins/src/gazebo_ros_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera.cpp
@@ -391,7 +391,6 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
     auto border_crop = _sdf->Get<bool>("border_crop", true).first;
     auto hack_baseline = _sdf->Get<double>("hack_baseline", 0.0).first;
 
-    // Get Optical center from camera
     double default_cx = (static_cast<double>(width[i]) + 1.0) / 2.0;
     double default_cy = (static_cast<double>(height[i]) + 1.0) / 2.0;
 
@@ -404,6 +403,7 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
     if (impl_->camera_[i]->LensDistortion()) {
       impl_->camera_[i]->LensDistortion()->SetCrop(border_crop);
 
+      // Get Optical center from camera
       default_cx = impl_->camera_[i]->LensDistortion()->Center().X();
       default_cy = impl_->camera_[i]->LensDistortion()->Center().Y();
 
@@ -414,6 +414,7 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
       distortion_t2 = impl_->camera_[i]->LensDistortion()->P2();
     }
 
+    // Override the default values if sdf tag exists
     double cx = _sdf->Get<double>("cx", default_cx).first;
     double cy = _sdf->Get<double>("cy", default_cy).first;
 

--- a/gazebo_plugins/test/CMakeLists.txt
+++ b/gazebo_plugins/test/CMakeLists.txt
@@ -29,6 +29,7 @@ set(tests
   test_gazebo_ros_ray_sensor
   test_gazebo_ros_tricycle_drive
   test_gazebo_ros_vacuum_gripper
+  test_gazebo_ros_camera_optical_center
   test_gazebo_ros_wheelslip
 )
 

--- a/gazebo_plugins/test/test_gazebo_ros_camera_distortion.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_camera_distortion.cpp
@@ -14,7 +14,7 @@
 
 #include <cv_bridge/cv_bridge.h>
 #include <gazebo/test/ServerFixture.hh>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <opencv2/core/core.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <rclcpp/rclcpp.hpp>

--- a/gazebo_plugins/test/test_gazebo_ros_camera_optical_center.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_camera_optical_center.cpp
@@ -1,0 +1,113 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cv_bridge/cv_bridge.h>
+#include <opencv2/core/core.hpp>
+#include <gazebo/test/ServerFixture.hh>
+#include <image_transport/image_transport.h>
+#include <rclcpp/rclcpp.hpp>
+
+#include <memory>
+#include <string>
+
+using namespace std::literals::chrono_literals; // NOLINT
+
+/// Test parameters
+struct TestParams
+{
+  /// Path to world file
+  std::string world;
+
+  /// Camera info topic to subscribe to
+  std::string info_topic;
+};
+
+class GazeboRosCameraTest
+    : public gazebo::ServerFixture, public ::testing::WithParamInterface<TestParams>
+{
+ public:
+  void TearDown() override
+  {
+    // Make sure they're destroyed even if test fails by ASSERT
+    cam_info_sub_.reset();
+    ServerFixture::TearDown();
+  }
+
+  /// Subscribe to camera info.
+  rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr cam_info_sub_;
+};
+
+TEST_P(GazeboRosCameraTest, CameraDefaultOpticalCenter)
+{
+  // Load test world and start paused
+  this->Load(GetParam().world, true);
+
+  // World
+  auto world = gazebo::physics::get_world();
+  ASSERT_NE(nullptr, world);
+
+  // Create node and executor
+  auto node = std::make_shared<rclcpp::Node>("gazebo_ros_camera_optical_center_test");
+  ASSERT_NE(nullptr, node);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+
+  // Subscribe to camera info
+  sensor_msgs::msg::CameraInfo::SharedPtr cam_info;
+  cam_info_sub_ = node->create_subscription<sensor_msgs::msg::CameraInfo>(
+      GetParam().info_topic, rclcpp::SensorDataQoS(),
+      [&cam_info](const sensor_msgs::msg::CameraInfo::SharedPtr _msg) {
+        cam_info = _msg;
+      });
+
+  world->Step(5000);
+  executor.spin_once(100ms);
+  executor.spin_once(100ms);
+  executor.spin_once(100ms);
+  executor.spin_once(100ms);
+
+  ASSERT_NE(nullptr, cam_info);
+
+  // Load camera coefficients from published ROS information
+  auto intrinsic_matrix = cv::Mat(3, 3, CV_64F);
+  if (cam_info->k.size() == 9) {
+    memcpy(
+        intrinsic_matrix.data, cam_info->k.data(),
+        cam_info->k.size() * sizeof(double));
+  }
+
+  // check optical center cx, cy equals to default values if no sdf
+  // tag is provided.
+  ASSERT_DOUBLE_EQ(intrinsic_matrix.at<double>(0, 2), 320.5);
+  ASSERT_DOUBLE_EQ(intrinsic_matrix.at<double>(1, 2), 240.5);
+
+  // Clean up
+  cam_info_sub_.reset();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GazeboRosCamera, GazeboRosCameraTest, ::testing::Values(
+    TestParams({"worlds/gazebo_ros_camera_optical_center.world",
+                      "/camera1/camera_info"})
+  ));
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  testing::InitGoogleTest(&argc, argv);
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
+}

--- a/gazebo_plugins/test/worlds/gazebo_ros_camera_optical_center.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_camera_optical_center.world
@@ -1,0 +1,83 @@
+<?xml version="1.0" ?>
+
+<sdf version="1.6">
+  <world name="default">
+
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>100</mu>
+                <mu2>50</mu2>
+              </ode>
+            </friction>
+            <bounce>
+              <restitution_coefficient>1.0</restitution_coefficient>
+              <threshold>0</threshold>
+            </bounce>
+            <contact>
+              <ode>
+                <max_vel>10000</max_vel>
+                <min_depth>0.001</min_depth>
+              </ode>
+            </contact>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <cast_shadows>false</cast_shadows>
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="camera_model">
+      <pose>0 0 0.5 0 0 3.14</pose>
+      <static>true</static>
+      <link name="camera_link">
+        <sensor type="camera" name="camera1">
+          <update_rate>60</update_rate>
+          <visualize>true</visualize>
+          <camera name="head">
+            <horizontal_fov>1.3962634</horizontal_fov>
+            <image>
+              <width>640</width>
+              <height>480</height>
+              <format>R8G8B8</format>
+            </image>
+          </camera>
+          <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
+            <ros>
+              <camera_name>camera1</camera_name>
+            </ros>
+            <!-- camera_name>omit so it defaults to sensor name</camera_name-->
+            <!-- frame_name>omit so it defaults to link name</frame_name-->
+          </plugin>
+        </sensor>
+      </link>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
This PR makes make changes to set the camera optical centre from gazebo directly instead of taking optical centre(cx, cy) values from SDF tag. 



Signed-off-by: deepanshu <deepanshubansal01@gmail.com>




