### PR TITLE
gazebo_plugins: Fix <min_intensity> setting in ray sensor plugin for LaserScan msg type

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_ray_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_ray_sensor.cpp
@@ -197,7 +197,7 @@ void GazeboRosRaySensorPrivate::SubscribeGazeboLaserScan()
 void GazeboRosRaySensorPrivate::PublishLaserScan(ConstLaserScanStampedPtr & _msg)
 {
   // Convert Laser scan to ROS LaserScan
-  auto ls = gazebo_ros::Convert<sensor_msgs::msg::LaserScan>(*_msg);
+  auto ls = gazebo_ros::Convert<sensor_msgs::msg::LaserScan>(*_msg, min_intensity_);
   // Set tf frame
   ls.header.frame_id = frame_name_;
   // Publish output

--- a/gazebo_plugins/test/test_gazebo_ros_ray_sensor.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_ray_sensor.cpp
@@ -107,8 +107,8 @@ TEST_F(GazeboRosRaySensorTest, CorrectOutput)
   sensor_msgs::msg::PointCloud2::SharedPtr pc2 = nullptr;
   sensor_msgs::msg::Range::SharedPtr range = nullptr;
   auto ls_sub = SUBSCRIBE_SETTER(ls, "/ray/laserscan");
-  auto ls_min_intensity_sub = SUBSCRIBE_SETTER(ls_min_intensity,
-      "/ray/laserscan_min_intensity");
+  auto ls_min_intensity_sub =
+    SUBSCRIBE_SETTER(ls_min_intensity, "/ray/laserscan_min_intensity");
   auto pc_sub = SUBSCRIBE_SETTER(pc, "/ray/pointcloud");
   auto pc2_sub = SUBSCRIBE_SETTER(pc2, "/ray/pointcloud2");
   auto range_sub = SUBSCRIBE_SETTER(range, "/ray/range");

--- a/gazebo_plugins/test/test_gazebo_ros_ray_sensor.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_ray_sensor.cpp
@@ -102,10 +102,13 @@ TEST_F(GazeboRosRaySensorTest, CorrectOutput)
 
   // Create subscribe setter for each output type
   sensor_msgs::msg::LaserScan::SharedPtr ls = nullptr;
+  sensor_msgs::msg::LaserScan::SharedPtr ls_min_intensity = nullptr;
   sensor_msgs::msg::PointCloud::SharedPtr pc = nullptr;
   sensor_msgs::msg::PointCloud2::SharedPtr pc2 = nullptr;
   sensor_msgs::msg::Range::SharedPtr range = nullptr;
   auto ls_sub = SUBSCRIBE_SETTER(ls, "/ray/laserscan");
+  auto ls_min_intensity_sub = SUBSCRIBE_SETTER(ls_min_intensity,
+      "/ray/laserscan_min_intensity");
   auto pc_sub = SUBSCRIBE_SETTER(pc, "/ray/pointcloud");
   auto pc2_sub = SUBSCRIBE_SETTER(pc2, "/ray/pointcloud2");
   auto range_sub = SUBSCRIBE_SETTER(range, "/ray/range");
@@ -122,6 +125,7 @@ TEST_F(GazeboRosRaySensorTest, CorrectOutput)
 
   // Ensure every message was received
   ASSERT_NE(ls, nullptr);
+  ASSERT_NE(ls_min_intensity, nullptr);
   ASSERT_NE(pc, nullptr);
   ASSERT_NE(pc2, nullptr);
   ASSERT_NE(range, nullptr);
@@ -181,6 +185,31 @@ TEST_F(GazeboRosRaySensorTest, CorrectOutput)
     if (idx > static_cast<int>(ls->ranges.size())) {idx = ls->ranges.size() - 1;}
     EXPECT_NEAR(ls->ranges[idx], range, POINT_DISTANCE_TOL);
     EXPECT_NEAR(ls->intensities[idx], 80, ROUNDING_ERROR_TOL);
+  }
+
+  // LaserScan with min intensity verification
+  EXPECT_EQ(ls_min_intensity->header.frame_id, "ray_link");
+  EXPECT_NEAR(ls_min_intensity->angle_min, -0.5236, ROUNDING_ERROR_TOL);
+  EXPECT_NEAR(ls_min_intensity->angle_max, 0.5236, ROUNDING_ERROR_TOL);
+  EXPECT_NEAR(ls_min_intensity->range_min, 0.05, ROUNDING_ERROR_TOL);
+  EXPECT_NEAR(ls_min_intensity->range_max, 50.0, ROUNDING_ERROR_TOL);
+  EXPECT_NEAR(
+    ls_min_intensity->angle_increment,
+    (ls_min_intensity->angle_max - ls_min_intensity->angle_min) /
+    ls_min_intensity->ranges.size(), ROUNDING_ERROR_TOL);
+
+  // Ensure each ground truth range is found in the laserscan
+  for (size_t i = 0; i < ranges.size(); ++i) {
+    double range = ranges[i];
+    double angle = angles[i];
+    // Check for a correct range at roughly the ground truth angle
+    int idx = (angle - ls->angle_min) / ls_min_intensity->angle_increment;
+    if (idx < 0) {idx = 0;}
+    if (idx > static_cast<int>(ls_min_intensity->ranges.size())) {
+      idx = ls_min_intensity->ranges.size() - 1;
+    }
+    EXPECT_NEAR(ls_min_intensity->ranges[idx], range, POINT_DISTANCE_TOL);
+    EXPECT_NEAR(ls_min_intensity->intensities[idx], 81, ROUNDING_ERROR_TOL);
   }
 
   // Artificialy trigger sigInt

--- a/gazebo_plugins/test/worlds/gazebo_ros_ray_sensor.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_ray_sensor.world
@@ -68,6 +68,14 @@
             </ros>
             <output_type>sensor_msgs/LaserScan</output_type>
           </plugin>
+          <plugin name="ls_min_intensity" filename="libgazebo_ros_ray_sensor.so">
+            <ros>
+              <namespace>/ray</namespace>
+              <remapping>~/out:=laserscan_min_intensity</remapping>
+            </ros>
+            <output_type>sensor_msgs/LaserScan</output_type>
+            <min_intensity>81</min_intensity>
+          </plugin>
           <plugin name="range" filename="libgazebo_ros_ray_sensor.so">
             <ros>
               <namespace>/ray</namespace>


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

While the ray sensor plugin's [`<min_intensity>`](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/galactic/gazebo_plugins/include/gazebo_plugins/gazebo_ros_ray_sensor.hpp#L66) parameter works when the msg output type is `PointCloud`, the parameter is being ignored when the output is `LaserScan` msg type. This PR fixes the issue by making use of the `min_intensity` parameter when converting from gz to ROS2 msg. 

Updated integration test with a new plugin that has the `min_intensity` parameter set.