### PR TITLE
Add ROS Package Paths to Gazebo Resource Paths

### DIFF
--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -22,6 +22,7 @@ if(WIN32)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_index_cpp REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(gazebo_dev REQUIRED)
 find_package(gazebo_msgs REQUIRED)
@@ -102,6 +103,7 @@ add_library(gazebo_ros_factory SHARED
   src/gazebo_ros_factory.cpp
 )
 ament_target_dependencies(gazebo_ros_factory
+  "ament_index_cpp"
   "rclcpp"
   "gazebo_dev"
   "gazebo_msgs"

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -22,6 +22,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>ament_index_cpp</depend>
   <depend>builtin_interfaces</depend>
   <depend>gazebo_dev</depend>
   <depend>gazebo_msgs</depend>

--- a/gazebo_ros/src/gazebo_ros_factory.cpp
+++ b/gazebo_ros/src/gazebo_ros_factory.cpp
@@ -84,7 +84,7 @@ public:
   std::unordered_set<std::string> GetResourcePaths();
 
   /// Call the gazebo service to add a resource path
-  bool AddResourcePath(const std::string& path);
+  bool AddResourcePath(const std::string & path);
 
   /// \brief World pointer from Gazebo.
   gazebo::physics::WorldPtr world_;
@@ -204,10 +204,9 @@ void GazeboRosFactoryPrivate::SpawnEntity(
   // Gather all the ros packages referenced
   std::unordered_set<std::string> ros_package_names;
   std::string package_key = "package://";
-  std::string& urdf_s = req->xml;
+  std::string & urdf_s = req->xml;
   size_t index = urdf_s.find(package_key);
-  while (index != std::string::npos)
-  {
+  while (index != std::string::npos) {
     index += package_key.length();
     size_t index2 = urdf_s.find('/', index);
     std::string package_name = urdf_s.substr(index, index2 - index);
@@ -217,13 +216,12 @@ void GazeboRosFactoryPrivate::SpawnEntity(
 
   std::unordered_set<std::string> existing = GetResourcePaths();
 
-  for (const std::string& package_name : ros_package_names)
-  {
-    std::filesystem::path package_share_directory(ament_index_cpp::get_package_share_directory(package_name));
+  for (const std::string& package_name : ros_package_names) {
+    std::filesystem::path package_share_directory;
+    package_share_directory = ament_index_cpp::get_package_share_directory(package_name);
     std::string parent = std::string(package_share_directory.parent_path());
 
-    if (existing.count(parent) != 0)
-    {
+    if (existing.count(parent) != 0) {
       continue;
     }
     RCLCPP_INFO(ros_node_->get_logger(), "Adding to model path: %s", parent.c_str());
@@ -440,13 +438,13 @@ std::unordered_set<std::string> GazeboRosFactoryPrivate::GetResourcePaths()
 
 bool GazeboRosFactoryPrivate::AddResourcePath(const std::string& path)
 {
-    /*gazebo::msgs::StringMsg_V request;
-    request.push_back(path);
+  /*gazebo::msgs::StringMsg_V request;
+  request.push_back(path);
 
-    gazebo::msgs::Empty response;
+  gazebo::msgs::Empty response;
 
-    return gz_node_->Request("/gazebo/resource_paths/add", 5000, request, response);*/
-    return false;
+  return gz_node_->Request("/gazebo/resource_paths/add", 5000, request, response);*/
+  return false;
 }
 
 GZ_REGISTER_SYSTEM_PLUGIN(GazeboRosFactory)


### PR DESCRIPTION
I've had it with meshes not loading when I spawn URDF into Gazebo. 

This PR aims to eventually 
 * Extract all the ROS package names from mesh filenames of the form `package://package_name/whatever`
 * Determine which paths aren't on the Gazebo Resource Path and add as necessary, using [server service calls](https://gazebosim.org/api/sim/7/classgz_1_1sim_1_1Server.html#details)

However, I'm still learning to do calls to gazebo services, so that part is a WIP and I would appreciate assistance with. 

(Note: I've developed this code with Foxy but the PR is for the `ros2` branch)