### PR TITLE
Refactor gzserver launch args, add --initial_sim_time

### DIFF
--- a/gazebo_ros/launch/gzserver.launch.py
+++ b/gazebo_ros/launch/gzserver.launch.py
@@ -39,6 +39,9 @@ def generate_launch_description():
         _boolean_command('lockstep'),
         _boolean_command('help'),
         _boolean_command('pause'),
+        # join with '=' (--initial_sim_time=[time]) so that old versions of
+        # gazebo will parse it all as a single argument and ignore the [time].
+        _arg_command('initial_sim_time', join_with='='),
         _arg_command('physics'),
         _arg_command('play'),
         _boolean_command('record'),
@@ -111,6 +114,10 @@ def generate_launch_description():
         DeclareLaunchArgument(
             'help', default_value='false',
             description='Set "true" to produce gzserver help message.'
+        ),
+        DeclareLaunchArgument(
+            'initial_sim_time', default_value='',
+            description='Specify the initial simulation time (seconds).'
         ),
         DeclareLaunchArgument(
             'pause', default_value='false',

--- a/gazebo_ros/launch/gzserver.launch.py
+++ b/gazebo_ros/launch/gzserver.launch.py
@@ -39,22 +39,22 @@ def generate_launch_description():
         _boolean_command('lockstep'),
         _boolean_command('help'),
         _boolean_command('pause'),
-        _arg_command('physics'), LaunchConfiguration('physics'),
-        _arg_command('play'), LaunchConfiguration('play'),
+        _arg_command('physics'),
+        _arg_command('play'),
         _boolean_command('record'),
-        _arg_command('record_encoding'), LaunchConfiguration('record_encoding'),
-        _arg_command('record_path'), LaunchConfiguration('record_path'),
-        _arg_command('record_period'), LaunchConfiguration('record_period'),
-        _arg_command('record_filter'), LaunchConfiguration('record_filter'),
-        _arg_command('seed'), LaunchConfiguration('seed'),
-        _arg_command('iters'), LaunchConfiguration('iters'),
+        _arg_command('record_encoding'),
+        _arg_command('record_path'),
+        _arg_command('record_period'),
+        _arg_command('record_filter'),
+        _arg_command('seed'),
+        _arg_command('iters'),
         _boolean_command('minimal_comms'),
         _plugin_command('init'),
         _plugin_command('factory'),
         _plugin_command('force_system'),
         # Wait for (https://github.com/ros-simulation/gazebo_ros_pkgs/pull/941)
         # _plugin_command('force_system'), ' ',
-        _arg_command('profile'), LaunchConfiguration('profile'),
+        _arg_command('profile'),
         # Support a yaml params_file:
         #   If a params file is to be used, it needs to be preceded by --ros-args
         #   and followed by a trailing --
@@ -225,14 +225,11 @@ def _boolean_command(arg):
     return py_cmd
 
 
-# Add string commands if not empty
-def _arg_command(arg, condition=None):
-    if condition:
-        cmd = ['"--', arg, '" if "" != "', condition, '" else ""']
-    else:
-        cmd = ['"--', arg, '" if "" != "', LaunchConfiguration(arg), '" else ""']
+# Add string command and argument if not empty
+def _arg_command(arg, join_with=" "):
+    cmd = ['"--', arg, join_with, '" if "" != "', LaunchConfiguration(arg), '" else ""']
     py_cmd = PythonExpression(cmd)
-    return py_cmd
+    return (py_cmd, LaunchConfiguration(arg))
 
 
 # Add --command if condition not empty


### PR DESCRIPTION
This refactors some of the argument handling in `gzserver.launch.py` and adds support for the `--initial_sim_time` parameter, which was recently added in https://github.com/gazebosim/gazebo-classic/pull/3294. It is straightforward to review the changes by commit:

* https://github.com/ros-simulation/gazebo_ros_pkgs/commit/00c0c1e1249a4ab0f7a13ee8d6bd549f3a429a5e: Move the functionality of the `_arg_command` helper with a `condition` to a separate `_conditional_command` helper function and update the `params_file` support to use `_conditional_command`.
* https://github.com/ros-simulation/gazebo_ros_pkgs/pull/1456/commits/efa494f3285bd8516b1e32af925a72559e5232a7: Remove the `condition` argument from `_arg_command` and add a `join_with` argument instead that defaults to a space `' '`. Also, since all the remaining uses of `_arg_command` also pass the corresponding `LaunchConfiguration()` right afterward, change the return value of `_arg_command` to a list joining the `--command` string with the `LaunchConfiguration()` value. This simplifies the specification of the `cmd` variable in the launch description.
* https://github.com/ros-simulation/gazebo_ros_pkgs/pull/1456/commits/c6f90bcb365d63286fa4fa05fea6e5fdb89c2f03: Add support for the `--initial_sim_time` argument, using `join_with='='` so that it will be passed as `--initial_sim_time=[time]`. This is a valid alternative to `--initial_sim_time [time]` but allows old versions of gazebo to parse it all as a single argument and ignore it as unrecognized. Otherwise the `--initial_sim_time` may be ignored, but the `[time]` argument may linger and cause unintended parsing issues.