### PR TITLE
Add a warning about the use of gazebo_msgs without Gazebo Classic

### DIFF
--- a/gazebo_msgs/CMakeLists.txt
+++ b/gazebo_msgs/CMakeLists.txt
@@ -2,6 +2,20 @@ cmake_minimum_required(VERSION 3.5)
 
 project(gazebo_msgs)
 
+if(NOT DEFINED IGNORE_GAZEBO_MSGS_WARNING)
+  if(DEFINED ENV{ROS_DISTRO})
+    set(ROS_DISTRO $ENV{ROS_DISTRO})
+    if(NOT (ROS_DISTRO STREQUAL "iron" OR
+            ROS_DISTRO STREQUAL "humble"))
+      message(WARNING "This gazebo_msgs package hosts messages designed initially for Gazebo Classic "
+        "which is not available on ROS 2 Jazzy which is unavailable on ROS 2 Jazzy. "
+        "The new Gazebo uses the ros_gz bridge message vailable at:"
+        "https://github.com/gazebosim/ros_gz/tree/ros2/ros_gz_bridge#bridge-communication-between-ros-and-gazebo\n"
+        "To avoid this warning and use this Gazebo Classic messages anyway you can use flag -DIGNORE_GAZEBO_MSGS_WARNING")
+    endif()
+  endif()
+endif()
+
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)

--- a/gazebo_msgs/CMakeLists.txt
+++ b/gazebo_msgs/CMakeLists.txt
@@ -2,20 +2,6 @@ cmake_minimum_required(VERSION 3.5)
 
 project(gazebo_msgs)
 
-if(NOT DEFINED IGNORE_GAZEBO_MSGS_WARNING)
-  if(DEFINED ENV{ROS_DISTRO})
-    set(ROS_DISTRO $ENV{ROS_DISTRO})
-    if(NOT (ROS_DISTRO STREQUAL "iron" OR
-            ROS_DISTRO STREQUAL "humble"))
-      message(WARNING "This gazebo_msgs package hosts messages designed initially for Gazebo Classic "
-        "which is not available on ROS 2 Jazzy which is unavailable on Ubuntu Noble. "
-        "The new Gazebo uses the ros_gz bridge message vailable at:"
-        "https://github.com/gazebosim/ros_gz/tree/ros2/ros_gz_bridge#bridge-communication-between-ros-and-gazebo\n"
-        "To avoid this warning and use this Gazebo Classic messages anyway you can use flag -DIGNORE_GAZEBO_MSGS_WARNING")
-    endif()
-  endif()
-endif()
-
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)

--- a/gazebo_msgs/CMakeLists.txt
+++ b/gazebo_msgs/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT DEFINED IGNORE_GAZEBO_MSGS_WARNING)
     if(NOT (ROS_DISTRO STREQUAL "iron" OR
             ROS_DISTRO STREQUAL "humble"))
       message(WARNING "This gazebo_msgs package hosts messages designed initially for Gazebo Classic "
-        "which is not available on ROS 2 Jazzy which is unavailable on ROS 2 Jazzy. "
+        "which is not available on ROS 2 Jazzy which is unavailable on Ubuntu Noble. "
         "The new Gazebo uses the ros_gz bridge message vailable at:"
         "https://github.com/gazebosim/ros_gz/tree/ros2/ros_gz_bridge#bridge-communication-between-ros-and-gazebo\n"
         "To avoid this warning and use this Gazebo Classic messages anyway you can use flag -DIGNORE_GAZEBO_MSGS_WARNING")

--- a/gazebo_msgs/CMakeLists.txt
+++ b/gazebo_msgs/CMakeLists.txt
@@ -97,7 +97,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 
 ament_export_dependencies(rosidl_default_runtime)
 
-ament_package()
+ament_package(CONFIG_EXTRAS "cmake/gazebo_msgs-extras.cmake")
 
 install(
   FILES gazebo_msgs_mapping_rules.yaml

--- a/gazebo_msgs/cmake/gazebo_msgs-extras.cmake
+++ b/gazebo_msgs/cmake/gazebo_msgs-extras.cmake
@@ -1,0 +1,13 @@
+if(NOT DEFINED IGNORE_GAZEBO_MSGS_WARNING)
+  if(DEFINED ENV{ROS_DISTRO})
+    set(ROS_DISTRO $ENV{ROS_DISTRO})
+    if(NOT (ROS_DISTRO STREQUAL "iron" OR
+            ROS_DISTRO STREQUAL "humble"))
+      message(WARNING "This gazebo_msgs package hosts messages designed initially for Gazebo Classic "
+        "which is not available on ROS 2 Jazzy which is unavailable on ROS 2 Jazzy. "
+        "The new Gazebo uses the ros_gz bridge message vailable at:"
+        "https://github.com/gazebosim/ros_gz/tree/ros2/ros_gz_bridge#bridge-communication-between-ros-and-gazebo\n"
+        "To avoid this warning and use this Gazebo Classic messages anyway you can use flag -DIGNORE_GAZEBO_MSGS_WARNING")
+    endif()
+  endif()
+endif()


### PR DESCRIPTION
Related to https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1532.

Add a warning for ROS 2 distributions different than humble and iron (current supported ones) that keeps Gazebo users aware of the real goal of the package (being msgs for Gazebo classic).