### PR TITLE
Fix: Warning of QoS profile

### DIFF
--- a/gazebo_ros/scripts/spawn_entity.py
+++ b/gazebo_ros/scripts/spawn_entity.py
@@ -169,7 +169,7 @@ class SpawnEntityNode(Node):
 
             latched_qos = QoSProfile(
                 depth=1,
-                durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL)
+                durability=QoSDurabilityPolicy.TRANSIENT_LOCAL)
             self.subscription = self.create_subscription(
                 String, self.args.topic, entity_xml_cb, latched_qos)
 


### PR DESCRIPTION
Spawner script has warnings in humble branch, the enum opction was marked as deprecated. Also, foxy branch allows using this enum. Need to use TRANSIENT_LOCAL instead of RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL.

More info: https://github.com/ros2/rclpy/blob/c7feb4b70c33aaf22e8ad467605c0a58451299c9/rclpy/rclpy/qos.py#L387