### PR TITLE
[gazebo_ros_control] Typo was bugging me

### DIFF
--- a/gazebo_ros_control/src/default_robot_hw_sim.cpp
+++ b/gazebo_ros_control/src/default_robot_hw_sim.cpp
@@ -98,7 +98,7 @@ bool DefaultRobotHWSim::initSim(
     {
       ROS_WARN_STREAM_NAMED("default_robot_hw_sim","Transmission " << transmissions[j].name_
         << " has more than one joint. Currently the default robot hardware simulation "
-        << " interface only supports one.");
+        << "interface only supports one.");
       continue;
     }
 


### PR DESCRIPTION
There is one too many spaces in the error message.