### PR TITLE
Add Gazebo Classic EOL notice

### DIFF
--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -32,6 +32,10 @@ find_package(rmw REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(tinyxml_vendor REQUIRED)
 
+# Needed for EOL GUI notice
+find_package (Qt5Widgets REQUIRED)
+find_package (Qt5Core REQUIRED)
+
 link_directories(
   ${gazebo_dev_LIBRARY_DIRS}
 )
@@ -152,6 +156,16 @@ ament_target_dependencies(gazebo_ros_force_system
 target_link_libraries(gazebo_ros_force_system
   gazebo_ros_node
 )
+
+set (CMAKE_AUTOMOC ON)
+add_library(gazebo_ros_eol_gui  SHARED src/gazebo_ros_eol_gui.cpp)
+
+target_link_libraries(gazebo_ros_eol_gui ${Qt5Core_LIBRARIES} ${Qt5Widgets_LIBRARIES})
+ament_target_dependencies(gazebo_ros_eol_gui 
+  "gazebo_dev"
+)
+set (CMAKE_AUTOMOC OFF)
+
 ament_export_libraries(gazebo_ros_force_system)
 
 ament_export_include_directories(include)
@@ -190,6 +204,7 @@ install(
     gazebo_ros_properties
     gazebo_ros_state
     gazebo_ros_utils
+    gazebo_ros_eol_gui
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)

--- a/gazebo_ros/CMakeLists.txt
+++ b/gazebo_ros/CMakeLists.txt
@@ -33,8 +33,8 @@ find_package(std_srvs REQUIRED)
 find_package(tinyxml_vendor REQUIRED)
 
 # Needed for EOL GUI notice
-find_package (Qt5Widgets REQUIRED)
-find_package (Qt5Core REQUIRED)
+find_package(Qt5Widgets REQUIRED)
+find_package(Qt5Core REQUIRED)
 
 link_directories(
   ${gazebo_dev_LIBRARY_DIRS}
@@ -157,14 +157,18 @@ target_link_libraries(gazebo_ros_force_system
   gazebo_ros_node
 )
 
-set (CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOMOC ON)
 add_library(gazebo_ros_eol_gui  SHARED src/gazebo_ros_eol_gui.cpp)
 
-target_link_libraries(gazebo_ros_eol_gui ${Qt5Core_LIBRARIES} ${Qt5Widgets_LIBRARIES})
-ament_target_dependencies(gazebo_ros_eol_gui 
+target_link_libraries(gazebo_ros_eol_gui
+  ${Qt5Core_LIBRARIES}
+  ${Qt5Widgets_LIBRARIES}
+  gazebo_ros_utils
+)
+ament_target_dependencies(gazebo_ros_eol_gui
   "gazebo_dev"
 )
-set (CMAKE_AUTOMOC OFF)
+set(CMAKE_AUTOMOC OFF)
 
 ament_export_libraries(gazebo_ros_force_system)
 

--- a/gazebo_ros/include/gazebo_ros/utils.hpp
+++ b/gazebo_ros/include/gazebo_ros/utils.hpp
@@ -89,5 +89,9 @@ private:
   gazebo::common::Time last_time_;
 };
 
+/// Determines if the Gazebo-classic EOL notice should be displayed
+GAZEBO_ROS_UTILS_PUBLIC
+bool ShouldDisplayEOLNotice();
+
 }  // namespace gazebo_ros
 #endif  // GAZEBO_ROS__UTILS_HPP_

--- a/gazebo_ros/launch/gzclient.launch.py
+++ b/gazebo_ros/launch/gzclient.launch.py
@@ -31,6 +31,7 @@ from scripts import GazeboRosPaths
 def generate_launch_description():
     cmd = [
         'gzclient',
+        ['--gui-client-plugin=libgazebo_ros_eol_gui.so'],
         _boolean_command('version'),
         _boolean_command('verbose'),
         _boolean_command('help'),

--- a/gazebo_ros/launch/gzserver.launch.py
+++ b/gazebo_ros/launch/gzserver.launch.py
@@ -233,7 +233,7 @@ def _boolean_command(arg):
 
 
 # Add string command and argument if not empty
-def _arg_command(arg, join_with="="):
+def _arg_command(arg, join_with='='):
     cmd = ['"--', arg, join_with, '" if "" != "', LaunchConfiguration(arg), '" else ""']
     py_cmd = PythonExpression(cmd)
     return (py_cmd, LaunchConfiguration(arg))

--- a/gazebo_ros/src/gazebo_ros_eol_gui.cpp
+++ b/gazebo_ros/src/gazebo_ros_eol_gui.cpp
@@ -1,75 +1,72 @@
-/*
- * Copyright (C) 2025 Open Source Robotics Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
+// Copyright 2025 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-#include <gazebo/common/CommonIface.hh>
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/gui/GuiIface.hh>
 #include <gazebo/gui/GuiPlugin.hh>
 #include <gazebo/gui/MainWindow.hh>
+#include <gazebo_ros/utils.hpp>
+
+namespace gazebo_ros
+{
 
 class GazeboRosEolGui : public gazebo::GUIPlugin
 {
   Q_OBJECT
 
   /// \brief Constructor
-  public: GazeboRosEolGui () : GUIPlugin()
+
+public:
+  GazeboRosEolGui()
+  : GUIPlugin()
   {
-    // Gazebo 11.15.0 and later contain the EOL warning in the core, so there's
-    // no need to add the notice here.
-    if (GAZEBO_MINOR_VERSION < 15)
-    {
+    if (gazebo_ros::ShouldDisplayEOLNotice()) {
       auto mainWindow = gazebo::gui::get_main_window();
-      QWidget *menuFrame = mainWindow->menuWidget();
-      QHBoxLayout *menuLayout =
-          dynamic_cast<QHBoxLayout *>(menuFrame->layout());
-      if (!menuLayout)
-      {
+      QWidget * menuFrame = mainWindow->menuWidget();
+      QHBoxLayout * menuLayout =
+        dynamic_cast<QHBoxLayout *>(menuFrame->layout());
+      if (!menuLayout) {
         gzerr << "GazeboRosEolGui: Could not find menu layout. Not adding EOL "
-                 "notice\n";
+          "notice\n";
         return;
       }
 
-      const char *ignoreEol =
-          gazebo::common::getEnv("GAZEBO_SUPPRESS_EOL_WARNING");
-      if (ignoreEol == nullptr || strncmp(ignoreEol, "1", 1) != 0)
-      {
-        // Add Gazebo classic EOL notice label
-        QList<QMenuBar *> menuBars = mainWindow->findChildren<QMenuBar *>();
-        auto eolNotice = new QLabel(menuBars[0]);
-        // It's important that the text in the href does not contain new lines.
-        // Otherwise, the resulting url will be invalid.
-        eolNotice->setText(R"(<font color='#ff9966'>
-          This version of Gazebo reaches end-of-life in January 2025.
-          Consider <a style='color: #ffcc00'
-          href='https://gazebosim.org/docs/latest/gazebo_classic_migration/?utm_source=gazebo_ros_pkgs'
-          >migrating to the new Gazebo</a></font>)");
-        eolNotice->setOpenExternalLinks(true);
-        menuLayout->addStretch(1);
-        menuLayout->addWidget(eolNotice);
-        menuLayout->addStretch(4);
-      }
-
-      this->move(0, 0);
-      this->resize(0, 0);
+      // Add Gazebo classic EOL notice label
+      QList<QMenuBar *> menuBars = mainWindow->findChildren<QMenuBar *>();
+      auto eolNotice = new QLabel(menuBars[0]);
+      // It's important that the text in the href does not contain new lines.
+      // Otherwise, the resulting url will be invalid.
+      eolNotice->setText(
+        R"(<font color='#ff9966'>
+        This version of Gazebo reaches end-of-life in January 2025.
+        Consider <a style='color: #ffcc00'
+        href='https://gazebosim.org/docs/latest/gazebo_classic_migration?utm_source=gazebo_ros_pkgs&utm_medium=gui'
+        >migrating to the new Gazebo</a></font>)");
+      eolNotice->setOpenExternalLinks(true);
+      menuLayout->addStretch(1);
+      menuLayout->addWidget(eolNotice);
+      menuLayout->addStretch(4);
     }
+
+    this->move(0, 0);
+    this->resize(0, 0);
   }
 };
 
 // Register this plugin with the simulator
 GZ_REGISTER_GUI_PLUGIN(GazeboRosEolGui)
+
+}  // namespace gazebo_ros
 
 #include "gazebo_ros_eol_gui.moc"

--- a/gazebo_ros/src/gazebo_ros_eol_gui.cpp
+++ b/gazebo_ros/src/gazebo_ros_eol_gui.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <gazebo/common/CommonIface.hh>
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/gui/GuiIface.hh>
+#include <gazebo/gui/GuiPlugin.hh>
+#include <gazebo/gui/MainWindow.hh>
+
+class GazeboRosEolGui : public gazebo::GUIPlugin
+{
+  Q_OBJECT
+
+  /// \brief Constructor
+  public: GazeboRosEolGui () : GUIPlugin()
+  {
+    // Gazebo 11.15.0 and later contain the EOL warning in the core, so there's
+    // no need to add the notice here.
+    if (GAZEBO_MINOR_VERSION < 15)
+    {
+      auto mainWindow = gazebo::gui::get_main_window();
+      QWidget *menuFrame = mainWindow->menuWidget();
+      QHBoxLayout *menuLayout =
+          dynamic_cast<QHBoxLayout *>(menuFrame->layout());
+      if (!menuLayout)
+      {
+        gzerr << "GazeboRosEolGui: Could not find menu layout. Not adding EOL "
+                 "notice\n";
+        return;
+      }
+
+      const char *ignoreEol =
+          gazebo::common::getEnv("GAZEBO_SUPPRESS_EOL_WARNING");
+      if (ignoreEol == nullptr || strncmp(ignoreEol, "1", 1) != 0)
+      {
+        // Add Gazebo classic EOL notice label
+        QList<QMenuBar *> menuBars = mainWindow->findChildren<QMenuBar *>();
+        auto eolNotice = new QLabel(menuBars[0]);
+        // It's important that the text in the href does not contain new lines.
+        // Otherwise, the resulting url will be invalid.
+        eolNotice->setText(R"(<font color='#ff9966'>
+          This version of Gazebo reaches end-of-life in January 2025.
+          Consider <a style='color: #ffcc00'
+          href='https://gazebosim.org/docs/latest/gazebo_classic_migration/?utm_source=gazebo_ros_pkgs'
+          >migrating to the new Gazebo</a></font>)");
+        eolNotice->setOpenExternalLinks(true);
+        menuLayout->addStretch(1);
+        menuLayout->addWidget(eolNotice);
+        menuLayout->addStretch(4);
+      }
+
+      this->move(0, 0);
+      this->resize(0, 0);
+    }
+  }
+};
+
+// Register this plugin with the simulator
+GZ_REGISTER_GUI_PLUGIN(GazeboRosEolGui)
+
+#include "gazebo_ros_eol_gui.moc"

--- a/gazebo_ros/src/gazebo_ros_init.cpp
+++ b/gazebo_ros/src/gazebo_ros_init.cpp
@@ -158,6 +158,26 @@ void GazeboRosInit::Load(int argc, char ** argv)
       "because it's already initialized with other arguments");
   }
 
+  if (gazebo_ros::ShouldDisplayEOLNotice()) {
+    const char * msg =
+      R"(
+#     # ####### ####### ###  #####  #######
+##    # #     #    #     #  #     # #
+# #   # #     #    #     #  #       #
+#  #  # #     #    #     #  #       #####
+#   # # #     #    #     #  #       #
+#    ## #     #    #     #  #     # #
+#     # #######    #    ###  #####  #######
+
+This version of Gazebo, now called Gazebo classic, reaches end-of-life
+in January 2025. Users are highly encouraged to migrate to the new Gazebo
+using our migration guides (https://gazebosim.org/docs/latest/gazebo_classic_migration?utm_source=gazebo_ros_pkgs&utm_medium=cli)
+
+)";
+
+    gzwarn << msg << std::endl;
+  }
+
   // Offer transient local durability on the clock topic so that if publishing is infrequent (e.g.
   // the simulation is paused), late subscribers can receive the previously published message(s).
   impl_->clock_pub_ = impl_->ros_node_->create_publisher<rosgraph_msgs::msg::Clock>(

--- a/gazebo_ros/src/utils.cpp
+++ b/gazebo_ros/src/utils.cpp
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <gazebo/common/CommonIface.hh>
 #include <gazebo_ros/utils.hpp>
 #include <gazebo/sensors/GaussianNoiseModel.hh>
 
+#include <cstring>
 #include <string>
 
 namespace gazebo_ros
@@ -82,6 +84,18 @@ bool Throttler::IsReady(const gazebo::common::Time & _now)
   // Enough time has passed, set last time to now and return true
   last_time_ = _now;
   return true;
+}
+
+bool ShouldDisplayEOLNotice()
+{
+  // Gazebo 11.15.0 and later contain the EOL warning in the core, so there's
+  // no need to add the notice here.
+  if (GAZEBO_MAJOR_VERSION == 11 && GAZEBO_MINOR_VERSION >= 15) {
+    return false;
+  }
+
+  const char * ignoreEol = gazebo::common::getEnv("GAZEBO_SUPPRESS_EOL_WARNING");
+  return ignoreEol == nullptr || strncmp(ignoreEol, "1", 1) != 0;
 }
 
 }  // namespace gazebo_ros


### PR DESCRIPTION
Similar to https://github.com/gazebosim/gazebo-classic/pull/3405, but adds the EOL notice via plugins instead of to the core.  This is needed for Gazebo users on Jammy since the 11.15.0 will not be released on Jammy.

## TODO
- [x] Add notice for the console