### PR TITLE
change radiation type comment from ultrasonic to ultrasound

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_ray_sensor.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_ray_sensor.hpp
@@ -48,7 +48,7 @@ class GazeboRosRaySensorPrivate;
 
   \verbatim
   <radiation_type>: The radiation type to publish when the output type is sensor_msgs/Range.
-                   Can be either "infrared" or "ultrasonic".
+                   Can be either "infrared" or "ultrasound".
                    Default: "infrared".
   \endverbatim
 


### PR DESCRIPTION
Fixed the radiation type comment from ultrasonic to ultrasound. 

* The option in source code is "ultrasound".