### PR TITLE
Added step control to gazebo_ros_init plugin

### DIFF
--- a/gazebo_msgs/CMakeLists.txt
+++ b/gazebo_msgs/CMakeLists.txt
@@ -66,6 +66,7 @@ set(srv_files
   "srv/SetPhysicsProperties.srv"
   "srv/SpawnEntity.srv"
   "srv/SpawnModel.srv"
+  "srv/StepControl.srv"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/gazebo_msgs/srv/StepControl.srv
+++ b/gazebo_msgs/srv/StepControl.srv
@@ -1,0 +1,6 @@
+# sets pose and twist of a link.  All children link poses/twists of the URDF tree will be updated accordingly
+int64 steps                  # dt in seconds
+
+---
+bool success                       # return true if set wrench successful
+string status_message              # comments if available


### PR DESCRIPTION
This commit is to enable gazebo step control via service call. Step control is required in certain scenarios.

Services Introduced:
    enable_control service to enable/disable stepping
    step_control service to provide number of steps to execute

Example:
- Enable step control; gazebo will pause and will only step after receiving /step_control calls

    ros2 service call /enable_control std_srvs/srv/SetBool "{data: True}"

- Step simulation by 1

    ros2 service call /step_control gazebo_msgs/srv/StepControl "{steps: 1}"

Signed-off-by: Arshad Mehmood <arshad.mehmood@intel.com>