### PR TITLE
Import setup from setuptools instead of distutils.core

### DIFF
--- a/gazebo_plugins/package.xml
+++ b/gazebo_plugins/package.xml
@@ -18,7 +18,8 @@
   <author>John Hsu</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
   <build_depend>gazebo_dev</build_depend>
   <!--
     Need to use gazebo_dev since run script needs pkg-config

--- a/gazebo_plugins/package.xml
+++ b/gazebo_plugins/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>gazebo_plugins</name>
   <version>2.9.2</version>
   <description>

--- a/gazebo_plugins/setup.py
+++ b/gazebo_plugins/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup()

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -21,6 +21,8 @@
   <author>Dave Coleman</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend>cmake_modules</build_depend>
   <build_depend>gazebo_dev</build_depend>

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>gazebo_ros</name>
   <version>2.9.2</version>
   <description>

--- a/gazebo_ros/setup.py
+++ b/gazebo_ros/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup()


### PR DESCRIPTION
Recently users of newer distributions who build Noetic from source noticed issues when importing setup from distutils.core.
This problem was discussed on [Discourse](https://discourse.ros.org/t/ros-1-and-python-3-10s-deprecation-of-distutils-core/29834), and we hope that we can make the needed updates to Noetic to allow for future builds from source of Noetic.
As a first step, this PR introduces changes from the [Noetic Migration Guide](https://wiki.ros.org/noetic/Migration#Setuptools_instead_of_Distutils) that addresses the change to the setuptools module instead of distutils.core and the corresponding buildtool_depend tags for python 2&3.