### PR TITLE
Set gzserver to log output to "both" in launch

### DIFF
--- a/gazebo_ros/launch/gzserver.launch.py
+++ b/gazebo_ros/launch/gzserver.launch.py
@@ -193,7 +193,7 @@ def generate_launch_description():
         # would be possible pending ros2/launch#290.
         ExecuteProcess(
             cmd=cmd,
-            output='screen',
+            output='both',
             additional_env=env,
             shell=False,
             prefix=prefix,
@@ -204,7 +204,7 @@ def generate_launch_description():
         # Execute node with default on_exit if the node is not required
         ExecuteProcess(
             cmd=cmd,
-            output='screen',
+            output='both',
             additional_env=env,
             shell=False,
             prefix=prefix,


### PR DESCRIPTION
Set gzserver.launch.py to log output to "both", otherwise no log messages from gzserver or plugins are saved to disk.
Not done to gzclient to avoid duplicate log messages for plugins that are in both client and server.
