### PR TITLE
gazebo_ros_factory: more reliable model spawning

### DIFF
--- a/gazebo_ros/src/gazebo_ros_factory.cpp
+++ b/gazebo_ros/src/gazebo_ros_factory.cpp
@@ -97,9 +97,6 @@ public:
   /// Gazebo node for communication.
   gazebo::transport::NodePtr gz_node_;
 
-  /// Publishes model factory messages.
-  gazebo::transport::PublisherPtr gz_factory_pub_;
-
   /// Publishes light factory messages.
   gazebo::transport::PublisherPtr gz_factory_light_pub_;
 
@@ -160,7 +157,6 @@ void GazeboRosFactoryPrivate::OnWorldCreated(const std::string & _world_name)
   // Gazebo transport
   gz_node_ = gazebo::transport::NodePtr(new gazebo::transport::Node());
   gz_node_->Init(_world_name);
-  gz_factory_pub_ = gz_node_->Advertise<gazebo::msgs::Factory>("~/factory");
   gz_factory_light_pub_ = gz_node_->Advertise<gazebo::msgs::Light>("~/factory/light");
   gz_request_pub_ = gz_node_->Advertise<gazebo::msgs::Request>("~/request");
 }
@@ -272,9 +268,7 @@ void GazeboRosFactoryPrivate::SpawnEntity(
   } else {
     std::ostringstream sdfStr;
     sdfStr << "<sdf version='" << SDF_VERSION << "'>" << entity_elem->ToString("") << "</sdf>";
-    gazebo::msgs::Factory msg;
-    msg.set_sdf(sdfStr.str());
-    gz_factory_pub_->Publish(msg);
+    world_->InsertModelString(sdfStr.str());
   }
 
   // Only verify spawning if name is set, to keep ROS 1 functionality, but it would be more


### PR DESCRIPTION
Use the [World::InsertModelString](https://github.com/gazebosim/gazebo-classic/blob/gazebo11_11.12.0/gazebo/physics/World.cc#L2558-L2565) API instead of the gazebo-transport `~/factory` topic to spawn models. This is more reliable, since gazebo transport may lose messages. You can test this with the `spawn_entity.py` script.

For reference, the `~/factory` callback ([World::OnFactoryMsg](https://github.com/gazebosim/gazebo-classic/blob/gazebo11_11.12.0/gazebo/physics/World.cc#L1587-L1592)) receives a `gazebo::msgs::Factory` and pushes it to the World's `dataPtr->factoryMsgs` data structure to be processed in a separate thread.

The [World::InsertModelString](https://github.com/gazebosim/gazebo-classic/blob/gazebo11_11.12.0/gazebo/physics/World.cc#L2558-L2565) receives a `std::string`, wraps it in a `gazebo::msgs::Factory` and pushes the message to the `dataPtr->factoryMsgs` data structure. So the C++ API has the same data endpoint but copies the data directly instead of using gazebo transport. This c++ API can be used in the `gazebo_ros_factory` plugin because it is loaded and running in the `gzserver` process.