### PR TITLE
Noetic: Add `<deprecated>` tag to package.xml files

### DIFF
--- a/gazebo_dev/package.xml
+++ b/gazebo_dev/package.xml
@@ -22,4 +22,11 @@
 
   <build_export_depend>libgazebo11-dev</build_export_depend>
   <exec_depend>gazebo11</exec_depend>
+  <export>
+    <deprecated>
+      This package has been deprecated as of January 2025 with Gazebo classic 11 reaching
+      end-of-life. Users are highly encouraged to migrate to the new Gazebo
+      using our migration guides (https://gazebosim.org/docs/latest/gazebo_classic_migration)
+    </deprecated>
+  </export>
 </package>

--- a/gazebo_msgs/package.xml
+++ b/gazebo_msgs/package.xml
@@ -32,6 +32,13 @@
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>std_srvs</exec_depend>
+  <export>
+    <deprecated>
+      This package has been deprecated as of January 2025 with Gazebo classic 11 reaching
+      end-of-life. Users are highly encouraged to migrate to the new Gazebo
+      using our migration guides (https://gazebosim.org/docs/latest/gazebo_classic_migration)
+    </deprecated>
+  </export>
 </package>
 
 

--- a/gazebo_plugins/package.xml
+++ b/gazebo_plugins/package.xml
@@ -57,5 +57,10 @@
 
   <export>
     <gazebo_ros plugin_path="${prefix}/../../lib" gazebo_media_path="${prefix}" />
+    <deprecated>
+      This package has been deprecated as of January 2025 with Gazebo classic 11 reaching
+      end-of-life. Users are highly encouraged to migrate to the new Gazebo
+      using our migration guides (https://gazebosim.org/docs/latest/gazebo_classic_migration)
+    </deprecated>
   </export>
 </package>

--- a/gazebo_ros/package.xml
+++ b/gazebo_ros/package.xml
@@ -40,5 +40,11 @@
   <depend>geometry_msgs</depend>
   <depend>tinyxml</depend>
   <exec_depend>python-argparse</exec_depend>
-
+  <export>
+    <deprecated>
+      This package has been deprecated as of January 2025 with Gazebo classic 11 reaching
+      end-of-life. Users are highly encouraged to migrate to the new Gazebo
+      using our migration guides (https://gazebosim.org/docs/latest/gazebo_classic_migration)
+    </deprecated>
+  </export>
 </package>

--- a/gazebo_ros_control/package.xml
+++ b/gazebo_ros_control/package.xml
@@ -33,5 +33,10 @@
 
   <export>
     <gazebo_ros_control plugin="${prefix}/robot_hw_sim_plugins.xml"/>
+    <deprecated>
+      This package has been deprecated as of January 2025 with Gazebo classic 11 reaching
+      end-of-life. Users are highly encouraged to migrate to the new Gazebo
+      using our migration guides (https://gazebosim.org/docs/latest/gazebo_classic_migration)
+    </deprecated>
   </export>
 </package>

--- a/gazebo_ros_pkgs/package.xml
+++ b/gazebo_ros_pkgs/package.xml
@@ -24,5 +24,10 @@
 
   <export>
     <metapackage/>
+    <deprecated>
+      This package has been deprecated as of January 2025 with Gazebo classic 11 reaching
+      end-of-life. Users are highly encouraged to migrate to the new Gazebo
+      using our migration guides (https://gazebosim.org/docs/latest/gazebo_classic_migration)
+    </deprecated>
   </export>
 </package>


### PR DESCRIPTION
These packages are now deprecated with Gazebo classic 11 reaching end-of-life. This adds the `<deprecated>` tag (https://www.ros.org/reps/rep-0149.html#deprecated) enabling tools to notify users about the deprecation.