### PR TITLE
gazebo_ros_camera: configure projection matrix from sdf

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera.hpp
@@ -59,9 +59,15 @@ class GazeboRosCameraPrivate;
       <triggered>true</triggered>
 
       <!-- Set some projection matrix fields-->
+      <!-- Projection matrix principal point cx-->
       <P_cx>0</P_cx>
+      <!-- Projection matrix principal point cy-->
       <P_cy>320.5</P_cy>
+      <!-- Projection matrix focal length fy-->
+      <P_fy>0</P_fy>
+      <!-- Projection matrix translation Tx, Ty between stereo cameras-->
       <Tx>240.5</Tx>
+      <Ty>0</Ty>
 
       <hack_baseline>0.07</hack_baseline>
     </plugin>

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera.hpp
@@ -58,6 +58,11 @@ class GazeboRosCameraPrivate;
       <!-- Set to true to turn on triggering -->
       <triggered>true</triggered>
 
+      <!-- Set some projection matrix fields-->
+      <P_cx>0</P_cx>
+      <P_cy>320.5</P_cy>
+      <Tx>240.5</Tx>
+
       <hack_baseline>0.07</hack_baseline>
     </plugin>
   \endcode

--- a/gazebo_plugins/src/gazebo_ros_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera.cpp
@@ -447,14 +447,14 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
 
     // camera_ projection matrix (same as camera_ matrix due
     // to lack of distortion/rectification) (is this generated?)
-    camera_info_msg.p[0] = focal_length;
+    camera_info_msg.p[0] = _sdf->Get<double>("fx_p", focal_length).first;
     camera_info_msg.p[1] = 0.0;
-    camera_info_msg.p[2] = cx;
-    camera_info_msg.p[3] = -focal_length * hack_baseline;
+    camera_info_msg.p[2] = _sdf->Get<double>("cx'", cx).first;
+    camera_info_msg.p[3] = _sdf->Get<double>("Tx", -focal_length * hack_baseline).first;
     camera_info_msg.p[4] = 0.0;
-    camera_info_msg.p[5] = focal_length;
-    camera_info_msg.p[6] = cy;
-    camera_info_msg.p[7] = 0.0;
+    camera_info_msg.p[5] = _sdf->Get<double>("fy_p", focal_length).first;
+    camera_info_msg.p[6] = _sdf->Get<double>("cy'", cy).first;
+    camera_info_msg.p[7] = _sdf->Get<double>("Ty", 0).first;
     camera_info_msg.p[8] = 0.0;
     camera_info_msg.p[9] = 0.0;
     camera_info_msg.p[10] = 1.0;

--- a/gazebo_plugins/src/gazebo_ros_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera.cpp
@@ -445,8 +445,7 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
     camera_info_msg.r[7] = 0.0;
     camera_info_msg.r[8] = 1.0;
 
-    // camera_ projection matrix (same as camera_ matrix due
-    // to lack of distortion/rectification) (is this generated?)
+    // projection matrix
     camera_info_msg.p[0] = _sdf->Get<double>("P_fx", focal_length).first;
     camera_info_msg.p[1] = 0.0;
     camera_info_msg.p[2] = _sdf->Get<double>("P_cx", cx).first;

--- a/gazebo_plugins/src/gazebo_ros_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera.cpp
@@ -447,13 +447,13 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
 
     // camera_ projection matrix (same as camera_ matrix due
     // to lack of distortion/rectification) (is this generated?)
-    camera_info_msg.p[0] = _sdf->Get<double>("fx_p", focal_length).first;
+    camera_info_msg.p[0] = _sdf->Get<double>("P_fx", focal_length).first;
     camera_info_msg.p[1] = 0.0;
-    camera_info_msg.p[2] = _sdf->Get<double>("cx'", cx).first;
+    camera_info_msg.p[2] = _sdf->Get<double>("P_cx", cx).first;
     camera_info_msg.p[3] = _sdf->Get<double>("Tx", -focal_length * hack_baseline).first;
     camera_info_msg.p[4] = 0.0;
-    camera_info_msg.p[5] = _sdf->Get<double>("fy_p", focal_length).first;
-    camera_info_msg.p[6] = _sdf->Get<double>("cy'", cy).first;
+    camera_info_msg.p[5] = _sdf->Get<double>("P_fy", focal_length).first;
+    camera_info_msg.p[6] = _sdf->Get<double>("P_cy", cy).first;
     camera_info_msg.p[7] = _sdf->Get<double>("Ty", 0).first;
     camera_info_msg.p[8] = 0.0;
     camera_info_msg.p[9] = 0.0;

--- a/gazebo_plugins/test/worlds/gazebo_ros_camera.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_camera.world
@@ -35,6 +35,10 @@
             <!-- camera_name>omit so it defaults to sensor name</camera_name-->
             <!-- frame_name>omit so it defaults to link name</frame_name-->
             <hack_baseline>0.07</hack_baseline>
+            <!-- setting some projection matrix fields-->
+            <P_cx>0</P_cx>
+            <P_cy>320.5</P_cy>
+            <Tx>240.5</Tx>
           </plugin>
         </sensor>
       </link>


### PR DESCRIPTION
This PR allows for the projection matrix in `gazebo_ros_camera` to be configured from SDF.

Signed-off-by: Brian Chen <brian.chen@openrobotics.org>