### PR TITLE
gazebo_ros: Fix spawn_entity.py model removal binding

### DIFF
--- a/gazebo_ros/scripts/spawn_entity.py
+++ b/gazebo_ros/scripts/spawn_entity.py
@@ -261,8 +261,8 @@ class SpawnEntityNode(Node):
                 DeleteEntity, '%s/delete_entity' % self.args.gazebo_namespace)
             if not self.clientDeletion.wait_for_service(timeout_sec=self.args.timeout):
                 self.get_logger().error(
-                    'Service %s/delete_entity unavailable. ' +
-                    'Was Gazebo started with GazeboRosFactory?')
+                    'Service %s/delete_entity unavailable. Was Gazebo started with GazeboRosFactory?' %
+                        (self.args.gazebo_namespace))
 
             try:
                 rclpy.spin(self)


### PR DESCRIPTION
Resolved spawn_entity.py node shutdown issue preventing removal of model from simulation after broken binding.

Without this change, the spawn_entity node's context is destroyed before the deletion message can be sent.