### PR TITLE
Add `<deprecated>` tag to package.xml files

### DIFF
--- a/gazebo_dev/package.xml
+++ b/gazebo_dev/package.xml
@@ -25,5 +25,10 @@
 
   <export>
     <build_type>ament_cmake</build_type>
+    <deprecated>
+      This package has been deprecated as of January 2025 with Gazebo classic 11 reaching
+      end-of-life. Users are highly encouraged to migrate to the new Gazebo
+      using our migration guides (https://gazebosim.org/docs/latest/gazebo_classic_migration)
+    </deprecated>
   </export>
 </package>

--- a/gazebo_msgs/package.xml
+++ b/gazebo_msgs/package.xml
@@ -37,5 +37,10 @@
   <export>
     <build_type>ament_cmake</build_type>
     <ros1_bridge mapping_rules="gazebo_msgs_mapping_rules.yaml"/>
+    <deprecated>
+      This package has been deprecated as of January 2025 with Gazebo classic 11 reaching
+      end-of-life. Users are highly encouraged to migrate to the new Gazebo
+      using our migration guides (https://gazebosim.org/docs/latest/gazebo_classic_migration)
+    </deprecated>
   </export>
 </package>

--- a/gazebo_plugins/package.xml
+++ b/gazebo_plugins/package.xml
@@ -49,5 +49,10 @@
 
   <export>
     <build_type>ament_cmake</build_type>
+    <deprecated>
+      This package has been deprecated as of January 2025 with Gazebo classic 11 reaching
+      end-of-life. Users are highly encouraged to migrate to the new Gazebo
+      using our migration guides (https://gazebosim.org/docs/latest/gazebo_classic_migration)
+    </deprecated>
   </export>
 </package>

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -49,5 +49,10 @@
 
   <export>
     <build_type>ament_cmake</build_type>
+    <deprecated>
+      This package has been deprecated as of January 2025 with Gazebo classic 11 reaching
+      end-of-life. Users are highly encouraged to migrate to the new Gazebo
+      using our migration guides (https://gazebosim.org/docs/latest/gazebo_classic_migration)
+    </deprecated>
   </export>
 </package>

--- a/gazebo_ros_pkgs/package.xml
+++ b/gazebo_ros_pkgs/package.xml
@@ -27,5 +27,10 @@
 
   <export>
     <build_type>ament_cmake</build_type>
+    <deprecated>
+      This package has been deprecated as of January 2025 with Gazebo classic 11 reaching
+      end-of-life. Users are highly encouraged to migrate to the new Gazebo
+      using our migration guides (https://gazebosim.org/docs/latest/gazebo_classic_migration)
+    </deprecated>
   </export>
 </package>


### PR DESCRIPTION
These packages are now deprecated with Gazebo classic 11 reaching end-of-life. This adds the `<deprecated>` tag (https://www.ros.org/reps/rep-0149.html#deprecated) enabling tools to notify users about the deprecation.