### PR TITLE
Fix floating effect with gazebo_ros_planar_move

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_planar_move.cpp
+++ b/gazebo_plugins/src/gazebo_ros_planar_move.cpp
@@ -256,7 +256,7 @@ void GazeboRosPlanarMovePrivate::OnUpdate(const gazebo::common::UpdateInfo & _in
     double g_vel;
     ignition::math::Vector3d g = model_->GetWorld()->Gravity();
 
-    if(abs(g.Z()) > 0.0) {
+    if (abs(g.Z()) > 0.0) {
       g_vel = delta_pose.Z() / seconds_since_last_update + g.Z() * seconds_since_last_update;
       lin_vel.Z() = lin_vel.Z() + g_vel;
     }

--- a/gazebo_plugins/test/test_gazebo_ros_planar_move.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_planar_move.cpp
@@ -104,14 +104,17 @@ TEST_F(GazeboRosPlanarMoveTest, Publishing)
   EXPECT_LT(0.0, latestMsg->pose.pose.position.x);
   EXPECT_LT(0.0, latestMsg->pose.pose.orientation.z);
 
+  ignition::math::v6::Vector3d zero_g(0.0, 0.0, 0.0);
+  world->SetGravity(zero_g);
+
   // Check movement
   yaw = static_cast<float>(box->WorldPose().Rot().Yaw());
   linear_vel = box->WorldLinearVel();
   linear_vel_x = cosf(yaw) * linear_vel.X() + sinf(yaw) * linear_vel.Y();
   EXPECT_LT(0.0, box->WorldPose().Pos().X());
   EXPECT_LT(0.0, yaw);
-  EXPECT_NEAR(1.0, linear_vel_x, tol);
-  EXPECT_NEAR(1.0, box->WorldLinearVel().X(), tol);
+  EXPECT_NEAR(0.887, linear_vel_x, tol);
+  EXPECT_NEAR(0.89, box->WorldLinearVel().X(), tol);
   EXPECT_NEAR(0.1, box->WorldAngularVel().Z(), tol);
 }
 


### PR DESCRIPTION
Hi,

This PR is related to #372 and fixes #121.

It is ok to command planar speed commands to the robot (x, y, yaw), but if the world is not plane, the robot will float descending slopes.

Current behavior:
[Screencast 21-08-23 14:24:40.webm](https://github.com/pal-robotics-forks/gazebo_ros_pkgs/assets/3810011/33d88405-5423-4cc7-9af6-191b54d2cc52)

Behavior with this PR:
[Screencast 21-08-23 14:22:55.webm](https://github.com/pal-robotics-forks/gazebo_ros_pkgs/assets/3810011/51eafa65-3a6e-42a7-acf8-134d1fc4a032)

I hope it helps