### PR TITLE
Structured point cloud

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera.cpp
@@ -714,8 +714,8 @@ void GazeboRosCamera::OnNewDepthFrame(
 
   sensor_msgs::PointCloud2Modifier cloud_modifier(impl_->cloud_msg_);
   cloud_modifier.setPointCloud2FieldsByString(2, "xyz", "rgb");
-  cloud_modifier.resize(_width * _height);
-
+  //cloud_modifier.resize(_width * _height);
+  impl_->cloud_msg_.data.resize(_width * _height * impl_->cloud_msg_.point_step);
   impl_->cloud_msg_.is_dense = true;
 
   int image_index = 0;

--- a/gazebo_plugins/src/gazebo_ros_camera.cpp
+++ b/gazebo_plugins/src/gazebo_ros_camera.cpp
@@ -714,7 +714,6 @@ void GazeboRosCamera::OnNewDepthFrame(
 
   sensor_msgs::PointCloud2Modifier cloud_modifier(impl_->cloud_msg_);
   cloud_modifier.setPointCloud2FieldsByString(2, "xyz", "rgb");
-  //cloud_modifier.resize(_width * _height);
   impl_->cloud_msg_.data.resize(_width * _height * impl_->cloud_msg_.point_step);
   impl_->cloud_msg_.is_dense = true;
 


### PR DESCRIPTION
This PR fixes the wrong behaviour that makes the camera to publish always unstructured point clouds (height=1).
Related to #1267 and #749. ROS2 branch but can be backported to other branches as well. It's a very old bug.