### PR TITLE
Update gazebo_ros_utils.cpp

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_utils.cpp
+++ b/gazebo_plugins/src/gazebo_ros_utils.cpp
@@ -85,6 +85,11 @@ void GazeboRos ::readCommonParameter() {
 
 
     tf_prefix_ = tf::getPrefixParam(*rosnode_);
+    if(tf_prefix_.empty())
+    {
+        tf_prefix_ = namespace_;
+        boost::trim_right_if(tf_prefix_,boost::is_any_of("/"));
+    }    
     ROS_INFO_NAMED("utils", "%s: <tf_prefix> = %s", info(), tf_prefix_.c_str());
 }
 


### PR DESCRIPTION
why delete it [commit](https://github.com/cohen39/gazebo_ros_pkgs/commit/f6ee16514d10cc3d617b17c5a1c69e4bf32ab6de)， it has error for multi_robot.

the same project ( https://github.com/YZH-bot/multi_turtlebot3_navigation) and [launch](https://github.com/YZH-bot/multi_turtlebot3_navigation/blob/main/multi_turtlebot3_navigation/launch/multi_turtlebot3_gazebo.launch), has different tf_prefix:

melodic <tf_prefix> = /tb3_2
[ INFO] [1699271126.111498612, 0.005000000]: waitForService: Service [/gazebo/set_physics_properties] is now available.
[ INFO] [1699271126.367119382, 0.171000000]: Laser Plugin: Using the 'robotNamespace' param: '/tb3_0/'
[ INFO] [1699271126.367146412, 0.171000000]: Starting Laser Plugin (ns = /tb3_0/)
[ INFO] [1699271126.367589006, 0.171000000]: Laser Plugin (ns = /tb3_0/) <tf_prefix_>, set to "/tb3_0"
[ INFO] [1699271126.460272969, 0.171000000]: Starting plugin DiffDrive(ns = /tb3_0//)
[ INFO] [1699271126.460342909, 0.171000000]: DiffDrive(ns = /tb3_0//): = na
[ INFO] [1699271126.460940404, 0.171000000]: DiffDrive(ns = /tb3_0//): <tf_prefix> = /tb3_0
[ INFO] [1699271126.461666926, 0.171000000]: DiffDrive(ns = /tb3_0//): Advertise joint_states
[ INFO] [1699271126.462239042, 0.171000000]: DiffDrive(ns = /tb3_0//): Try to subscribe to cmd_vel
[ INFO] [1699271126.463594362, 0.171000000]: DiffDrive(ns = /tb3_0//): Subscribe to cmd_vel
[ INFO] [1699271126.464234441, 0.171000000]: DiffDrive(ns = /tb3_0//): Advertise odom on odom
[tb3_0/spawn_urdf-4] process has finished cleanly
log file: /root/.ros/log/f9119a9a-7c99-11ee-bc4c-70a8d3041e92/tb3_0-spawn_urdf-4*.log
[ INFO] [1699271126.736215029, 0.373000000]: Laser Plugin: Using the 'robotNamespace' param: '/tb3_2/'
[ INFO] [1699271126.736237720, 0.373000000]: Starting Laser Plugin (ns = /tb3_2/)
[ INFO] [1699271126.736630927, 0.373000000]: Laser Plugin (ns = /tb3_2/) <tf_prefix_>, set to "/tb3_2"
[ INFO] [1699271126.736865743, 0.373000000]: Starting plugin DiffDrive(ns = /tb3_2//)
[ INFO] [1699271126.736881051, 0.373000000]: DiffDrive(ns = /tb3_2//): = na
[ INFO] [1699271126.737290932, 0.373000000]: DiffDrive(ns = /tb3_2//): <tf_prefix> = /tb3_2
[ INFO] [1699271126.738427561, 0.373000000]: DiffDrive(ns = /tb3_2//): Advertise joint_states
[ INFO] [1699271126.738598915, 0.373000000]: DiffDrive(ns = /tb3_2//): Try to subscribe to cmd_vel
[ INFO] [1699271126.740768595, 0.373000000]: DiffDrive(ns = /tb3_2//): Subscribe to cmd_vel
[ INFO] [1699271126.741374146, 0.373000000]: DiffDrive(ns = /tb3_2//): Advertise odom on odom
[ INFO] [1699271126.743033744, 0.375000000]: Physics dynamic reconfigure ready.
[ INFO] [1699271127.003148832, 0.568000000]: Laser Plugin: Using the 'robotNamespace' param: '/tb3_1/'
[ INFO] [1699271127.003171934, 0.568000000]: Starting Laser Plugin (ns = /tb3_1/)
[ INFO] [1699271127.003827050, 0.568000000]: Laser Plugin (ns = /tb3_1/) <tf_prefix_>, set to "/tb3_1"
[tb3_2/spawn_urdf-8] process has finished cleanly
log file: /root/.ros/log/f9119a9a-7c99-11ee-bc4c-70a8d3041e92/tb3_2-spawn_urdf-8*.log
[ INFO] [1699271127.103532818, 0.568000000]: Starting plugin DiffDrive(ns = /tb3_1//)
[ INFO] [1699271127.103627446, 0.568000000]: DiffDrive(ns = /tb3_1//): = na
[ INFO] [1699271127.104789588, 0.568000000]: DiffDrive(ns = /tb3_1//): <tf_prefix> = /tb3_1
[ INFO] [1699271127.106056907, 0.568000000]: DiffDrive(ns = /tb3_1//): Advertise joint_states
[ INFO] [1699271127.106131218, 0.568000000]: DiffDrive(ns = /tb3_1//): Try to subscribe to cmd_vel
[ INFO] [1699271127.109744401, 0.568000000]: DiffDrive(ns = /tb3_1//): Subscribe to cmd_vel
[ INFO] [1699271127.110732968, 0.568000000]: DiffDrive(ns = /tb3_1//): Advertise odom on odom

noetic <tf_prefix> =

[ INFO] [1699271278.211178033]: Finished loading Gazebo ROS API Plugin.
[ INFO] [1699271278.211951893]: waitForService: Service [/gazebo/set_physics_properties] has not been advertised, waiting...
[ INFO] [1699271278.682913794, 0.006000000]: waitForService: Service [/gazebo/set_physics_properties] is now available.
[ INFO] [1699271278.690392282, 0.013000000]: Physics dynamic reconfigure ready.
[ INFO] [1699271279.160430519, 0.373000000]: Laser Plugin: Using the 'robotNamespace' param: '/tb3_0/'
[ INFO] [1699271279.160459996, 0.373000000]: Starting Laser Plugin (ns = /tb3_0/)
[ INFO] [1699271279.160965646, 0.373000000]: Laser Plugin (ns = /tb3_0/) <tf_prefix_>, set to ""
[ INFO] [1699271279.256451029, 0.373000000]: Starting plugin DiffDrive(ns = /tb3_0//)
[ INFO] [1699271279.256499367, 0.373000000]: DiffDrive(ns = /tb3_0//): = na
[ INFO] [1699271279.257056570, 0.373000000]: DiffDrive(ns = /tb3_0//): <tf_prefix> =
[ INFO] [1699271279.257836492, 0.373000000]: DiffDrive(ns = /tb3_0//): Advertise joint_states
[ INFO] [1699271279.258156851, 0.373000000]: DiffDrive(ns = /tb3_0//): Try to subscribe to cmd_vel
[ INFO] [1699271279.259073676, 0.373000000]: DiffDrive(ns = /tb3_0//): Subscribe to cmd_vel
[ INFO] [1699271279.259296909, 0.373000000]: DiffDrive(ns = /tb3_0//): Advertise odom on odom
[ INFO] [1699271279.539584460, 0.575000000]: Laser Plugin: Using the 'robotNamespace' param: '/tb3_1/'
[ INFO] [1699271279.539607944, 0.575000000]: Starting Laser Plugin (ns = /tb3_1/)
[ INFO] [1699271279.540136480, 0.575000000]: Laser Plugin (ns = /tb3_1/) <tf_prefix_>, set to ""
[ INFO] [1699271279.540372405, 0.575000000]: Starting plugin DiffDrive(ns = /tb3_1//)
[ INFO] [1699271279.540386711, 0.575000000]: DiffDrive(ns = /tb3_1//): = na
[ INFO] [1699271279.540663841, 0.575000000]: DiffDrive(ns = /tb3_1//): <tf_prefix> =
[ INFO] [1699271279.541259271, 0.575000000]: DiffDrive(ns = /tb3_1//): Advertise joint_states
[ INFO] [1699271279.541295346, 0.575000000]: DiffDrive(ns = /tb3_1//): Try to subscribe to cmd_vel
[ INFO] [1699271279.541929186, 0.575000000]: DiffDrive(ns = /tb3_1//): Subscribe to cmd_vel
[ INFO] [1699271279.542547015, 0.575000000]: DiffDrive(ns = /tb3_1//): Advertise odom on odom
[tb3_0/spawn_urdf-4] process has finished cleanly
log file: /home/robot/.ros/log/53bfb76a-7c9a-11ee-96e9-4b9ee184865e/tb3_0-spawn_urdf-4*.log
[ INFO] [1699271279.821183944, 0.773000000]: Laser Plugin: Using the 'robotNamespace' param: '/tb3_2/'
[ INFO] [1699271279.821206016, 0.773000000]: Starting Laser Plugin (ns = /tb3_2/)
[ INFO] [1699271279.821846578, 0.773000000]: Laser Plugin (ns = /tb3_2/) <tf_prefix_>, set to ""
[ INFO] [1699271279.921383645, 0.773000000]: Starting plugin DiffDrive(ns = /tb3_2//)
[ INFO] [1699271279.921407112, 0.773000000]: DiffDrive(ns = /tb3_2//): = na
[ INFO] [1699271279.921758381, 0.773000000]: DiffDrive(ns = /tb3_2//): <tf_prefix> =
[ INFO] [1699271279.922102470, 0.773000000]: DiffDrive(ns = /tb3_2//): Advertise joint_states
[ INFO] [1699271279.922116153, 0.773000000]: DiffDrive(ns = /tb3_2//): Try to subscribe to cmd_vel
[ INFO] [1699271279.923347946, 0.773000000]: DiffDrive(ns = /tb3_2//): Subscribe to cmd_vel
[ INFO] [1699271279.923542897, 0.773000000]: DiffDrive(ns = /tb3_2//): Advertise odom on odom