### PR TITLE
gzserver.launch.py: fix _arg_command

### DIFF
--- a/gazebo_ros/launch/gzserver.launch.py
+++ b/gazebo_ros/launch/gzserver.launch.py
@@ -233,7 +233,7 @@ def _boolean_command(arg):
 
 
 # Add string command and argument if not empty
-def _arg_command(arg, join_with=" "):
+def _arg_command(arg, join_with="="):
     cmd = ['"--', arg, join_with, '" if "" != "', LaunchConfiguration(arg), '" else ""']
     py_cmd = PythonExpression(cmd)
     return (py_cmd, LaunchConfiguration(arg))


### PR DESCRIPTION
Fixes https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1501.

I believe that the `_arg_command()` method in `gzserver.launch.py` was broken by https://github.com/ros-simulation/gazebo_ros_pkgs/pull/1456. I think this fixes it by setting the default value of `join_with` to '='.

Test with `ros2 launch gazebo_ros gzserver.launch.py verbose:=true physics:=dart` and you should see extra console messages from `DARTModel.cc`.