### PR TITLE
fix: Fixed uninitialized warning

### DIFF
--- a/gazebo_ros/include/gazebo_ros/node.hpp
+++ b/gazebo_ros/include/gazebo_ros/node.hpp
@@ -188,7 +188,7 @@ Node::SharedPtr Node::CreateWithArgs(Args && ... args)
   }
 
   // Generate warning on start up if use_sim_time parameter is set to false
-  bool check_sim_time;
+  bool check_sim_time = false;
   node->get_parameter("use_sim_time", check_sim_time);
   if (!check_sim_time) {
     RCLCPP_WARN(


### PR DESCRIPTION
check_sim_time would be uninitialized in the case, that the parameter use_sim_time is not set at all.