### PR TITLE
Add rectification matrix in sdf, docs, and example usage

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera.hpp
@@ -59,7 +59,7 @@ class GazeboRosCameraPrivate;
 
       <!-- Set to true to turn on triggering -->
       <triggered>true</triggered>
-      
+
       <!-- Set some projection matrix fields-->
       <!-- Projection matrix principal point cx-->
       <P_cx>0</P_cx>

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera.hpp
@@ -59,6 +59,9 @@ class GazeboRosCameraPrivate;
 
       <!-- Set to true to turn on triggering -->
       <triggered>true</triggered>
+      
+      <!-- Set some projection matrix fields-->
+      <rectification_matrix>0.999 0.0 -0.049 0.0 1.0 0.0 0.049 0.0 0.999</rectification_matrix>
 
       <hack_baseline>0.07</hack_baseline>
     </plugin>

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_camera.hpp
@@ -70,7 +70,7 @@ class GazeboRosCameraPrivate;
       <!-- Projection matrix translation Tx, Ty between stereo cameras-->
       <Tx>240.5</Tx>
       <Ty>0</Ty>
-      <!-- Full 3x3 rectification matrix -->
+      <!-- Full 3x3 rectification matrix. Values are in row-major order -->
       <rectification_matrix>0.999 0.0 -0.049 0.0 1.0 0.0 0.049 0.0 0.999</rectification_matrix>
 
       <hack_baseline>0.07</hack_baseline>

--- a/gazebo_plugins/src/gazebo_ros_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera.cpp
@@ -435,15 +435,21 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
     camera_info_msg.k[8] = 1.0;
 
     // rectification
-    camera_info_msg.r[0] = 1.0;
-    camera_info_msg.r[1] = 0.0;
-    camera_info_msg.r[2] = 0.0;
-    camera_info_msg.r[3] = 0.0;
-    camera_info_msg.r[4] = 1.0;
-    camera_info_msg.r[5] = 0.0;
-    camera_info_msg.r[6] = 0.0;
-    camera_info_msg.r[7] = 0.0;
-    camera_info_msg.r[8] = 1.0;
+    // Get string from SDF and parse into Matrix3d for populating message
+    std::string default_rmat("1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1.0");
+    std::istringstream stream(_sdf->Get<std::string>("rectification_matrix", default_rmat).first);
+
+    ignition::math::Matrix3d rmat;
+    stream >> rmat;
+    camera_info_msg.r[0] = rmat(0,0);
+    camera_info_msg.r[1] = rmat(0,1);
+    camera_info_msg.r[2] = rmat(0,2);
+    camera_info_msg.r[3] = rmat(1,0);
+    camera_info_msg.r[4] = rmat(1,1);
+    camera_info_msg.r[5] = rmat(1,2);
+    camera_info_msg.r[6] = rmat(2,0);
+    camera_info_msg.r[7] = rmat(2,1);
+    camera_info_msg.r[8] = rmat(2,2);
 
     // camera_ projection matrix (same as camera_ matrix due
     // to lack of distortion/rectification) (is this generated?)

--- a/gazebo_plugins/src/gazebo_ros_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera.cpp
@@ -441,15 +441,15 @@ void GazeboRosCamera::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _
 
     ignition::math::Matrix3d rmat;
     stream >> rmat;
-    camera_info_msg.r[0] = rmat(0,0);
-    camera_info_msg.r[1] = rmat(0,1);
-    camera_info_msg.r[2] = rmat(0,2);
-    camera_info_msg.r[3] = rmat(1,0);
-    camera_info_msg.r[4] = rmat(1,1);
-    camera_info_msg.r[5] = rmat(1,2);
-    camera_info_msg.r[6] = rmat(2,0);
-    camera_info_msg.r[7] = rmat(2,1);
-    camera_info_msg.r[8] = rmat(2,2);
+    camera_info_msg.r[0] = rmat(0, 0);
+    camera_info_msg.r[1] = rmat(0, 1);
+    camera_info_msg.r[2] = rmat(0, 2);
+    camera_info_msg.r[3] = rmat(1, 0);
+    camera_info_msg.r[4] = rmat(1, 1);
+    camera_info_msg.r[5] = rmat(1, 2);
+    camera_info_msg.r[6] = rmat(2, 0);
+    camera_info_msg.r[7] = rmat(2, 1);
+    camera_info_msg.r[8] = rmat(2, 2);
 
     // projection matrix
     camera_info_msg.p[0] = _sdf->Get<double>("P_fx", focal_length).first;

--- a/gazebo_plugins/test/worlds/gazebo_ros_camera.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_camera.world
@@ -35,6 +35,8 @@
             <!-- camera_name>omit so it defaults to sensor name</camera_name-->
             <!-- frame_name>omit so it defaults to link name</frame_name-->
             <hack_baseline>0.07</hack_baseline>
+            <!-- setting some projection matrix fields-->
+            <rectification_matrix>0.999 0.0 -0.049 0.0 1.0 0.0 0.049 0.0 0.999</rectification_matrix>
           </plugin>
         </sensor>
       </link>


### PR DESCRIPTION
Adds the ability to use a `rectification_matrix` sdf tag to populate the `camera_info_msg`, as discussed in this PR: https://github.com/ros-simulation/gazebo_ros_pkgs/pull/1409