### PR TITLE
gazebo_ros: Added set_model_configuration service to ROS2(Humble)

### DIFF
--- a/gazebo_ros/worlds/empty.world
+++ b/gazebo_ros/worlds/empty.world
@@ -9,5 +9,12 @@
     <include>
       <uri>model://ground_plane</uri>
     </include>
+
+    <plugin name="gazebo_ros_properties" filename="libgazebo_ros_properties.so">
+      <ros>
+        <namespace>/gazebo</namespace>
+      </ros>
+      <update_rate>1.0</update_rate>
+    </plugin>
   </world>
 </sdf>


### PR DESCRIPTION
## Description

This pull request aims to enhance the functionality by porting the ROS1 service `set_model_configuration` to ROS2 (Humble). Upon launching the `empty.world`, users gain the ability to specify initial joint angles, facilitating entity spawning at custom configurations.

## Changes Made

**Ported ROS1 Service to ROS2 (Humble)**:
   - The primary focus of this pull request is the migration of the ROS1 service to ROS2 (Humble), ensuring compatibility with the latest ROS ecosystem advancements.
.

## How to Test

1. Set up ROS2 (Humble) dependencies in your environment.

2. Build and compile the project with the latest changes.

3. Launch `empty. world` in your ROS2 environment.

4. Write a service call to test the functionality:
```cpp
void SetModelConfiguration::set_model_configuration()
{
  set_model_configuration_client_ =
    this->create_client<gazebo_msgs::srv::SetModelConfiguration>("/gazebo/set_model_configuration");

  if (set_model_configuration_client_->service_is_ready())
  {
    auto srv = std::make_shared<gazebo_msgs::srv::SetModelConfiguration::Request>();

    srv->model_name = std::string("<>");
    srv->urdf_param_name = std::string("robot_description");
    std::map<std::string, double> joint_map = {
      {"<>", 0.0}, {"<>", 1.56}, {"<>", -3.0},
      {"<>", 0.0}, {"<>", 1.56}, {"<>", -3.0},
      {"<>", 0.0}, {"<>", 1.56}, {"<>", -3.0},
      {"<>", 0.0}, {"<>", 1.56}, {"<>", -3.0},
    };
  for (auto & it : joint_map)
    {
      srv->joint_names.push_back(it.first);
      srv->joint_positions.push_back(it.second);
    }

    auto setmodel_future_ = set_model_configuration_client_->async_send_request(srv);
  }
  else
    RCLCPP_WARN(
      get_logger(),
      "[SetSimulationConfiguration]: not calling service using a callback, service not ready!");
}

// <> : Enter the respective arguments, this example is for a 12DOF robot.

