### PR TITLE
Fix gazebo_ros scripts signal handling and do not load the gazebo_ros_api_plugin into the gzclient

### DIFF
--- a/gazebo_ros/scripts/debug
+++ b/gazebo_ros/scripts/debug
@@ -19,4 +19,4 @@ then
 fi
 
 setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
-. $setup_path/setup.sh && rosrun gazebo_ros gdbrun gzserver $final
+. $setup_path/setup.sh && exec rosrun gazebo_ros gdbrun gzserver $final

--- a/gazebo_ros/scripts/gazebo
+++ b/gazebo_ros/scripts/gazebo
@@ -49,7 +49,7 @@ if $(kill -0 $! 2> /dev/null); then
 fi
 
 # Kill the server if it is alive
-if $(kill -0 $! 2> /dev/null); then
+if $(kill -0 $gzserver_pid 2> /dev/null); then
   # -2 SIGINT valid for Linux and Mac
-  kill -2 $!
+  kill -2 $gzserver_pid
 fi

--- a/gazebo_ros/scripts/gzclient
+++ b/gazebo_ros/scripts/gzclient
@@ -17,12 +17,6 @@ then
     final="$final -g `catkin_find --first-only libgazebo_ros_paths_plugin.$EXT`"
 fi
 
-# add ros api plugin if it does not already exist in the passed in arguments
-if [ `expr "$final" : ".*libgazebo_ros_api_plugin\.$EXT.*"` -eq 0 ]
-then
-    final="$final -g `catkin_find --first-only libgazebo_ros_api_plugin.$EXT`"
-fi
-
 setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
 
 # source setup.sh, but keep local modifications to GAZEBO_MASTER_URI and GAZEBO_MODEL_DATABASE_URI

--- a/gazebo_ros/scripts/gzclient
+++ b/gazebo_ros/scripts/gzclient
@@ -39,4 +39,4 @@ fi
 final=$(relocate_remappings "${final}")
 
 # Combine the commands
-GAZEBO_MASTER_URI="$desired_master_uri" GAZEBO_MODEL_DATABASE_URI="$desired_model_database_uri" gzclient $final
+GAZEBO_MASTER_URI="$desired_master_uri" GAZEBO_MODEL_DATABASE_URI="$desired_model_database_uri" exec gzclient $final

--- a/gazebo_ros/scripts/gzserver
+++ b/gazebo_ros/scripts/gzserver
@@ -38,4 +38,4 @@ fi
 
 final=$(relocate_remappings "${final}")
 
-GAZEBO_MASTER_URI="$desired_master_uri" GAZEBO_MODEL_DATABASE_URI="$desired_model_database_uri" gzserver $final
+GAZEBO_MASTER_URI="$desired_master_uri" GAZEBO_MODEL_DATABASE_URI="$desired_model_database_uri" exec gzserver $final

--- a/gazebo_ros/scripts/perf
+++ b/gazebo_ros/scripts/perf
@@ -18,4 +18,4 @@ then
 fi
 
 setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
-. $setup_path/setup.sh && /usr/bin/valgrind --tool=callgrind gzserver $final
+. $setup_path/setup.sh && exec /usr/bin/valgrind --tool=callgrind gzserver $final


### PR DESCRIPTION
- Use [`exec`](https://man7.org/linux/man-pages/man1/exec.1p.html) where appropriate, such that signals send by roslaunch are received directly by the `gzserver` or `gzclient` processes and do not have to be forwarded by the shell explicitly.
- Apply the `$gzserver_pid` variable saved earlier instead of `$! in the all-in-one `gazebo` script to kill the server process once the client terminates. The old version should also have been fine, because `$!` is the pid of the last _background_ process. Before, variable `gzserver_pid` was unused.
- With the `gzclient` script the `gazebo_ros_api_plugin` was also loaded into the client process. That plugin creates the `/gazebo` ROS node, and hence two identical nodes are spawned. Launching the client like that broke the ROS API of Gazebo for us, including `/clock` publishing, at least once the GUI would be closed.

  The `gzclient` script is also what is executed by the [launch files](https://github.com/meyerj/gazebo_ros_pkgs/blob/75ec16b72d6f70df9b4afe055cfaf46b08b8b656/gazebo_ros/launch/empty_world.launch#L50-L54) in package `gazebo_ros` if argument `gui:=true` (the default). In this case the node names do not clash because roslaunch overwrites the default node name with `/gazebo_gui`, but still it is probably unintended to load the plugin into the GUI at all, I assume.

This patch eventually fixes https://github.com/ros-simulation/gazebo_ros_pkgs/issues/751?