### PR TITLE
Add support to parse parameters file instead of individual params

### DIFF
--- a/gazebo_ros/src/node.cpp
+++ b/gazebo_ros/src/node.cpp
@@ -96,6 +96,18 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf, std::string node_name)
     }
   }
 
+  if (sdf->HasElement("parameters")) {
+    sdf::ElementPtr argument_sdf = sdf->GetElement("parameters");
+
+    arguments.push_back(RCL_ROS_ARGS_FLAG);
+    while (argument_sdf) {
+      std::string argument = argument_sdf->Get<std::string>();
+      arguments.push_back(RCL_PARAM_FILE_FLAG);
+      arguments.push_back(argument);
+      argument_sdf = argument_sdf->GetNextElement("parameters");
+    }
+  }
+
   // Convert each parameter tag to a ROS parameter
   if (sdf->HasElement("parameter")) {
     sdf::ElementPtr parameter_sdf = sdf->GetElement("parameter");


### PR DESCRIPTION
Hello!

I think it would be interesting to allow gazebo to pass thew whole parameters file instead of individual parameters which is quite cumbersome at some point. If the changes look good to you, I can add tests on top of it