### PR TITLE
Publish odom twist in robot-local coordinates

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_p3d.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_p3d.h
@@ -68,6 +68,9 @@ namespace gazebo
     /// \brief The body of the frame to display pose, twist
     private: physics::LinkPtr reference_link_;
 
+    /// \brief Compute twist in the local coordinate frame
+    private: bool local_twist_;
+
 
     /// \brief pointer to ros node
     private: ros::NodeHandle* rosnode_;


### PR DESCRIPTION
Hello everyone,
according to [nav_msgs/Odometry](https://docs.ros.org/en/noetic/api/nav_msgs/html/msg/Odometry.html), the twist message should be specified in the coordinate frame given by the (local) child_frame_id. Currently, the plugin publishes twist in the (global) header.frame_id coordinate frame.

I added a boolean parameter to change this behavior to the documented one. It defaults to false to not break legacy code.

Best regards,
Martin