### PR TITLE
[ros2] Add steerangle publisher to ackermann_drive

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_ackermann_drive.hpp
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_ackermann_drive.hpp
@@ -35,6 +35,7 @@ class GazeboRosAckermannDrivePrivate;
         <remapping>cmd_vel:=cmd_demo</remapping>
         <remapping>odom:=odom_demo</remapping>
         <remapping>distance:=distance_demo</remapping>
+        <remapping>steerangle:=steerangle_demo</remapping>
       </ros>
 
       <update_rate>100.0</update_rate>
@@ -71,6 +72,7 @@ class GazeboRosAckermannDrivePrivate;
       <publish_odom_tf>true</publish_odom_tf>
       <publish_wheel_tf>true</publish_wheel_tf>
       <publish_distance>true</publish_distance>
+      <publish_steerangle>true</publish_steerangle>
 
       <odometry_frame>odom_demo</odometry_frame>
       <robot_base_frame>chassis</robot_base_frame>

--- a/gazebo_plugins/test/test_gazebo_ros_ackermann_drive.cpp
+++ b/gazebo_plugins/test/test_gazebo_ros_ackermann_drive.cpp
@@ -17,6 +17,7 @@
 #include <geometry_msgs/msg/twist.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <nav_msgs/msg/odometry.hpp>
+#include <std_msgs/msg/float32.hpp>
 
 #include <memory>
 
@@ -54,6 +55,13 @@ TEST_F(GazeboRosAckermannDriveTest, Publishing)
     "test/odom_test", rclcpp::QoS(rclcpp::KeepLast(1)),
     [&latestMsg](const nav_msgs::msg::Odometry::SharedPtr _msg) {
       latestMsg = _msg;
+    });
+
+  std_msgs::msg::Float32::SharedPtr latestSteerangle;
+  auto subSteerangle = node->create_subscription<std_msgs::msg::Float32>(
+    "test/steerangle_test", rclcpp::QoS(rclcpp::KeepLast(1)),
+    [&latestSteerangle](const std_msgs::msg::Float32::SharedPtr _msg) {
+      latestSteerangle = _msg;
     });
 
   // Step a bit for model to settle
@@ -101,6 +109,8 @@ TEST_F(GazeboRosAckermannDriveTest, Publishing)
   EXPECT_EQ("odom_test", latestMsg->header.frame_id);
   EXPECT_LT(0.0, latestMsg->pose.pose.position.x);
   EXPECT_LT(0.0, latestMsg->pose.pose.orientation.z);
+  ASSERT_NE(nullptr, latestSteerangle);
+  EXPECT_LT(0.0, latestSteerangle->data);
 
   // Check movement
   yaw = static_cast<float>(vehicle->WorldPose().Rot().Yaw());

--- a/gazebo_plugins/test/worlds/gazebo_ros_ackermann_drive.world
+++ b/gazebo_plugins/test/worlds/gazebo_ros_ackermann_drive.world
@@ -540,6 +540,7 @@
           <remapping>cmd_vel:=cmd_test</remapping>
           <remapping>odom:=odom_test</remapping>
           <remapping>distance:=distance_test</remapping>
+          <remapping>steerangle:=steerangle_test</remapping>
         </ros>
 
         <update_rate>100.0</update_rate>
@@ -576,6 +577,7 @@
         <publish_odom_tf>true</publish_odom_tf>
         <publish_wheel_tf>true</publish_wheel_tf>
         <publish_distance>true</publish_distance>
+        <publish_steerangle>true</publish_steerangle>
 
         <odometry_frame>odom_test</odometry_frame>
         <robot_base_frame>chassis</robot_base_frame>

--- a/gazebo_plugins/worlds/gazebo_ros_ackermann_drive_demo.world
+++ b/gazebo_plugins/worlds/gazebo_ros_ackermann_drive_demo.world
@@ -565,6 +565,7 @@
           <remapping>cmd_vel:=cmd_demo</remapping>
           <remapping>odom:=odom_demo</remapping>
           <remapping>distance:=distance_demo</remapping>
+          <remapping>steerangle:=steerangle_demo</remapping>
         </ros>
 
         <update_rate>100.0</update_rate>
@@ -601,6 +602,7 @@
         <publish_odom_tf>true</publish_odom_tf>
         <publish_wheel_tf>true</publish_wheel_tf>
         <publish_distance>true</publish_distance>
+        <publish_steerangle>true</publish_steerangle>
 
         <odometry_frame>odom_demo</odometry_frame>
         <robot_base_frame>chassis</robot_base_frame>


### PR DESCRIPTION
 You need to get steering angle to control ackermann drive properly.
After I added the steerangle publisher to gazebo_ros_ackermann_drive.cpp, my car could be controlled by feedback controller such as Stanley method, etc.